### PR TITLE
feat: allow passing in time-strings as fallback for time converter

### DIFF
--- a/.changeset/time-string-fallback.md
+++ b/.changeset/time-string-fallback.md
@@ -1,0 +1,7 @@
+---
+'envapt': minor
+---
+
+`Converters.Time` fallbacks now accept a time-string in addition to a number — `fallback: '10s'` is the same as `fallback: 10000`. also adds `d` (days) and `w` (weeks) to the supported units. `TimeFallback` is exported if you want to type the fallback yourself.
+
+malformed time-string fallbacks (like `'1.5h'` or `'1500'` — runtime expects an integer with an explicit unit) now throw `EnvaptErrorCodes.MalformedTimeFallback` instead of the generic `FallbackConverterTypeMismatch`. number fallbacks keep working the same way.

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ class Config extends Envapter {
 | `Converters.Url`     | `'url'`     | URL objects                                                          |
 | `Converters.Regexp`  | `'regexp'`  | Regular expressions (supports `/pattern/flags` syntax)               |
 | `Converters.Date`    | `'date'`    | Date objects (supports ISO strings and timestamps)                   |
-| `Converters.Time`    | `'time'`    | Time values (e.g. `"5s"`, `"30m"`, `"2h"` converted to milliseconds) |
+| `Converters.Time`    | `'time'`    | Time values (e.g. `"5s"`, `"30m"`, `"2h"`, `"1d"`, `"1w"` → milliseconds). The fallback also accepts a time-string in addition to a number — `fallback: '10s'` is equivalent to `fallback: 10000`. |
 
 #### Custom Array Converters
 
@@ -853,6 +853,7 @@ try {
 | `InvalidFallbackType` (102)              | Fallback value type doesn't match expected converter type |
 | `ArrayFallbackElementTypeMismatch` (103) | Array fallback contains elements of wrong type            |
 | `FallbackConverterTypeMismatch` (104)    | Fallback type doesn't match the specified converter       |
+| `MalformedTimeFallback` (105)            | Time-string fallback doesn't match the required `<integer><unit>` format (e.g. `'10s'`, `'5m'`) |
 
 #### 🧪 Converter Errors (2xx)
 

--- a/packages/envapt/src/BuiltInConverters.ts
+++ b/packages/envapt/src/BuiltInConverters.ts
@@ -1,13 +1,61 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 
+import { EnvaptError, EnvaptErrorCodes } from './Error';
+
 import type {
     ArrayConverter,
     BuiltInConverter,
     BuiltInConverterFunction,
     JsonValue,
     MapOfConverterFunctions,
+    TimeFallback,
     TimeUnit
 } from './Types';
+
+const MS_PER_SECOND = 1000;
+const SECONDS_PER_MINUTE = 60;
+const MINUTES_PER_HOUR = 60;
+const HOURS_PER_DAY = 24;
+const DAYS_PER_WEEK = 7;
+const MS_PER_MINUTE = SECONDS_PER_MINUTE * MS_PER_SECOND;
+const MS_PER_HOUR = MINUTES_PER_HOUR * MS_PER_MINUTE;
+const MS_PER_DAY = HOURS_PER_DAY * MS_PER_HOUR;
+const MS_PER_WEEK = DAYS_PER_WEEK * MS_PER_DAY;
+
+const TIME_UNIT_MS: Record<TimeUnit, number> = {
+    ms: 1,
+    s: MS_PER_SECOND,
+    m: MS_PER_MINUTE,
+    h: MS_PER_HOUR,
+    d: MS_PER_DAY,
+    w: MS_PER_WEEK
+};
+
+const TIME_LOOSE_RE = new RegExp(String.raw`^(\d+(?:\.\d+)?)(ms|s|m|h|d|w)?$`, 'u');
+const TIME_STRICT_RE = new RegExp(String.raw`^(\d+)(ms|s|m|h|d|w)$`, 'u');
+
+/**
+ * Parse a time string (e.g. `"30s"`, `"1.5h"`) into milliseconds.
+ *
+ * @param input - The string to parse.
+ * @param strict - When `true`, require an explicit unit and disallow decimals (used for fallback strings).
+ *                 When `false` (default), allow decimals and treat missing unit as `ms` (used for raw env values).
+ * @returns The duration in milliseconds, or `undefined` if the input does not match the expected format.
+ * @internal
+ */
+function parseTimeString(input: string, strict = false): number | undefined {
+    const match = input.match(strict ? TIME_STRICT_RE : TIME_LOOSE_RE);
+    if (!match) return undefined;
+
+    const [, numStr, capturedUnit] = match;
+    if (!numStr) return undefined;
+
+    const value = Number.parseFloat(numStr);
+    if (Number.isNaN(value)) return undefined;
+
+    const unit = (capturedUnit ?? 'ms') as TimeUnit;
+    return value * TIME_UNIT_MS[unit];
+}
 
 /**
  * Built-in converter implementations
@@ -113,28 +161,24 @@ export class BuiltInConverters {
         return Number.isNaN(parsed.getTime()) ? fallback : parsed;
     }
 
-    static time(raw: string, fallback?: number): number | undefined {
-        const match = raw.match(new RegExp(String.raw`^(\d+(?:\.\d+)?)(ms|s|m|h)?$`, 'u'));
-        if (!match) return fallback;
+    static time(raw: string, fallback?: TimeFallback): number | undefined {
+        const parsedRaw = parseTimeString(raw);
+        if (parsedRaw !== undefined) return parsedRaw;
 
-        const [, numStr, capturedUnit] = match;
-        if (!numStr) return fallback;
-
-        const value = Number.parseFloat(numStr);
-        if (Number.isNaN(value)) return fallback;
-
-        const unit: TimeUnit = (capturedUnit ?? 'ms') as TimeUnit;
-
-        const SECONDS_TO_MS = 1000;
-        const SECONDS_PER_MINUTE = 60;
-        const MINUTES_PER_HOUR = 60;
-        const MINUTES_TO_MS = SECONDS_PER_MINUTE * SECONDS_TO_MS;
-        const HOURS_TO_MS = MINUTES_PER_HOUR * MINUTES_TO_MS;
-
-        if (unit === 'ms') return value;
-        if (unit === 's') return value * SECONDS_TO_MS;
-        if (unit === 'm') return value * MINUTES_TO_MS;
-        return value * HOURS_TO_MS;
+        // Raw didn't parse so apply fallback
+        if (typeof fallback === 'number') return fallback;
+        if (typeof fallback === 'string') {
+            // String fallback is held to the stricter format: explicit unit, integer value.
+            const parsedFallback = parseTimeString(fallback, true);
+            if (parsedFallback === undefined) {
+                throw new EnvaptError(
+                    EnvaptErrorCodes.MalformedTimeFallback,
+                    `Time-string fallback "${fallback}" is not a valid format. Expected <integer><unit> where unit is one of: ms, s, m, h, d, w.`
+                );
+            }
+            return parsedFallback;
+        }
+        return undefined;
     }
 
     /**

--- a/packages/envapt/src/Envapt.ts
+++ b/packages/envapt/src/Envapt.ts
@@ -9,7 +9,7 @@ import type {
     EnvKeyInput,
     EnvaptConverter,
     EnvaptOptions,
-    InferConverterReturnType,
+    InferConverterFallbackType,
     InferPrimitiveFallbackType,
     InferPrimitiveReturnType,
     PrimitiveConstructor
@@ -101,10 +101,10 @@ export function Envapt<TReturnType>(
 ): PropertyDecorator;
 
 /**
- * Usage 3: Built-in converter with optional fallback
+ * Usage 3: Built-in or array converter with optional fallback
  *
  * @param key - Environment variable name(s) to load
- * @param options - Configuration options with built-in converter
+ * @param options - Configuration options with built-in or array converter
  * @public
  * @example
  * ```ts
@@ -122,33 +122,19 @@ export function Envapt<TReturnType>(
  *   // Prefer CANARY_URL when present, otherwise fall back to APP_URL
  *   \@Envapt(['CANARY_URL', 'APP_URL'], { converter: Converters.Url })
  *   static readonly canaryUrl: URL | null;
- * }
- * ```
- */
-export function Envapt<TConverter extends BuiltInConverter>(
-    key: EnvKeyInput,
-    options: { converter: TConverter; fallback?: InferConverterReturnType<TConverter> | undefined }
-): PropertyDecorator;
-
-/**
- * Usage 4: Array converter with optional fallback
  *
- * @param key - Environment variable name(s) to load
- * @param options - Configuration options with array converter
- * @public
- * @example
- * ```ts
- * import { Converters } from 'envapt';
+ *   // `Converters.Time` accepts either a number (milliseconds) or a time-string fallback (`<integer><unit>`).
+ *   \@Envapt('REQUEST_TIMEOUT', { converter: Converters.Time, fallback: '10s' })
+ *   static readonly requestTimeout: number;
  *
- * class Config extends Envapter {
- *   // Comma-separated list of origins -> string[]
+ *   // Array converter: comma-separated list of origins -> string[]
  *   \@Envapt('ALLOWED_ORIGINS', {
  *     converter: { delimiter: ',', type: Converters.String },
  *     fallback: ['https://example.com']
  *   })
  *   static readonly allowedOrigins: string[];
  *
- *   // Pipe-separated ports -> number[]
+ *   // Array converter: pipe-separated ports -> number[]
  *   \@Envapt('PORTS', {
  *     converter: { delimiter: '|', type: Converters.Number },
  *     fallback: [3000]
@@ -157,9 +143,13 @@ export function Envapt<TConverter extends BuiltInConverter>(
  * }
  * ```
  */
-export function Envapt<TConverter extends ArrayConverter>(
+// `InferConverterFallbackType` handles the asymmetric `Converters.Time` case
+// (fallback may be a number OR a time-string); for every other converter it
+// reduces to `InferConverterReturnType`, so array-converter fallbacks behave
+// unchanged.
+export function Envapt<TConverter extends BuiltInConverter | ArrayConverter>(
     key: EnvKeyInput,
-    options: { converter: TConverter; fallback?: InferConverterReturnType<TConverter> | undefined }
+    options: { converter: TConverter; fallback?: InferConverterFallbackType<TConverter> | undefined }
 ): PropertyDecorator;
 
 /**

--- a/packages/envapt/src/Error.ts
+++ b/packages/envapt/src/Error.ts
@@ -9,6 +9,8 @@ export enum EnvaptErrorCodes {
     ArrayFallbackElementTypeMismatch = 103,
     /** Thrown when fallback type doesn't match the specified converter */
     FallbackConverterTypeMismatch = 104,
+    /** Thrown when a time-string fallback is malformed (does not match the required `<integer><unit>` format) */
+    MalformedTimeFallback = 105,
 
     // Converter related errors
     /** Thrown when invalid array converter configuration is provided */

--- a/packages/envapt/src/ListOfBuiltInConverters.ts
+++ b/packages/envapt/src/ListOfBuiltInConverters.ts
@@ -45,5 +45,5 @@ export const BuiltInConverterTypeCheckers: Record<ConverterValue, (value: unknow
     url: (value: unknown): value is URL => value instanceof URL,
     regexp: (value: unknown): value is RegExp => value instanceof RegExp,
     date: (value: unknown): value is Date => value instanceof Date,
-    time: (value: unknown): value is number => typeof value === 'number'
+    time: (value: unknown): value is number | string => typeof value === 'number' || typeof value === 'string'
 };

--- a/packages/envapt/src/Parser.ts
+++ b/packages/envapt/src/Parser.ts
@@ -124,7 +124,17 @@ export class Parser {
 
         const parsed = this.envService.get(key, undefined);
 
-        if (parsed === undefined) return hasFallback ? fallback : null;
+        if (parsed === undefined) {
+            if (!hasFallback) return null;
+            // For converters with asymmetric fallback / return types — currently only `time`,
+            // whose fallback may be a string while the return type is `number` — route the
+            // fallback through the converter so it gets coerced to the return type.
+            if (resolvedConverter === 'time' && typeof fallback === 'string') {
+                const timeFn = BuiltInConverters.getConverter(resolvedConverter);
+                return timeFn('', fallback) as TFallback;
+            }
+            return fallback;
+        }
 
         const converterFn = BuiltInConverters.getConverter(resolvedConverter);
         const result = converterFn(parsed, fallback);

--- a/packages/envapt/src/Types.ts
+++ b/packages/envapt/src/Types.ts
@@ -99,9 +99,10 @@ type JsonArray = JsonValue[];
 interface JsonObject {
     [key: string]: JsonValue;
 }
+
 /**
  * JSON value types for custom converters
- * @internal
+ * @public
  */
 type JsonValue = JsonPrimitive | JsonArray | JsonObject;
 
@@ -155,7 +156,13 @@ type MapOfConverterFunctions = Record<BuiltInConverter, BuiltInConverterFunction
  * Time unit types for duration conversions
  * @internal
  */
-type TimeUnit = 'ms' | 's' | 'm' | 'h';
+type TimeUnit = 'ms' | 's' | 'm' | 'h' | 'd' | 'w';
+
+/**
+ * Fallback type for time duration conversions
+ * @public
+ */
+type TimeFallback = number | `${number}${TimeUnit}`;
 
 /**
  * Helper type for getter methods that conditionally return undefined based on whether a fallback is provided
@@ -177,6 +184,18 @@ type InferConverterReturnType<TConverter extends BuiltInConverter | ArrayConvert
               ? BuiltInConverterReturnType<TConverter['type']>[]
               : string[]
           : unknown[];
+
+/**
+ * Type inference for the *fallback* slot of a converter — usually the same as the return type, but
+ * `Converters.Time` allows a time-string fallback ({@link TimeFallback}) in addition to `number`.
+ * Add future converters with asymmetric fallback/return types to this conditional.
+ * @internal
+ */
+type InferConverterFallbackType<TConverter extends BuiltInConverter | ArrayConverter> = TConverter extends
+    | Converters.Time
+    | 'time'
+    ? TimeFallback
+    : InferConverterReturnType<TConverter>;
 
 /**
  * Complete type inference for advanced converter methods
@@ -233,8 +252,10 @@ export type {
     BuiltInConverterFunction,
     MapOfConverterFunctions,
     TimeUnit,
+    TimeFallback,
     ConditionalReturn,
     InferConverterReturnType,
+    InferConverterFallbackType,
     AdvancedConverterReturn,
     InferPrimitiveReturnType,
     InferPrimitiveFallbackType,

--- a/packages/envapt/src/core/AdvancedMethods.ts
+++ b/packages/envapt/src/core/AdvancedMethods.ts
@@ -1,12 +1,14 @@
 import { PrimitiveMethods } from './PrimitiveMethods';
 
+import type { Converters } from '../Converters';
 import type {
     AdvancedConverterReturn,
     ArrayConverter,
     BuiltInConverter,
     ConditionalReturn,
     ConverterFunction,
-    EnvKeyInput
+    EnvKeyInput,
+    TimeFallback
 } from '../Types';
 
 /**
@@ -16,9 +18,16 @@ import type {
 export class AdvancedMethods extends PrimitiveMethods {
     /**
      * Get an environment variable using a built-in converter.
-     * Supports both Converter enum values and array converter configurations.
+     * Supports both `Converters` enum values and array converter configurations.
      * The key can be a single name or an ordered list; the first defined value wins.
      */
+    // Time-specific overload — constrains the fallback to TimeFallback (number | time-string).
+    // Must precede the generic BuiltInConverter overload so it wins overload resolution.
+    static getUsing<TFallback extends TimeFallback | undefined = undefined>(
+        key: EnvKeyInput,
+        converter: Converters.Time | 'time',
+        fallback?: TFallback
+    ): ConditionalReturn<number, TFallback>;
     static getUsing<TConverter extends BuiltInConverter | ArrayConverter, TFallback = undefined>(
         key: EnvKeyInput,
         converter: TConverter,
@@ -47,6 +56,11 @@ export class AdvancedMethods extends PrimitiveMethods {
     /**
      * @see {@link AdvancedMethods.getUsing}
      */
+    getUsing<TFallback extends TimeFallback | undefined = undefined>(
+        key: EnvKeyInput,
+        converter: Converters.Time | 'time',
+        fallback?: TFallback
+    ): ConditionalReturn<number, TFallback>;
     getUsing<TConverter extends BuiltInConverter | ArrayConverter, TFallback = undefined>(
         key: EnvKeyInput,
         converter: TConverter,

--- a/packages/envapt/tests/005-runtime-validation.test.ts
+++ b/packages/envapt/tests/005-runtime-validation.test.ts
@@ -278,10 +278,10 @@ describe('Runtime Validation', () => {
                 .with.property('code', EnvaptErrorCodes.FallbackConverterTypeMismatch);
         });
 
-        it('should throw when time converter has non-number fallback', () => {
+        it('should throw MalformedTimeFallback when time converter has a malformed string fallback', () => {
             expect(() => FallbackTypeValidationTests.timeWithStringFallback)
                 .to.throw(EnvaptError)
-                .with.property('code', EnvaptErrorCodes.FallbackConverterTypeMismatch);
+                .with.property('code', EnvaptErrorCodes.MalformedTimeFallback);
         });
 
         it('should throw when JSON converter has non-JSON fallback', () => {

--- a/packages/envapt/tests/014-time-string-fallback.test.ts
+++ b/packages/envapt/tests/014-time-string-fallback.test.ts
@@ -1,0 +1,106 @@
+import { resolve } from 'node:path';
+
+import { expect } from 'chai';
+import { it, describe, beforeEach } from 'vitest';
+
+import { Converters, Envapt, EnvaptError, EnvaptErrorCodes, Envapter } from '../src';
+
+import type { TimeFallback } from '../src';
+
+describe('Converters.Time — time-string fallbacks', () => {
+    beforeEach(() => (Envapter.envPaths = resolve(`${import.meta.dirname}/.env.builtin-test`)));
+
+    describe('valid time-string fallbacks (one per supported unit)', () => {
+        class Strings extends Envapter {
+            // Each TEST_TIME_STRING_FALLBACK_* key is intentionally absent from the
+            // fixture file so the string-fallback path is exercised.
+            @Envapt('TEST_TIME_STRING_FALLBACK_MS', { converter: Converters.Time, fallback: '1500ms' })
+            static readonly ms: number;
+
+            @Envapt('TEST_TIME_STRING_FALLBACK_S', { converter: Converters.Time, fallback: '2s' })
+            static readonly s: number;
+
+            @Envapt('TEST_TIME_STRING_FALLBACK_M', { converter: Converters.Time, fallback: '10m' })
+            static readonly m: number;
+
+            @Envapt('TEST_TIME_STRING_FALLBACK_H', { converter: Converters.Time, fallback: '3h' })
+            static readonly h: number;
+
+            @Envapt('TEST_TIME_STRING_FALLBACK_D', { converter: Converters.Time, fallback: '1d' })
+            static readonly d: number;
+
+            @Envapt('TEST_TIME_STRING_FALLBACK_W', { converter: Converters.Time, fallback: '1w' })
+            static readonly w: number;
+        }
+
+        it('parses ms', () => expect(Strings.ms).to.equal(1500));
+        it('parses s', () => expect(Strings.s).to.equal(2 * 1000));
+        it('parses m', () => expect(Strings.m).to.equal(10 * 60 * 1000));
+        it('parses h', () => expect(Strings.h).to.equal(3 * 60 * 60 * 1000));
+        it('parses d', () => expect(Strings.d).to.equal(24 * 60 * 60 * 1000));
+        it('parses w', () => expect(Strings.w).to.equal(7 * 24 * 60 * 60 * 1000));
+    });
+
+    describe('absent fallback', () => {
+        class NoFallback extends Envapter {
+            // Env value is malformed (`TEST_TIME_INVALID=5x` in the fixture) and no fallback
+            // is provided — converter returns undefined, decorator surfaces it as null.
+            @Envapt('TEST_TIME_INVALID', { converter: Converters.Time })
+            static readonly noFallback: number | null;
+        }
+
+        it('returns null when raw is malformed and no fallback is provided', () => {
+            expect(NoFallback.noFallback).to.be.null;
+        });
+    });
+
+    describe('malformed time-string fallbacks', () => {
+        it('throws MalformedTimeFallback for a bogus string fallback', () => {
+            class BogusFallback extends Envapter {
+                // 'bogus' isn't a valid TimeFallback — cast to bypass the compile-time guard
+                // so we can exercise the runtime throw path (JS callers / dynamic strings).
+                @Envapt('UNDEFINED_TIME_FOR_BOGUS_FALLBACK', {
+                    converter: Converters.Time,
+                    fallback: 'bogus' as unknown as TimeFallback
+                })
+                static readonly bogus: number;
+            }
+
+            expect(() => BogusFallback.bogus)
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MalformedTimeFallback);
+        });
+
+        it('throws MalformedTimeFallback for a decimal time-string (runtime is integer-only)', () => {
+            class DecimalFallback extends Envapter {
+                // `${number}${TimeUnit}` accepts '1.5h' at compile time, but the runtime regex
+                // requires an integer value. Documents the type/runtime gap.
+                @Envapt('UNDEFINED_TIME_FOR_DECIMAL_FALLBACK', {
+                    converter: Converters.Time,
+                    fallback: '1.5h'
+                })
+                static readonly decimal: number;
+            }
+
+            expect(() => DecimalFallback.decimal)
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MalformedTimeFallback);
+        });
+
+        it('throws MalformedTimeFallback for a unit-less time-string', () => {
+            class UnitLessFallback extends Envapter {
+                // The TimeFallback type rejects '1500' (TimeUnit is required in the template).
+                // Cast to bypass for the runtime-throw check.
+                @Envapt('UNDEFINED_TIME_FOR_UNITLESS_FALLBACK', {
+                    converter: Converters.Time,
+                    fallback: '1500' as unknown as TimeFallback
+                })
+                static readonly unitless: number;
+            }
+
+            expect(() => UnitLessFallback.unitless)
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MalformedTimeFallback);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

When using `Converters.Time`, currently, you need to pass in a number as a fallback. Now, instead, you can either pass a number or a valid time string

Closes #79 

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Internal refactor
- [ ] Documentation

## Scope check

- [x] This pull request focuses on one feature or closely related set of changes
- [x] No new packages or top level projects are introduced inside this repository
- [x] No core files have been copy pasted into new folders
- [x] Changes are limited to the existing `envapt/src` tree and necessary tests or docs

## Implementation notes

Explain how you implemented the change.
*WIP, will be updated*
- Key types or functions you added or modified
- Anything that might surprise a reviewer
- How this fits with the existing Envapt API and EnvaptError behavior

## TypeScript and safety

- [x] New code is written in strict TypeScript
- [x] No new `any` types were introduced (if they were, explain why)
- [x] No `value as any` style casts were added to bypass the type system
- [x] No unnecessary type casts were added
- [x] Existing strict TypeScript settings were not disabled or loosened
- [x] New code has complete type coverage (no `@ts-ignore` or missing types)
- [x] New code uses proper TypeScript generics or unions where applicable
- [x] Public types and signatures are well defined and documented where needed

## Tests

- [x] `pnpm lint` passes with zero lint errors (without the need for unnecessary `/* eslint-disable */` comments or changes to existing lint rules)
- [x] `pnpm test` passes locally
- [x] `pnpm coverage` passes locally without new coverage gaps
- [x] New or updated tests cover the behavior in this pull request

Describe the tests you added or updated.

## Docs and changesets

- [ ] README or other docs were updated if behavior changed
- [ ] A changeset was added with `pnpm cs add`, uses the correct bump level, and has a clear summary

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] Commit messages and PR title follow Conventional Commits
- [x] CI is expected to pass for this branch
