### PR TITLE
feat: array converter typesafety via Converters.array builder

### DIFF
--- a/.changeset/array-typesafety.md
+++ b/.changeset/array-typesafety.md
@@ -1,0 +1,27 @@
+---
+'envapt': major
+---
+
+**BREAKING:** array converters now use a phantom-branded `Converters.array({ of?, delimiter? })` builder instead of the `{ delimiter, type }` config object. inference survives variable indirection and union-widening, and bad element values in the raw env value throw `EnvaptError` (`ArrayElementConversionFailed`, code 206) instead of silently substituting the raw string into a wrong-typed array.
+
+Migration:
+
+```ts
+// before
+@Envapt('PORTS', { converter: { delimiter: ',', type: Converters.Number }, fallback: [] })
+@Envapt('TAGS', { converter: Converters.Array, fallback: [] })
+
+// after
+@Envapt('PORTS', { converter: Converters.array({ of: Converters.Number }), fallback: [] })
+@Envapt('TAGS', { converter: Converters.array(), fallback: [] })
+```
+
+**BREAKING:** `Converters` migrates from a TS `enum` to an `as const` object so envapt source stays compatible with `erasableSyntaxOnly` / Node's native TS execution. call sites are unchanged (`Converters.Number === 'number'` still holds), but `Converters` is no longer usable as a type. use `ConverterToken` instead.
+
+**BREAKING:** `Converters.Array` token is gone (use `Converters.array()`). the `ArrayConverter` and `ValidArrayConverterBuiltInType` types are gone (replaced by `ArrayOf<TElement>` and `ArrayElement`).
+
+new: `of:` accepts a custom `(raw: string) => T` function. the array element type is inferred from the function's return type, so `Converters.array({ of: (raw) => User.parse(raw) })` types the property as `User[]`.
+
+new: `Converters.array({ of: Converters.Time })` accepts `TimeFallback[]` (e.g. `['5s', '10m']`) as a fallback, matching the existing scalar `Converters.Time` asymmetry. string fallbacks are coerced to milliseconds at resolve time.
+
+`Envapter.getUsing` now routes through the parser whenever a fallback is provided, so `TimeFallback` / `TimeFallback[]` fallbacks are coerced consistently with the `@Envapt` decorator path. fixes a pre-existing inconsistency where `Envapter.getUsing('MISSING', Converters.Time, '10s')` returned `'10s'` instead of `10000`.

--- a/packages/envapt/README.md
+++ b/packages/envapt/README.md
@@ -59,7 +59,7 @@
         - [Automatic Runtime Type Detection](#automatic-runtime-type-detection)
         - [Primitive Converters](#primitive-converters)
         - [Built-in Converters](#built-in-converters)
-        - [Custom Array Converters](#custom-array-converters)
+        - [Array Converters via `Converters.array(...)`](#array-converters-via-convertersarray)
         - [Custom Converters](#custom-converters)
         - [Handling Missing Values](#handling-missing-values)
     - [Functional API](#functional-api)
@@ -161,7 +161,7 @@ console.log(`Server running on port ${port}`); // 8443
 console.log(`URL: ${url}`); // "http://localhost:8443"
 
 // Advanced converters
-const corsOrigins = Envapter.getUsing('ALLOWED_ORIGINS', Converters.Array, []);
+const corsOrigins = Envapter.getUsing('ALLOWED_ORIGINS', Converters.array(), []);
 const dbConfig = Envapter.getUsing('DATABASE_CONFIG', Converters.Json, {});
 
 // Multi-key lookup: try primary, then replica, then fall back
@@ -193,7 +193,7 @@ class AppConfig extends Envapter {
 
     @Envapt('ALLOWED_ORIGINS', {
         fallback: ['http://localhost:3000'],
-        converter: Converters.Array
+        converter: Converters.array()
     })
     static readonly allowedOrigins: string[];
 }
@@ -386,7 +386,7 @@ class Config extends Envapter {
     static readonly productionMode: boolean;
 
     // Advanced types
-    @Envapt('CORS_ORIGINS', { converter: Converters.Array, fallback: [] })
+    @Envapt('CORS_ORIGINS', { converter: Converters.array(), fallback: [] })
     static readonly corsOrigins: string[];
 
     @Envapt('CONFIG_JSON', { converter: Converters.Json, fallback: {} })
@@ -430,60 +430,78 @@ class Config extends Envapter {
 | `Converters.Bigint`  | `'bigint'`  | BigInt values for large integers                                     |
 | `Converters.Symbol`  | `'symbol'`  | Symbol values (creates symbols from string descriptions)             |
 | `Converters.Json`    | `'json'`    | JSON objects/arrays (safe parsing with fallback)                     |
-| `Converters.Array`   | `'array'`   | Comma-separated string arrays                                        |
 | `Converters.Url`     | `'url'`     | URL objects                                                          |
 | `Converters.Regexp`  | `'regexp'`  | Regular expressions (supports `/pattern/flags` syntax)               |
 | `Converters.Date`    | `'date'`    | Date objects (supports ISO strings and timestamps)                   |
 | `Converters.Time`    | `'time'`    | Time values (e.g. `"5s"`, `"30m"`, `"2h"` converted to milliseconds) |
 
-#### Custom Array Converters
+#### Array Converters via `Converters.array(...)`
 
-For more control over array parsing:
+Use the `Converters.array({ of?, delimiter? })` builder for delimited lists. It returns a phantom-branded `ArrayOf<T>` token whose element type survives any variable indirection.
 
 > [!IMPORTANT]
 > Array converters validate that:
 >
 > 1. **Fallback must be an array** (if provided)
 > 2. **All fallback elements have consistent types** (no mixed types like `['string', 42, true]`)
-> 3. **Array converter `type` matches fallback element types** (if `type` is specified)
+> 3. **Fallback element types match the configured `of` token** (when `of` is specified)
+> 4. **Element conversion failures throw `EnvaptError` (`ArrayElementConversionFailed`, code 206)** — no silent type lies.
 
 ```ts
 class Config extends Envapter {
-    // Basic array (comma-separated strings)
-    @Envapt('TAGS', { converter: Converters.Array, fallback: [] })
+    // Basic array (comma-separated strings — defaults: of=String, delimiter=',')
+    @Envapt('TAGS', { converter: Converters.array(), fallback: [] })
     static readonly tags: string[];
 
     // Custom delimiter
-    @Envapt('ALLOWED_METHODS', { converter: { delimiter: '|' }, fallback: ['GET'] })
+    @Envapt('ALLOWED_METHODS', { converter: Converters.array({ delimiter: '|' }), fallback: ['GET'] })
     declare readonly allowedMethods: string[];
 
-    // Custom delimiter with type conversion
-    @Envapt('RATE_LIMITS', { converter: { delimiter: ',', type: Converters.Number }, fallback: [100] })
+    // Element-typed array
+    @Envapt('RATE_LIMITS', {
+        converter: Converters.array({ of: Converters.Number, delimiter: ',' }),
+        fallback: [100]
+    })
     declare readonly rateLimits: number[];
 
-    @Envapt('FEATURE_FLAGS', { converter: { delimiter: ';', type: 'boolean' }, fallback: [false] })
-    declare readonly featureFlags: boolean[];
+    // Time-string fallback (TimeFallback[]) symmetry
+    @Envapt('TIMEOUTS', {
+        converter: Converters.array({ of: Converters.Time }),
+        fallback: ['5s', '10m']
+    })
+    declare readonly timeouts: number[];
+
+    // Custom function as element converter — element type inferred from return
+    @Envapt('USERS', {
+        converter: Converters.array({ of: (raw) => User.parse(raw) }),
+        fallback: []
+    })
+    declare readonly users: User[];
 }
 ```
 
 > [!WARNING]
-> These will throw runtime validation errors:
+> These will throw at runtime:
 >
 > ```ts
 > // ❌ Mixed types in fallback array
-> @Envapt('MIXED', { converter: Converters.Array, fallback: ['string', 42, true] })
+> @Envapt('MIXED', { converter: Converters.array(), fallback: ['string', 42, true] })
 >
-> // ❌ Array converter type doesn't match fallback elements
-> @Envapt('NUMS', { converter: { delimiter: ',', type: Converters.Number }, fallback: ['not', 'numbers'] })
+> // ❌ Fallback element type doesn't match `of`
+> @Envapt('NUMS', { converter: Converters.array({ of: Converters.Number }), fallback: ['not', 'numbers'] })
 >
 > // ❌ Non-array fallback with array converter
-> @Envapt('INVALID', { converter: Converters.Array, fallback: 'not-an-array' })
+> @Envapt('INVALID', { converter: Converters.array(), fallback: 'not-an-array' })
+>
+> // ❌ A bad element in the raw env value (e.g. PORTS=80,abc,443) now throws
+> //    ArrayElementConversionFailed instead of producing [80, 'abc', 443].
 > ```
 
-**ArrayConverter Interface:**
+**`Converters.array(opts?)` signature:**
 
-- `delimiter: string` - The string used to split array elements
-- `type?: BuiltInConverter` - Optional type to convert each element to (excludes `Converters.Array`, `Converters.Json`, and `Converters.Regexp`)
+- `of?: ConverterToken | (raw: string) => T` — element converter; defaults to `Converters.String`. Excludes `'json'` and `'regexp'`.
+- `delimiter?: string` — splitter; defaults to `','`.
+- Returns: `ArrayOf<T>`, a phantom-branded token. The `T` carries through variable assignment so inference holds even when you hoist the builder to a `const`.
 
 #### Custom Converters
 
@@ -575,7 +593,7 @@ const symbol = Envapter.getSymbol('SYMBOL_VAR', Symbol('default'));
 
 // Advanced converter methods
 const jsonData = Envapter.getUsing('CONFIG_JSON', Converters.Json);
-const urlArray = Envapter.getUsing('API_URLS', { delimiter: ',', type: Converters.Url });
+const urlArray = Envapter.getUsing('API_URLS', Converters.array({ of: Converters.Url }));
 const customData = Envapter.getWith('RAW_DATA', (raw) => raw?.split('|').map((s) => s.trim()));
 
 // Multi-key inputs work everywhere: Envapt will read left-to-right
@@ -584,7 +602,7 @@ const secretsHost = Envapter.get(['SECRETS_HOST', 'DEFAULT_HOST'], 'localhost');
 // Instance methods (same API available)
 const envapter = new Envapter();
 const value = envapter.get('VAR', 'default');
-const processed = envapter.getUsing('DATA', Converters.Array);
+const processed = envapter.getUsing('DATA', Converters.array());
 ```
 
 For functional-style environment variable access with converters:
@@ -594,7 +612,7 @@ import { Envapter, Converters } from 'envapt';
 
 // Use built-in converters directly
 const config = Envapter.getUsing('API_CONFIG', Converters.Json, { default: 'value' });
-const urls = Envapter.getUsing('SERVICE_URLS', { delimiter: '|', type: Converters.Url });
+const urls = Envapter.getUsing('SERVICE_URLS', Converters.array({ of: Converters.Url, delimiter: '|' }));
 const pgUrl = Envapter.getUsing(['PRIMARY_PG_URL', 'SECONDARY_PG_URL'], Converters.Url);
 
 // TypeScript: Use type override for better type inference

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -67,5 +67,8 @@
     "publishConfig": {
         "access": "public",
         "provenance": true
+    },
+    "devDependencies": {
+        "expect-type": "^1.3.0"
     }
 }

--- a/packages/envapt/src/BuiltInConverters.ts
+++ b/packages/envapt/src/BuiltInConverters.ts
@@ -2,8 +2,8 @@
 
 import { EnvaptError, EnvaptErrorCodes } from './Error';
 
+import type { ArrayOf, CustomElementConverter } from './Converters';
 import type {
-    ArrayConverter,
     BuiltInConverter,
     BuiltInConverterFunction,
     JsonValue,
@@ -116,15 +116,6 @@ export class BuiltInConverters {
         }
     }
 
-    static array(raw: string, fallback?: string[], delimiter = ','): string[] | undefined {
-        if (raw.trim() === '') return [];
-        const arr = raw
-            .split(delimiter)
-            .map((item) => item.trim())
-            .filter(Boolean);
-        return arr.length ? arr : fallback;
-    }
-
     static url(raw: string, fallback?: URL): URL | undefined {
         try {
             return new URL(raw);
@@ -182,9 +173,17 @@ export class BuiltInConverters {
     }
 
     /**
-     * Process array with custom converter config
+     * Process the raw env value for an {@link ArrayOf} configuration.
+     *
+     * Behaviour:
+     * - Splits on `config.delimiter`, trims each item, and filters out empty entries.
+     * - With a scalar element token: runs each item through the matching built-in converter.
+     *   If any element returns `undefined`, throws `ArrayElementConversionFailed` with positional info.
+     * - With a custom function element: runs each item through the function. Propagates user
+     *   exceptions; treats `undefined` returns as conversion failures (same throw as scalar path).
+     * - Returns `[]` when the raw value is empty/whitespace.
      */
-    static processArrayConverter(raw: string, fallback: unknown, config: ArrayConverter): unknown[] | undefined {
+    static processArrayConverter(raw: string, config: ArrayOf): unknown[] {
         if (raw.trim() === '') return [];
 
         const items = raw
@@ -192,18 +191,34 @@ export class BuiltInConverters {
             .map((item) => String(item).trim())
             .filter(Boolean);
 
-        // If no items after split, return fallback if provided
-        if (!items.length) return fallback ? (fallback as unknown[]) : undefined;
+        if (!items.length) return [];
 
-        // If no type specified, return as string array
-        const type = config.type;
-        if (!type) return items;
+        const elementOf = config.of;
 
-        // Convert each item using the specified type
-        const converter = BuiltInConverters.getConverter(type);
-        return items.map((item) => {
+        if (typeof elementOf === 'function') {
+            return items.map((item, index) => {
+                const converter = elementOf as CustomElementConverter;
+                const result = converter(item);
+                if (result === undefined) {
+                    throw new EnvaptError(
+                        EnvaptErrorCodes.ArrayElementConversionFailed,
+                        `Custom element converter returned undefined for item "${item}" at index ${index}.`
+                    );
+                }
+                return result;
+            });
+        }
+
+        const converter = BuiltInConverters.getConverter(elementOf);
+        return items.map((item, index) => {
             const converted = converter(item, undefined);
-            return converted ?? item;
+            if (converted === undefined) {
+                throw new EnvaptError(
+                    EnvaptErrorCodes.ArrayElementConversionFailed,
+                    `Element "${item}" at index ${index} could not be converted to ${elementOf}.`
+                );
+            }
+            return converted;
         });
     }
 
@@ -220,7 +235,6 @@ export class BuiltInConverters {
             symbol: BuiltInConverters.symbol,
             float: BuiltInConverters.float,
             json: BuiltInConverters.json,
-            array: BuiltInConverters.array,
             url: BuiltInConverters.url,
             regexp: BuiltInConverters.regexp,
             date: BuiltInConverters.date,

--- a/packages/envapt/src/Converters.ts
+++ b/packages/envapt/src/Converters.ts
@@ -1,37 +1,100 @@
+const SCALAR = {
+    String: 'string',
+    Number: 'number',
+    Boolean: 'boolean',
+    Bigint: 'bigint',
+    Symbol: 'symbol',
+    Integer: 'integer',
+    Float: 'float',
+    Json: 'json',
+    Url: 'url',
+    Regexp: 'regexp',
+    Date: 'date',
+    Time: 'time'
+} as const;
+
 /**
- * Enum for built-in converters
+ * String tokens for every built-in scalar converter.
  * @public
  */
-export enum Converters {
-    String = 'string',
-    Number = 'number',
-    Boolean = 'boolean',
-    Bigint = 'bigint',
-    Symbol = 'symbol',
-    Integer = 'integer',
-    Float = 'float',
-    Json = 'json',
-    Array = 'array',
-    Url = 'url',
-    Regexp = 'regexp',
-    Date = 'date',
-    Time = 'time'
+export type ConverterToken = (typeof SCALAR)[keyof typeof SCALAR];
+
+/**
+ * Custom element converter for use inside {@link Converters.array}. Receives the trimmed,
+ * non-empty raw string for one array slot and returns the parsed value.
+ * @public
+ */
+export type CustomElementConverter<TReturn = unknown> = (raw: string) => TReturn;
+
+/**
+ * Valid element converters for {@link Converters.array}: any scalar token except
+ * `json` and `regexp` (those don't compose as array elements), or a custom function.
+ * @public
+ */
+export type ArrayElement = Exclude<ConverterToken, 'json' | 'regexp'> | CustomElementConverter;
+
+/**
+ * Phantom-branded token produced by {@link Converters.array}. The `T` type parameter carries
+ * the element converter through any variable indirection so inference survives. The
+ * `__envaptKind` discriminant is present at runtime for dispatch.
+ * @public
+ */
+export interface ArrayOf<TElement extends ArrayElement = ArrayElement> {
+    readonly __envaptKind: 'array';
+    readonly of: TElement;
+    readonly delimiter: string;
 }
 
 /**
- * Type alias for converter values to maintain compatibility with existing string-based API
+ * Runtime type guard for tokens produced by {@link Converters.array}.
  * @internal
  */
-export type ConverterValue = `${Converters}`;
+export function isArrayOf(value: unknown): value is ArrayOf {
+    return (
+        typeof value === 'object' &&
+        value !== null &&
+        '__envaptKind' in value &&
+        (value as { __envaptKind: unknown }).__envaptKind === 'array'
+    );
+}
+
+type ArrayScalarElement = Exclude<ConverterToken, 'json' | 'regexp'>;
+
+// Overloads. The function-element overload must come first so it wins inference when `of`
+// is a function, otherwise TS picks the scalar branch and `raw` defaults to `any`.
+function buildArrayConverter<TReturn>(opts: {
+    of: CustomElementConverter<TReturn>;
+    delimiter?: string;
+}): ArrayOf<CustomElementConverter<TReturn>>;
+function buildArrayConverter<TToken extends ArrayScalarElement>(opts: {
+    of: TToken;
+    delimiter?: string;
+}): ArrayOf<TToken>;
+function buildArrayConverter(opts?: { delimiter?: string }): ArrayOf<'string'>;
+function buildArrayConverter(opts?: { of?: ArrayElement; delimiter?: string }): ArrayOf<ArrayElement> {
+    return {
+        __envaptKind: 'array',
+        of: opts?.of ?? SCALAR.String,
+        delimiter: opts?.delimiter ?? ','
+    };
+}
 
 /**
- * Valid array element converter types (excludes array, json, regexp)
- * @internal
+ * Built-in converters for environment variables. Use the scalar tokens (e.g. `Converters.Number`)
+ * for primitive types and the {@link Converters.array} builder for delimited lists.
+ *
+ * @example
+ * ```ts
+ * \@Envapt('PORT', { converter: Converters.Number, fallback: 3000 })
+ * static readonly port: number;
+ *
+ * \@Envapt('TAGS', { converter: Converters.array({ of: Converters.String, delimiter: ' ' }) })
+ * static readonly tags: string[];
+ * ```
+ *
+ * @public
  */
-export type ArrayElementConverter = Exclude<Converters, Converters.Array | Converters.Json | Converters.Regexp>;
-
-/**
- * Type alias for array element converter values
- * @internal
- */
-export type ArrayElementConverterValue = `${ArrayElementConverter}`;
+export const Converters = {
+    ...SCALAR,
+    array: buildArrayConverter
+} as const;

--- a/packages/envapt/src/Envapt.ts
+++ b/packages/envapt/src/Envapt.ts
@@ -2,8 +2,8 @@ import { EnvaptCache } from './core/EnvapterBase';
 import { Envapter } from './Envapter';
 import { Parser } from './Parser';
 
+import type { ArrayOf } from './Converters';
 import type {
-    ArrayConverter,
     BuiltInConverter,
     ConverterFunction,
     EnvKeyInput,
@@ -129,31 +129,30 @@ export function Envapt<TReturnType>(
  *
  *   // Array converter: comma-separated list of origins -> string[]
  *   \@Envapt('ALLOWED_ORIGINS', {
- *     converter: { delimiter: ',', type: Converters.String },
+ *     converter: Converters.array({ of: Converters.String }),
  *     fallback: ['https://example.com']
  *   })
  *   static readonly allowedOrigins: string[];
  *
  *   // Array converter: pipe-separated ports -> number[]
  *   \@Envapt('PORTS', {
- *     converter: { delimiter: '|', type: Converters.Number },
+ *     converter: Converters.array({ of: Converters.Number, delimiter: '|' }),
  *     fallback: [3000]
  *   })
  *   static readonly ports: number[];
  * }
  * ```
  */
-// `InferConverterFallbackType` handles the asymmetric `Converters.Time` case
-// (fallback may be a number OR a time-string); for every other converter it
-// reduces to `InferConverterReturnType`, so array-converter fallbacks behave
-// unchanged.
-export function Envapt<TConverter extends BuiltInConverter | ArrayConverter>(
+// `InferConverterFallbackType` handles asymmetric cases: scalar `Converters.Time`
+// accepts `TimeFallback`, and `ArrayOf<'time'>` accepts `TimeFallback[]`. Every
+// other converter reduces to `InferConverterReturnType`.
+export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
     key: EnvKeyInput,
     options: { converter: TConverter; fallback?: InferConverterFallbackType<TConverter> | undefined }
 ): PropertyDecorator;
 
 /**
- * Usage 5: Primitive constructor with optional fallback
+ * Usage 4: Primitive constructor with optional fallback
  *
  * @param key - Environment variable name(s) to load
  * @param options - Configuration options with primitive constructor
@@ -179,7 +178,7 @@ export function Envapt<TConstructor extends PrimitiveConstructor>(
 ): PropertyDecorator;
 
 /**
- * Usage 6: Fallback only (no converter)
+ * Usage 5: Fallback only (no converter)
  *
  * @param key - Environment variable name(s) to load
  * @param options - Configuration options with fallback only

--- a/packages/envapt/src/Error.ts
+++ b/packages/envapt/src/Error.ts
@@ -23,6 +23,8 @@ export enum EnvaptErrorCodes {
     InvalidConverterType = 204,
     /** Thrown when primitive type coercion on fallback value fails */
     PrimitiveCoercionFailed = 205,
+    /** Thrown when an array element fails to convert to the configured element type */
+    ArrayElementConversionFailed = 206,
 
     // Other errors
     /** Thrown when delimiter is missing in array converter configuration */

--- a/packages/envapt/src/ListOfBuiltInConverters.ts
+++ b/packages/envapt/src/ListOfBuiltInConverters.ts
@@ -1,11 +1,12 @@
-import type { ConverterValue } from './Converters';
+import type { ConverterToken } from './Converters';
 import type { JsonValue } from './Types';
 
 /**
- * List of built-in converters for Envapt.
+ * List of built-in scalar converters for Envapt. Arrays are handled separately via
+ * the {@link Converters.array} builder and the `ArrayOf<...>` brand.
  * @internal
  */
-export const ListOfBuiltInConverters: ConverterValue[] = [
+export const ListOfBuiltInConverters: ConverterToken[] = [
     'string',
     'number',
     'boolean',
@@ -14,7 +15,6 @@ export const ListOfBuiltInConverters: ConverterValue[] = [
     'integer',
     'float',
     'json',
-    'array',
     'url',
     'regexp',
     'date',
@@ -22,10 +22,10 @@ export const ListOfBuiltInConverters: ConverterValue[] = [
 ] as const;
 
 /**
- * Type checking functions for built-in converter return types.
+ * Type checking functions for built-in scalar converter return types.
  * @internal
  */
-export const BuiltInConverterTypeCheckers: Record<ConverterValue, (value: unknown) => boolean> = {
+export const BuiltInConverterTypeCheckers: Record<ConverterToken, (value: unknown) => boolean> = {
     string: (value: unknown): value is string => typeof value === 'string',
     number: (value: unknown): value is number => typeof value === 'number',
     boolean: (value: unknown): value is boolean => typeof value === 'boolean',
@@ -41,7 +41,6 @@ export const BuiltInConverterTypeCheckers: Record<ConverterValue, (value: unknow
             return false;
         }
     },
-    array: (value: unknown): value is unknown[] => Array.isArray(value),
     url: (value: unknown): value is URL => value instanceof URL,
     regexp: (value: unknown): value is RegExp => value instanceof RegExp,
     date: (value: unknown): value is Date => value instanceof Date,

--- a/packages/envapt/src/Parser.ts
+++ b/packages/envapt/src/Parser.ts
@@ -2,7 +2,8 @@ import { BuiltInConverters } from './BuiltInConverters';
 import { EnvaptError, EnvaptErrorCodes } from './Error';
 import { Validator } from './Validators';
 
-import type { EnvaptConverter, PrimitiveConstructor, ArrayConverter, BuiltInConverter, EnvKeyInput } from './Types';
+import type { ArrayOf } from './Converters';
+import type { BuiltInConverter, EnvKeyInput, EnvaptConverter, PrimitiveConstructor } from './Types';
 
 /**
  * @internal
@@ -60,7 +61,6 @@ export class Parser {
         const resolvedConverter = this.resolveConverter(converter, fallback);
         const processedFallback = this.processFallbackForConverter(resolvedConverter, fallback);
 
-        // Handle different converter types
         if (Validator.isArrayConverter(resolvedConverter)) {
             return this.processArrayConverter(key, processedFallback, resolvedConverter, hasFallback);
         }
@@ -81,7 +81,6 @@ export class Parser {
         converter: EnvaptConverter<TFallback>,
         fallback: TFallback | undefined
     ): TFallback | undefined {
-        // For primitive constructors, coerce the fallback to match the converter
         if (Validator.isPrimitiveConstructor(converter) && fallback !== undefined) {
             return Validator.coercePrimitiveFallback<TFallback>(converter, fallback);
         }
@@ -96,7 +95,6 @@ export class Parser {
         /* v8 ignore next -- @preserve */
         if (primitiveConstructor === Symbol) return 'symbol';
 
-        // This should never happen but TypeScript needs it
         /* v8 ignore next -- @preserve */
         throw new EnvaptError(EnvaptErrorCodes.InvalidConverterType, `Unknown primitive constructor`);
     }
@@ -108,18 +106,10 @@ export class Parser {
         hasFallback: boolean,
         wasOriginallyConstructor: boolean
     ): TFallback | null | undefined {
-        // Validate the built-in converter at runtime
         Validator.builtInConverter(resolvedConverter);
 
-        // Validate fallback type matches converter for built-in converters
-        // Only apply strict validation if this wasn't originally a constructor
         if (hasFallback && fallback !== undefined && !wasOriginallyConstructor) {
             Validator.validateBuiltInConverterFallback(resolvedConverter, fallback);
-
-            // Special handling for 'array' converter - check array element consistency
-            if (resolvedConverter === 'array' && Array.isArray(fallback)) {
-                Validator.validateArrayFallbackElementTypes(fallback);
-            }
         }
 
         const parsed = this.envService.get(key, undefined);
@@ -139,7 +129,6 @@ export class Parser {
         const converterFn = BuiltInConverters.getConverter(resolvedConverter);
         const result = converterFn(parsed, fallback);
 
-        // If converter failed (returned undefined) and no fallback was provided, return null
         if (result === undefined && !hasFallback) return null;
 
         return result as TFallback;
@@ -148,40 +137,42 @@ export class Parser {
     private processArrayConverter<TFallback>(
         key: EnvKeyInput,
         fallback: TFallback | undefined,
-        resolvedConverter: ArrayConverter,
+        resolvedConverter: ArrayOf,
         hasFallback: boolean
     ): TFallback | null | undefined {
-        // Validate the resolvedConverter at runtime and assert that it is indeed an ArrayConverter
         Validator.arrayConverter(resolvedConverter);
 
-        // Validate fallback type if a fallback is provided
         if (hasFallback && fallback !== undefined && !Array.isArray(fallback)) {
             throw new EnvaptError(
                 EnvaptErrorCodes.InvalidFallback,
-                `ArrayConverter requires that the fallback be an array, got ${typeof fallback}`
+                `ArrayOf<...> requires that the fallback be an array, got ${typeof fallback}`
             );
         }
 
-        // Additional validations for array converter fallbacks
         if (hasFallback && Array.isArray(fallback)) {
-            // Validate that all elements in fallback array have consistent types
             Validator.validateArrayFallbackElementTypes(fallback);
-
-            // For array converters with a type, validate that converter type matches fallback elements
-            if (resolvedConverter.type) {
-                Validator.validateArrayConverterElementTypeMatch(resolvedConverter.type, fallback);
-            }
+            Validator.validateArrayConverterElementTypeMatch(resolvedConverter.of, fallback);
         }
 
         const parsed = this.envService.get(key, undefined);
 
-        if (parsed === undefined) return hasFallback ? fallback : null;
+        if (parsed === undefined) {
+            if (!hasFallback) return null;
+            // When the array element is `time` and the fallback is a list of time-strings,
+            // coerce each entry through the time converter so the returned array is
+            // `number[]` matching the declared return type.
+            if (
+                resolvedConverter.of === 'time' &&
+                Array.isArray(fallback) &&
+                fallback.every((v) => typeof v === 'string')
+            ) {
+                const timeFn = BuiltInConverters.getConverter('time');
+                return fallback.map((v) => timeFn('', v as string)) as TFallback;
+            }
+            return fallback;
+        }
 
-        const result = BuiltInConverters.processArrayConverter(parsed, fallback, resolvedConverter);
-
-        // If converter failed (returned undefined) and no fallback was provided, return null
-        if (result === undefined && !hasFallback) return null;
-
+        const result = BuiltInConverters.processArrayConverter(parsed, resolvedConverter);
         return result as TFallback;
     }
 
@@ -193,7 +184,6 @@ export class Parser {
     ): TFallback | null | undefined {
         Validator.customConvertor(resolvedConverter);
 
-        // Custom converter function
         const raw = this.envService.get(key, undefined);
 
         return resolvedConverter(raw, fallback);
@@ -203,10 +193,8 @@ export class Parser {
         converter: EnvaptConverter<TFallback> | undefined,
         fallback: TFallback | undefined
     ): EnvaptConverter<TFallback> {
-        // User provided explicit converter. Use it
         if (converter) return converter;
 
-        // Auto-detect type from fallback using typeof
         const fallbackType = typeof fallback;
         if (fallbackType === 'number') return 'number';
         if (fallbackType === 'boolean') return 'boolean';

--- a/packages/envapt/src/Types.ts
+++ b/packages/envapt/src/Types.ts
@@ -1,4 +1,4 @@
-import type { Converters, ArrayElementConverter, ConverterValue, ArrayElementConverterValue } from './Converters';
+import type { ArrayOf, ConverterToken, CustomElementConverter } from './Converters';
 import type { Environment } from './core/EnvironmentMethods';
 import type { DotenvConfigOptions } from 'dotenv';
 
@@ -11,37 +11,17 @@ import type { DotenvConfigOptions } from 'dotenv';
 type PermittedDotenvConfig = Omit<DotenvConfigOptions, 'processEnv' | 'path'>;
 
 /**
- * Built-in converter types for common environment variable patterns
+ * Scalar built-in converter tokens (e.g. `'number'`, `'time'`).
+ * Excludes the array builder (see {@link ArrayOf}).
  * @public
  */
-type BuiltInConverter = ConverterValue | Converters;
+type BuiltInConverter = ConverterToken;
 
 /**
  * Primitive types supported by Envapter
  * @public
  */
 type PrimitiveConstructor = typeof String | typeof Number | typeof Boolean | typeof BigInt | typeof Symbol;
-
-/**
- * Valid array converter element types (excludes array, json, regexp)
- * @public
- */
-type ValidArrayConverterBuiltInType = ArrayElementConverterValue | ArrayElementConverter;
-
-/**
- * Array converter configuration for custom delimiters and element types
- * @public
- */
-interface ArrayConverter {
-    /**
-     * Delimiter to split the string by
-     */
-    delimiter: string;
-    /**
-     * Type to convert each array element to (excludes array, json, and regexp types)
-     */
-    type?: ArrayElementConverter | ArrayElementConverterValue;
-}
 
 /**
  * String value from a .env file or environment variable
@@ -65,19 +45,11 @@ type EnvKeyInput = string | readonly [string, ...string[]];
 type ConverterFunction<TFallback = unknown> = (raw: BaseInput, fallback?: TFallback) => TFallback;
 
 /**
- * Environment variable converter - can be a primitive constructor, built-in converter string, array converter object, or custom parser function
- * @see {@link PrimitiveConstructor} for primitive types
- * @see {@link Converters} for built-in types
- * @see {@link ArrayConverter} for array converter configuration
- * @see {@link ConverterFunction} for custom parser functions
+ * Environment variable converter: a primitive constructor, a built-in scalar token, an `ArrayOf<...>`
+ * produced by {@link Converters.array}, or a custom parser function.
  * @public
  */
-type EnvaptConverter<TFallback> =
-    | PrimitiveConstructor
-    | Converters
-    | ConverterValue
-    | ArrayConverter
-    | ConverterFunction<TFallback>;
+type EnvaptConverter<TFallback> = PrimitiveConstructor | BuiltInConverter | ArrayOf | ConverterFunction<TFallback>;
 
 /**
  * Options for the \@Envapt decorator (modern API)
@@ -116,7 +88,6 @@ interface ConverterMap {
     integer: number;
     float: number;
     json: JsonValue;
-    array: string[];
     url: URL;
     regexp: RegExp;
     date: Date;
@@ -124,14 +95,10 @@ interface ConverterMap {
 }
 
 /**
- * Type mapping for built-in converters to their return types
+ * Type mapping for built-in scalar converters to their return types
  * @internal
  */
-type BuiltInConverterReturnType<ConverterKey extends BuiltInConverter> = ConverterKey extends Converters
-    ? ConverterMap[`${ConverterKey}`]
-    : ConverterKey extends keyof ConverterMap
-      ? ConverterMap[ConverterKey]
-      : never;
+type BuiltInConverterReturnType<ConverterKey extends BuiltInConverter> = ConverterMap[ConverterKey];
 
 /**
  * Return type for built-in converter functions
@@ -173,39 +140,47 @@ type TimeFallback = number | `${number}${TimeUnit}`;
 type ConditionalReturn<ReturnType, TFallback> = TFallback extends undefined ? ReturnType | undefined : ReturnType;
 
 /**
- * Advanced type inference for built-in and array converters
- * Maps converter types to their expected return types
+ * Inferred return type for a converter.
+ *
+ * - `ArrayOf<E>` resolves to the element type's return as an array. When `E` is a custom
+ *   function, the function's return type drives the array element. When `E` is a scalar
+ *   token, `ConverterMap` provides the element type.
+ * - Bare scalar tokens resolve through `ConverterMap`.
  * @internal
  */
-type InferConverterReturnType<TConverter extends BuiltInConverter | ArrayConverter> =
-    TConverter extends BuiltInConverter
-        ? BuiltInConverterReturnType<TConverter>
-        : TConverter extends ArrayConverter
-          ? TConverter['type'] extends BuiltInConverter
-              ? BuiltInConverterReturnType<TConverter['type']>[]
-              : string[]
-          : unknown[];
+type InferConverterReturnType<TConverter> =
+    TConverter extends ArrayOf<infer Element>
+        ? Element extends BuiltInConverter
+            ? ConverterMap[Element][]
+            : Element extends CustomElementConverter<infer Returned>
+              ? Returned[]
+              : never
+        : TConverter extends BuiltInConverter
+          ? BuiltInConverterReturnType<TConverter>
+          : never;
 
 /**
- * Type inference for the *fallback* slot of a converter. Usually the same as the return type, but
- * `Converters.Time` allows a time-string fallback ({@link TimeFallback}) in addition to `number`.
- * Add future converters with asymmetric fallback/return types to this conditional.
+ * Type inference for the *fallback* slot of a converter. `Converters.Time` (scalar or array
+ * element) accepts {@link TimeFallback} / `TimeFallback[]`; everything else mirrors the
+ * return type. Add future asymmetric fallback/return converters to this conditional.
  * @internal
  */
-type InferConverterFallbackType<TConverter extends BuiltInConverter | ArrayConverter> = TConverter extends
-    | Converters.Time
-    | 'time'
+type InferConverterFallbackType<TConverter> = TConverter extends 'time'
     ? TimeFallback
-    : InferConverterReturnType<TConverter>;
+    : TConverter extends ArrayOf<infer Element>
+      ? Element extends 'time'
+          ? TimeFallback[]
+          : InferConverterReturnType<TConverter>
+      : InferConverterReturnType<TConverter>;
 
 /**
  * Complete type inference for advanced converter methods
  * @internal
  */
-type AdvancedConverterReturn<
-    TConverter extends BuiltInConverter | ArrayConverter,
-    TFallback = undefined
-> = ConditionalReturn<InferConverterReturnType<TConverter>, TFallback>;
+type AdvancedConverterReturn<TConverter, TFallback = undefined> = ConditionalReturn<
+    InferConverterReturnType<TConverter>,
+    TFallback
+>;
 
 /**
  * Type inference for primitive constructor return types
@@ -268,8 +243,6 @@ export type {
     PermittedDotenvConfig,
     BuiltInConverter,
     PrimitiveConstructor,
-    ValidArrayConverterBuiltInType,
-    ArrayConverter,
     ConverterFunction,
     EnvaptConverter,
     EnvaptOptions,

--- a/packages/envapt/src/Validators.ts
+++ b/packages/envapt/src/Validators.ts
@@ -1,20 +1,15 @@
 import fs from 'node:fs';
 
+import { isArrayOf } from './Converters';
 import { EnvaptError, EnvaptErrorCodes } from './Error';
 import { ListOfBuiltInConverters, BuiltInConverterTypeCheckers } from './ListOfBuiltInConverters';
 
-import type {
-    ArrayConverter,
-    BuiltInConverter,
-    ConverterFunction,
-    EnvaptConverter,
-    PermittedDotenvConfig,
-    ValidArrayConverterBuiltInType
-} from './Types';
+import type { ArrayOf, ConverterToken } from './Converters';
+import type { BuiltInConverter, ConverterFunction, EnvaptConverter, PermittedDotenvConfig } from './Types';
 
 export class Validator {
     /**
-     * Check if a value is a built-in converter type
+     * Check if a value is a built-in scalar converter token
      */
     static isBuiltInConverter<TFallback>(value: EnvaptConverter<TFallback>): value is BuiltInConverter {
         if (typeof value === 'string') return ListOfBuiltInConverters.includes(value);
@@ -22,31 +17,10 @@ export class Validator {
     }
 
     /**
-     * Check if a value is an ArrayConverter configuration object
+     * Check if a value is an `ArrayOf<...>` token produced by {@link Converters.array}.
      */
-    static isArrayConverter(value: unknown): value is ArrayConverter {
-        return (
-            typeof value === 'object' &&
-            value !== null &&
-            'delimiter' in value &&
-            typeof (value as ArrayConverter).delimiter === 'string'
-        );
-    }
-
-    /**
-     * Check if a value is a valid ArrayConverter type
-     */
-    static isValidArrayConverterType(value: unknown): value is ValidArrayConverterBuiltInType {
-        if (typeof value !== 'string') return false;
-
-        const invalidTypes = ['array', 'json', 'regexp'];
-
-        if (invalidTypes.includes(value)) return false;
-        const validTypes: ValidArrayConverterBuiltInType[] = ListOfBuiltInConverters.filter(
-            (type): type is ValidArrayConverterBuiltInType => !invalidTypes.includes(type)
-        );
-
-        return validTypes.includes(value as ValidArrayConverterBuiltInType);
+    static isArrayConverter(value: unknown): value is ArrayOf {
+        return isArrayOf(value);
     }
 
     static customConvertor<TFallback>(
@@ -61,30 +35,43 @@ export class Validator {
     }
 
     /**
-     * Validate ArrayConverter configuration with runtime checks
+     * Runtime validation that the `ArrayOf<...>` configuration is well-formed.
      */
-    static arrayConverter(value: unknown): asserts value is ArrayConverter {
-        if (!this.isArrayConverter(value)) {
-            throw new EnvaptError(EnvaptErrorCodes.MissingDelimiter, 'Must have delimiter property');
-        }
-
-        if (value.type !== undefined && !this.isValidArrayConverterType(value.type)) {
+    static arrayConverter(value: unknown): asserts value is ArrayOf {
+        if (!isArrayOf(value)) {
             throw new EnvaptError(
                 EnvaptErrorCodes.InvalidArrayConverterType,
-                `"${value.type as string}" is not a valid converter type`
+                'Expected an ArrayOf<...> token produced by Converters.array(...)'
+            );
+        }
+
+        if (typeof value.delimiter !== 'string' || value.delimiter.length === 0) {
+            throw new EnvaptError(
+                EnvaptErrorCodes.MissingDelimiter,
+                `ArrayOf<...> requires a non-empty string delimiter, got ${typeof value.delimiter}`
+            );
+        }
+
+        const elementOf = value.of;
+        const isScalar = typeof elementOf === 'string' && ListOfBuiltInConverters.includes(elementOf as ConverterToken);
+        const isCustomFn = typeof elementOf === 'function';
+        if (!isScalar && !isCustomFn) {
+            throw new EnvaptError(
+                EnvaptErrorCodes.InvalidArrayConverterType,
+                `ArrayOf<...> element ("of") must be a built-in scalar token or a function, got ${typeof elementOf}`
             );
         }
     }
 
     /**
-     * Validate that a string is a valid built-in converter type
+     * Validate that a string is a valid built-in scalar converter token
      */
     static builtInConverter(value: unknown): asserts value is BuiltInConverter {
         if (typeof value !== 'string') {
             throw new EnvaptError(EnvaptErrorCodes.InvalidConverterType, `Expected string, got ${typeof value}`);
         }
 
-        if (!ListOfBuiltInConverters.includes(value as BuiltInConverter)) {
+        if (!ListOfBuiltInConverters.includes(value as ConverterToken)) {
             throw new EnvaptError(
                 EnvaptErrorCodes.InvalidBuiltInConverter,
                 `"${value}" is not a valid converter type. Valid types are: ${ListOfBuiltInConverters.join(',')}`
@@ -109,11 +96,11 @@ export class Validator {
      * Validate that all elements in an array fallback have consistent types
      */
     static validateArrayFallbackElementTypes(fallback: unknown[]): void {
-        if (fallback.length === 0) return; // Empty array is valid
+        if (fallback.length === 0) return;
 
         const firstElementType = typeof fallback[0];
         const hasInconsistentTypes = fallback.some((element, index) => {
-            if (index === 0) return false; // Skip first element
+            if (index === 0) return false;
             return typeof element !== firstElementType;
         });
 
@@ -126,18 +113,39 @@ export class Validator {
     }
 
     /**
-     * Validate that array converter type matches fallback element types
+     * Validate that an `ArrayOf<...>` element converter matches the runtime types of its
+     * fallback elements. For `Converters.Time` arrays the element-time-string format is also
+     * checked here.
      */
-    static validateArrayConverterElementTypeMatch(converterType: string, fallback: unknown[]): void {
-        if (fallback.length === 0) return; // Empty array is valid
+    static validateArrayConverterElementTypeMatch(elementOf: ArrayOf['of'], fallback: unknown[]): void {
+        if (fallback.length === 0) return;
 
+        if (typeof elementOf === 'function') {
+            // Custom element converters can return anything; we can't statically validate the fallback shape.
+            return;
+        }
+
+        const elementToken = elementOf;
+
+        // Time array fallbacks may be number[] OR string[] (TimeFallback[]).
+        if (elementToken === 'time') {
+            const everyNumber = fallback.every((v) => typeof v === 'number');
+            const everyString = fallback.every((v) => typeof v === 'string');
+            if (!everyNumber && !everyString) {
+                throw new EnvaptError(
+                    EnvaptErrorCodes.ArrayFallbackElementTypeMismatch,
+                    'Time array fallback must be all numbers or all time-string entries.'
+                );
+            }
+            return;
+        }
+
+        const typeChecker = BuiltInConverterTypeCheckers[elementToken];
         const firstElement = fallback[0];
-        const typeChecker = BuiltInConverterTypeCheckers[converterType as keyof typeof BuiltInConverterTypeCheckers];
-
         if (!typeChecker(firstElement)) {
             throw new EnvaptError(
                 EnvaptErrorCodes.ArrayFallbackElementTypeMismatch,
-                `Array converter type "${converterType}" does not match fallback element type. Expected ${converterType} compatible elements.`
+                `Array converter type "${elementToken}" does not match fallback element type. Expected ${elementToken} compatible elements.`
             );
         }
     }
@@ -158,16 +166,10 @@ export class Validator {
         converter: typeof String | typeof Number | typeof Boolean | typeof BigInt | typeof Symbol,
         fallback: unknown
     ): CoercedType {
-        // Check if fallback is already the correct type and return as-is
         if (this.isCorrectPrimitiveType(converter, fallback)) return fallback as CoercedType;
-
-        // Otherwise, coerce the value
         return this.performPrimitiveCoercion<CoercedType>(converter, fallback);
     }
 
-    /**
-     * Check if fallback is already the correct primitive type
-     */
     private static isCorrectPrimitiveType(
         converter: typeof String | typeof Number | typeof Boolean | typeof BigInt | typeof Symbol,
         fallback: unknown
@@ -180,9 +182,6 @@ export class Validator {
         return false;
     }
 
-    /**
-     * Perform the actual primitive coercion
-     */
     private static performPrimitiveCoercion<CoercedType>(
         converter: typeof String | typeof Number | typeof Boolean | typeof BigInt | typeof Symbol,
         fallback: unknown
@@ -201,7 +200,6 @@ export class Validator {
             );
         }
 
-        // This should never happen but TypeScript needs it
         /* v8 ignore next -- @preserve */
         throw new EnvaptError(
             EnvaptErrorCodes.PrimitiveCoercionFailed,

--- a/packages/envapt/src/core/AdvancedMethods.ts
+++ b/packages/envapt/src/core/AdvancedMethods.ts
@@ -1,9 +1,8 @@
 import { PrimitiveMethods } from './PrimitiveMethods';
 
-import type { Converters } from '../Converters';
+import type { ArrayOf } from '../Converters';
 import type {
     AdvancedConverterReturn,
-    ArrayConverter,
     BuiltInConverter,
     ConditionalReturn,
     ConverterFunction,
@@ -18,34 +17,37 @@ import type {
 export class AdvancedMethods extends PrimitiveMethods {
     /**
      * Get an environment variable using a built-in converter.
-     * Supports both `Converters` enum values and array converter configurations.
-     * The key can be a single name or an ordered list; the first defined value wins.
+     *
+     * Supports both scalar tokens (e.g. `Converters.Number`) and `ArrayOf<...>` tokens
+     * produced by `Converters.array(...)`. The key can be a single name or an ordered list;
+     * the first defined value wins.
      */
     // Time-specific overload — constrains the fallback to TimeFallback (number | time-string).
     // Must precede the generic BuiltInConverter overload so it wins overload resolution.
     static getUsing<TFallback extends TimeFallback | undefined = undefined>(
         key: EnvKeyInput,
-        converter: Converters.Time | 'time',
+        converter: 'time',
         fallback?: TFallback
     ): ConditionalReturn<number, TFallback>;
-    static getUsing<TConverter extends BuiltInConverter | ArrayConverter, TFallback = undefined>(
+    static getUsing<TConverter extends BuiltInConverter | ArrayOf, TFallback = undefined>(
         key: EnvKeyInput,
         converter: TConverter,
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback>;
-    static getUsing<TReturn>(
-        key: EnvKeyInput,
-        converter: BuiltInConverter | ArrayConverter,
-        fallback?: TReturn
-    ): TReturn;
-    static getUsing<TConverter extends BuiltInConverter | ArrayConverter, TFallback = undefined>(
+    static getUsing<TReturn>(key: EnvKeyInput, converter: BuiltInConverter | ArrayOf, fallback?: TReturn): TReturn;
+    static getUsing<TConverter extends BuiltInConverter | ArrayOf, TFallback = undefined>(
         key: EnvKeyInput,
         converter: TConverter,
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback> {
-        // Check if variable exists first, for consistency with primitive methods
         const { key: resolvedKey, value } = this.resolveKeyInput(key);
-        if (!value) return fallback as AdvancedConverterReturn<TConverter, TFallback>;
+
+        // No env value AND no fallback: return undefined to match primitive-method semantics.
+        // Otherwise route through the parser so asymmetric fallback types (TimeFallback,
+        // TimeFallback[] for `of: time` arrays) get coerced to the declared return type.
+        if (!value && fallback === undefined) {
+            return undefined as AdvancedConverterReturn<TConverter, TFallback>;
+        }
 
         const hasFallback = fallback !== undefined;
         const result = this.parser.convertValue(resolvedKey, fallback, converter, hasFallback);
@@ -58,16 +60,16 @@ export class AdvancedMethods extends PrimitiveMethods {
      */
     getUsing<TFallback extends TimeFallback | undefined = undefined>(
         key: EnvKeyInput,
-        converter: Converters.Time | 'time',
+        converter: 'time',
         fallback?: TFallback
     ): ConditionalReturn<number, TFallback>;
-    getUsing<TConverter extends BuiltInConverter | ArrayConverter, TFallback = undefined>(
+    getUsing<TConverter extends BuiltInConverter | ArrayOf, TFallback = undefined>(
         key: EnvKeyInput,
         converter: TConverter,
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback>;
-    getUsing<TReturn>(key: EnvKeyInput, converter: BuiltInConverter | ArrayConverter, fallback?: TReturn): TReturn;
-    getUsing<TConverter extends BuiltInConverter | ArrayConverter, TFallback = undefined>(
+    getUsing<TReturn>(key: EnvKeyInput, converter: BuiltInConverter | ArrayOf, fallback?: TReturn): TReturn;
+    getUsing<TConverter extends BuiltInConverter | ArrayOf, TFallback = undefined>(
         key: EnvKeyInput,
         converter: TConverter,
         fallback?: TFallback

--- a/packages/envapt/src/index.ts
+++ b/packages/envapt/src/index.ts
@@ -1,6 +1,7 @@
 export { Envapt } from './Envapt';
 export { Envapter, Environment } from './Envapter';
-export { Converters } from './Converters';
+export { Converters, isArrayOf } from './Converters';
+export type { ArrayElement, ArrayOf, ConverterToken, CustomElementConverter } from './Converters';
 export * from './Error';
 
 export type * from './Types';

--- a/packages/envapt/tests/.env.018-array
+++ b/packages/envapt/tests/.env.018-array
@@ -1,0 +1,27 @@
+# Fixture for tests/018-array-typesafety.test.ts
+
+# Malformed element values (should throw ArrayElementConversionFailed)
+PORTS_BAD=80,abc,443
+FLAGS_BAD=true,nope,false
+TIMES_BAD=5s,bogus,10m
+URLS_BAD=https://a.test,not a url,https://b.test
+DATES_BAD=2024-01-01T00:00:00Z,not-a-date,2025-01-01T00:00:00Z
+
+# Empty items must be filtered without error
+LIST_WITH_GAPS=1, , 2, ,,3
+
+# Custom function inputs
+UPPERCASE_TAGS=alpha,beta,gamma
+PARSED_NUMS=ff,10,ffff
+FAILING_CUSTOM=good,bad,good
+
+# Present time-string list
+TIMES_PRESENT=2s,3m,1h
+
+# Defaults
+DEFAULT_CSV=a,b,c
+PIPE_SEPARATED=x|y|z
+
+# Variable indirection
+PORTS_INDIRECT=8080,8081
+CSV_INDIRECT=alpha,beta

--- a/packages/envapt/tests/002-envapt.test.ts
+++ b/packages/envapt/tests/002-envapt.test.ts
@@ -120,7 +120,7 @@ describe('Envapt', () => {
 
             @Envapt('TEST_VAR_UNDEFINED_FALLBACK_WITH_CONVERTER', {
                 fallback: undefined,
-                converter: { delimiter: ',', type: Converters.Time }
+                converter: Converters.array({ of: Converters.Time, delimiter: ',' })
             })
             public static readonly undefinedFallbackWithArrayConverter: string;
         }
@@ -239,13 +239,13 @@ describe('Envapt', () => {
             @Envapt('DATABASE_CONFIG', { converter: Converters.Json })
             static readonly databaseConfig: object;
 
-            @Envapt('API_ENDPOINTS', { converter: { delimiter: ';' } })
+            @Envapt('API_ENDPOINTS', { converter: Converters.array({ delimiter: ';' }) })
             static readonly apiEndpoints: string[];
 
-            @Envapt('CORS_ORIGINS', { converter: { delimiter: '|', type: Converters.Url } })
+            @Envapt('CORS_ORIGINS', { converter: Converters.array({ of: Converters.Url, delimiter: '|' }) })
             static readonly corsOrigins: URL[];
 
-            @Envapt('SERVICE_TAGS', { converter: { delimiter: ' ' } })
+            @Envapt('SERVICE_TAGS', { converter: Converters.array({ delimiter: ' ' }) })
             static readonly serviceTags: string[];
 
             @Envapt('ENABLED_FEATURES', { converter: Converters.Boolean })

--- a/packages/envapt/tests/004-builtin-converters.test.ts
+++ b/packages/envapt/tests/004-builtin-converters.test.ts
@@ -64,34 +64,43 @@ describe('Built-in Converters', () => {
 
     describe('array converters', () => {
         class ArrayTest {
-            @Envapt('TEST_ARRAY_COMMA', { converter: Converters.Array, fallback: [] })
+            @Envapt('TEST_ARRAY_COMMA', { converter: Converters.array(), fallback: [] })
             static readonly arrayDefault: string[];
 
-            @Envapt('TEST_ARRAY_COMMA', { converter: { delimiter: ',' }, fallback: [] })
+            @Envapt('TEST_ARRAY_COMMA', { converter: Converters.array({ delimiter: ',' }), fallback: [] })
             static readonly arrayComma: string[];
 
-            @Envapt('TEST_ARRAY_SPACE', { converter: { delimiter: ' ' }, fallback: [] })
+            @Envapt('TEST_ARRAY_SPACE', { converter: Converters.array({ delimiter: ' ' }), fallback: [] })
             static readonly arraySpace: string[];
 
-            @Envapt('TEST_ARRAY_EMPTY', { converter: Converters.Array, fallback: ['default'] })
+            @Envapt('TEST_ARRAY_EMPTY', { converter: Converters.array(), fallback: ['default'] })
             static readonly arrayEmpty: string[];
 
-            @Envapt('TEST_ARRAY_WHITESPACE_ONLY', { converter: Converters.Array, fallback: [] })
+            @Envapt('TEST_ARRAY_WHITESPACE_ONLY', { converter: Converters.array(), fallback: [] })
             static readonly arrayWhitespaceOnly: string[];
 
-            @Envapt('TEST_ARRAY_COMMA_SPACE', { converter: { delimiter: ', ' }, fallback: [] })
+            @Envapt('TEST_ARRAY_COMMA_SPACE', { converter: Converters.array({ delimiter: ', ' }), fallback: [] })
             static readonly arrayCommaSpace: string[];
 
-            @Envapt('NONEXISTENT_ARRAY', { converter: Converters.Array, fallback: ['fallback1', 'fallback2'] })
+            @Envapt('NONEXISTENT_ARRAY', { converter: Converters.array(), fallback: ['fallback1', 'fallback2'] })
             static readonly nonexistentArray: string[];
 
-            @Envapt('TEST_ARRAY_NUMBERS', { converter: { delimiter: ',', type: Converters.Number }, fallback: [] })
+            @Envapt('TEST_ARRAY_NUMBERS', {
+                converter: Converters.array({ of: Converters.Number, delimiter: ',' }),
+                fallback: []
+            })
             static readonly arrayNumbers: number[];
 
-            @Envapt('TEST_ARRAY_BOOLEANS', { converter: { delimiter: ',', type: Converters.Boolean }, fallback: [] })
+            @Envapt('TEST_ARRAY_BOOLEANS', {
+                converter: Converters.array({ of: Converters.Boolean, delimiter: ',' }),
+                fallback: []
+            })
             static readonly arrayBooleans: boolean[];
 
-            @Envapt('TEST_ARRAY_TIME', { converter: { delimiter: ',', type: Converters.Time }, fallback: [] })
+            @Envapt('TEST_ARRAY_TIME', {
+                converter: Converters.array({ of: Converters.Time, delimiter: ',' }),
+                fallback: []
+            })
             static readonly arrayTime: number[];
         }
 

--- a/packages/envapt/tests/005-runtime-validation.test.ts
+++ b/packages/envapt/tests/005-runtime-validation.test.ts
@@ -14,18 +14,7 @@ describe('Runtime Validation', () => {
 
     describe('Built-in converter validation', () => {
         it('should validate correct built-in converter types', () => {
-            const validTypes = [
-                'string',
-                'number',
-                'boolean',
-                'bigint',
-                'symbol',
-                'array',
-                'json',
-                'url',
-                'regexp',
-                'date'
-            ];
+            const validTypes = ['string', 'number', 'boolean', 'bigint', 'symbol', 'json', 'url', 'regexp', 'date'];
 
             for (const type of validTypes) {
                 const testFunction = (): void => Validator.builtInConverter(type);
@@ -34,7 +23,8 @@ describe('Runtime Validation', () => {
         });
 
         it('should throw for invalid built-in converter types', () => {
-            const invalidTypes = ['invalid', 'str', 'num'];
+            // Note: 'array' is no longer a scalar token in v5 (use Converters.array() instead).
+            const invalidTypes = ['invalid', 'str', 'num', 'array'];
 
             const testFunction = (type: string) => () => Validator.builtInConverter(type);
 
@@ -60,59 +50,49 @@ describe('Runtime Validation', () => {
         });
     });
 
-    describe('ArrayConverter validation', () => {
-        it('should validate correct ArrayConverter configurations', () => {
-            const validConfigs = [
-                { delimiter: ',' },
-                { delimiter: ';', type: 'string' },
-                { delimiter: '|', type: 'number' },
-                { delimiter: ' ', type: 'boolean' }
+    describe('ArrayOf validation (brand-based)', () => {
+        it('should validate well-formed ArrayOf tokens from Converters.array(...)', () => {
+            const validTokens = [
+                Converters.array(),
+                Converters.array({ of: Converters.String }),
+                Converters.array({ of: Converters.Number, delimiter: '|' }),
+                Converters.array({ of: Converters.Boolean, delimiter: ' ' }),
+                Converters.array({ of: (raw: string) => raw.toUpperCase() })
             ];
 
-            for (const config of validConfigs) {
-                const testFunction = (): void => Validator.arrayConverter(config);
+            for (const token of validTokens) {
+                const testFunction = (): void => Validator.arrayConverter(token);
                 expect(testFunction).to.not.throw();
             }
         });
 
-        it('should throw for invalid ArrayConverter configurations', () => {
-            const invalidConfigs = [{}, 'string', null];
+        it('should throw for values missing the ArrayOf brand', () => {
+            const invalidConfigs = [{}, 'string', null, { delimiter: ',' }, { of: 'string', delimiter: ',' }];
 
             const testFunction = (config: unknown) => () => Validator.arrayConverter(config);
 
             invalidConfigs.forEach((config) => {
                 expect(testFunction(config))
                     .to.throw(EnvaptError)
-                    .with.property('code', EnvaptErrorCodes.MissingDelimiter);
-            });
-        });
-
-        it('should throw for invalid ArrayConverter types', () => {
-            const invalidTypes = ['array', 'json', 'regexp', 'invalid'];
-
-            const testFunction = (type: string) => () => Validator.arrayConverter({ delimiter: ',', type });
-
-            invalidTypes.forEach((type) => {
-                expect(testFunction(type))
-                    .to.throw(EnvaptError)
                     .with.property('code', EnvaptErrorCodes.InvalidArrayConverterType);
             });
         });
 
-        it('should validate correct ArrayConverter element types', () => {
-            const validTypes = ['string', 'number', 'boolean', 'integer', 'bigint', 'symbol', 'float', 'url', 'date'];
-
-            for (const type of validTypes) {
-                expect(Validator.isValidArrayConverterType(type)).to.be.true;
-            }
+        it('should throw when a hand-rolled ArrayOf has an unknown `of` token', () => {
+            // Bypass TS to feed a malformed token through runtime validation.
+            // intentionally malformed for runtime validation -- justified
+            const malformed = { __envaptKind: 'array', of: 'not-a-real-token', delimiter: ',' };
+            expect(() => Validator.arrayConverter(malformed))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.InvalidArrayConverterType);
         });
 
-        it('should reject invalid ArrayConverter element types', () => {
-            const invalidTypes = ['array', 'json', 'regexp', 'invalid', 123, {}, null];
-
-            for (const type of invalidTypes) {
-                expect(Validator.isValidArrayConverterType(type)).to.be.false;
-            }
+        it('should throw when a hand-rolled ArrayOf has a missing or empty delimiter', () => {
+            // intentionally malformed for runtime validation -- justified
+            const missingDelimiter = { __envaptKind: 'array', of: 'string', delimiter: '' };
+            expect(() => Validator.arrayConverter(missingDelimiter))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingDelimiter);
         });
     });
 
@@ -120,37 +100,24 @@ describe('Runtime Validation', () => {
         class FallbackTests {
             // @ts-expect-error Inconsistent fallback type
             @Envapt('NONEXISTENT_ARRAY_VAR', {
-                converter: { delimiter: ',' },
+                converter: Converters.array(),
                 fallback: 'not-an-array'
             })
             static readonly invalidArrayFallback: string[];
 
-            // @ts-expect-error Inconsistent fallback type
-            @Envapt('INVALID_ARRAY_CONVERTER_TYPE', {
-                converter: { delimiter: ',', type: 'invalid' },
-                fallback: []
-            })
-            static readonly invalidArrayConverterType: string[];
-
             @Envapt('NONEXISTENT_ARRAY_VAR', {
-                converter: { delimiter: ',' }
+                converter: Converters.array()
             })
             static readonly noFallbackArray: string[] | null;
         }
 
-        it('should throw error when ArrayConverter is used with non-array fallback for missing env var', () => {
+        it('should throw error when ArrayOf is used with non-array fallback for missing env var', () => {
             expect(() => FallbackTests.invalidArrayFallback)
                 .to.throw(EnvaptError)
                 .with.property('code', EnvaptErrorCodes.InvalidFallback);
         });
 
-        it('should throw error when ArrayConverter is used with invalid type in converter', () => {
-            expect(() => FallbackTests.invalidArrayConverterType)
-                .to.throw(EnvaptError)
-                .with.property('code', EnvaptErrorCodes.InvalidArrayConverterType);
-        });
-
-        it('should return null when ArrayConverter is used without fallback for missing env var', () => {
+        it('should return null when ArrayOf is used without fallback for missing env var', () => {
             expect(FallbackTests.noFallbackArray).to.be.null;
         });
     });
@@ -298,45 +265,41 @@ describe('Runtime Validation', () => {
 
     describe('Array converter fallback element type validation', () => {
         class ArrayConverterValidationTests {
-            // Array converter with mixed-type fallback elements
-            // @ts-expect-error Inconsistent fallback type
+            // @ts-expect-error Inconsistent fallback element types
             @Envapt('NONEXISTENT_ARRAY_VAR', {
-                converter: { delimiter: ',', type: Converters.String },
+                converter: Converters.array({ of: Converters.String }),
                 fallback: ['string', 42, 'another-string']
             })
             static readonly arrayWithMixedTypeElements: string[];
 
-            // Array converter where type doesn't match fallback element type
-            // @ts-expect-error Inconsistent fallback type
+            // @ts-expect-error Fallback elements don't match the declared `of` token
             @Envapt('NONEXISTENT_ARRAY_VAR', {
-                converter: { delimiter: ',', type: Converters.Number },
+                converter: Converters.array({ of: Converters.Number }),
                 fallback: ['not-a-number', 'also-not-a-number']
             })
             static readonly arrayWithWrongElementType: number[];
 
-            // Default 'array' converter with mixed-type fallback elements
-            // @ts-expect-error Inconsistent fallback type
+            // @ts-expect-error Default Converters.array() returns string[]; mixed-type fallback rejected
             @Envapt('NONEXISTENT_ARRAY_VAR', {
-                converter: Converters.Array,
+                converter: Converters.array(),
                 fallback: ['string', 42, true]
             })
             static readonly defaultArrayWithMixedTypes: string[];
 
-            // Valid array converters for comparison
             @Envapt('NONEXISTENT_ARRAY_VAR', {
-                converter: { delimiter: ',', type: Converters.String },
+                converter: Converters.array({ of: Converters.String }),
                 fallback: ['all', 'strings', 'here']
             })
             static readonly validStringArray: string[];
 
             @Envapt('NONEXISTENT_ARRAY_VAR', {
-                converter: { delimiter: ',', type: Converters.Number },
+                converter: Converters.array({ of: Converters.Number }),
                 fallback: [1, 2, 3]
             })
             static readonly validNumberArray: number[];
 
             @Envapt('NONEXISTENT_ARRAY_VAR', {
-                converter: Converters.Array,
+                converter: Converters.array(),
                 fallback: ['all', 'strings']
             })
             static readonly validDefaultArray: string[];
@@ -414,7 +377,6 @@ describe('Runtime Validation', () => {
         });
 
         it('should throw PrimitiveCoercionFailed when Symbol coercion fails', () => {
-            // Use an object with a toString that throws to cause Symbol constructor to fail
             const problematicObject = {
                 toString() {
                     throw new Error('Cannot convert to string');
@@ -448,6 +410,22 @@ describe('Runtime Validation', () => {
             expect(() => Validator.validateArrayConverterElementTypeMatch('string', [123]))
                 .to.throw(EnvaptError)
                 .with.property('code', EnvaptErrorCodes.ArrayFallbackElementTypeMismatch);
+        });
+
+        it('should accept TimeFallback[] (string[]) when element token is "time"', () => {
+            expect(() => Validator.validateArrayConverterElementTypeMatch('time', ['5s', '10m'])).to.not.throw();
+            expect(() => Validator.validateArrayConverterElementTypeMatch('time', [5000, 600000])).to.not.throw();
+        });
+
+        it('should throw for a time-array fallback that is neither all numbers nor all strings', () => {
+            expect(() => Validator.validateArrayConverterElementTypeMatch('time', [{}, {}]))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.ArrayFallbackElementTypeMismatch);
+        });
+
+        it('should skip element-type validation when `of` is a custom function', () => {
+            const customOf = (raw: string): number => Number(raw);
+            expect(() => Validator.validateArrayConverterElementTypeMatch(customOf, [1, 2, 3])).to.not.throw();
         });
     });
 

--- a/packages/envapt/tests/008-instance-props.test.ts
+++ b/packages/envapt/tests/008-instance-props.test.ts
@@ -87,7 +87,7 @@ describe('Instance Properties with @Envapt', () => {
 
     describe('advanced converters on instance properties', () => {
         class AdvancedConvertersInstance {
-            @Envapt('INSTANCE_ARRAY', { converter: Converters.Array, fallback: [] })
+            @Envapt('INSTANCE_ARRAY', { converter: Converters.array(), fallback: [] })
             declare readonly arrayProp: string[];
 
             @Envapt('INSTANCE_JSON', { converter: Converters.Json, fallback: {} })
@@ -156,7 +156,7 @@ describe('Instance Properties with @Envapt', () => {
             @Envapt('INSTANCE_MISSING_BOOLEAN', { converter: Converters.Boolean, fallback: true })
             declare readonly missingBoolean: boolean;
 
-            @Envapt('INSTANCE_MISSING_ARRAY', { converter: Converters.Array, fallback: ['default1', 'default2'] })
+            @Envapt('INSTANCE_MISSING_ARRAY', { converter: Converters.array(), fallback: ['default1', 'default2'] })
             declare readonly missingArray: string[];
         }
 
@@ -273,7 +273,7 @@ describe('Instance Properties with @Envapt', () => {
             @Envapt('INSTANCE_BOOLEAN_TRUE', { converter: Converters.Boolean, fallback: false })
             declare readonly instanceBoolean: boolean;
 
-            @Envapt('INSTANCE_ARRAY', { converter: Converters.Array, fallback: [] })
+            @Envapt('INSTANCE_ARRAY', { converter: Converters.array(), fallback: [] })
             static readonly staticArray: string[];
         }
 

--- a/packages/envapt/tests/009-advanced-methods.test.ts
+++ b/packages/envapt/tests/009-advanced-methods.test.ts
@@ -29,18 +29,21 @@ describe('Advanced Converter Methods', () => {
             expect(result).to.deep.equal({ name: 'test', version: 1, enabled: true });
         });
 
-        it('should convert using Converters enum - Array', () => {
-            const result = Envapter.getUsing('TEST_ARRAY_COMMA', Converters.Array);
+        it('should convert using Converters.array() default', () => {
+            const result = Envapter.getUsing('TEST_ARRAY_COMMA', Converters.array());
             expect(result).to.deep.equal(['item1', 'item2', 'item3']);
         });
 
         it('should convert using array converter with custom delimiter', () => {
-            const result = Envapter.getUsing('TEST_ARRAY_SPACE', { delimiter: ' ' });
+            const result = Envapter.getUsing('TEST_ARRAY_SPACE', Converters.array({ delimiter: ' ' }));
             expect(result).to.deep.equal(['one', 'two', 'three']);
         });
 
         it('should convert using array converter with type conversion', () => {
-            const result = Envapter.getUsing('TEST_ARRAY_NUMBERS', { delimiter: ',', type: Converters.Number });
+            const result = Envapter.getUsing(
+                'TEST_ARRAY_NUMBERS',
+                Converters.array({ of: Converters.Number, delimiter: ',' })
+            );
             expect(result).to.deep.equal([1, 2, 3]);
         });
 
@@ -196,14 +199,19 @@ describe('Advanced Converter Methods', () => {
             }).to.throw();
         });
 
-        it('should throw error for invalid array converter', () => {
+        it('should accept Converters.array() and reject malformed ArrayOf tokens at runtime', () => {
             expect(() => {
-                Envapter.getUsing('TEST_STRING', { delimiter: ',' });
+                Envapter.getUsing('TEST_STRING', Converters.array());
             }).to.not.throw();
 
             expect(() => {
-                //@ts-expect-error We're passing an invalid type here for testing
-                Envapter.getUsing('TEST_STRING', { delimiter: ',', type: 'invalid' });
+                // Bypass TS to simulate a hand-rolled ArrayOf with an invalid `of`.
+                // intentionally malformed for runtime validation -- justified
+                Envapter.getUsing('TEST_STRING', {
+                    __envaptKind: 'array',
+                    of: 'invalid',
+                    delimiter: ','
+                } as unknown as ReturnType<typeof Converters.array>);
             }).to.throw();
         });
 
@@ -220,7 +228,7 @@ describe('Advanced Converter Methods', () => {
             const str = Envapter.getUsing('TEST_STRING', Converters.String);
             const num = Envapter.getUsing('TEST_NUMBER', Converters.Number);
             const bool = Envapter.getUsing('TEST_BOOLEAN', Converters.Boolean);
-            const arr = Envapter.getUsing('TEST_ARRAY_COMMA', Converters.Array);
+            const arr = Envapter.getUsing('TEST_ARRAY_COMMA', Converters.array());
 
             // With fallbacks should not be undefined
             const strWithFallback = Envapter.getUsing('TEST_STRING', Converters.String, 'default');

--- a/packages/envapt/tests/012-template-variable.test.ts
+++ b/packages/envapt/tests/012-template-variable.test.ts
@@ -38,13 +38,13 @@ describe('template variable resolution', () => {
         static readonly symbolTemplate: symbol;
 
         // Array converters with templates
-        @Envapt('TEST_ARRAY_COMMA_TEMPLATE', { converter: Converters.Array, fallback: [] })
+        @Envapt('TEST_ARRAY_COMMA_TEMPLATE', { converter: Converters.array(), fallback: [] })
         static readonly arrayCommaTemplate: string[];
 
-        @Envapt('TEST_ARRAY_SPACE_TEMPLATE', { converter: { delimiter: ' ' }, fallback: [] })
+        @Envapt('TEST_ARRAY_SPACE_TEMPLATE', { converter: Converters.array({ delimiter: ' ' }), fallback: [] })
         static readonly arraySpaceTemplate: string[];
 
-        @Envapt('TEST_ARRAY_COMMA_SPACE_TEMPLATE', { converter: { delimiter: ', ' }, fallback: [] })
+        @Envapt('TEST_ARRAY_COMMA_SPACE_TEMPLATE', { converter: Converters.array({ delimiter: ', ' }), fallback: [] })
         static readonly arrayCommaSpaceTemplate: string[];
 
         // JSON converter with templates

--- a/packages/envapt/tests/013-defensive-tests.test.ts
+++ b/packages/envapt/tests/013-defensive-tests.test.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, it, vi } from 'vitest';
 
 import { BuiltInConverters } from '../src/BuiltInConverters';
+import { Converters } from '../src/Converters';
 import { Envapter } from '../src/Envapter';
 import { EnvaptError, EnvaptErrorCodes } from '../src/Error';
 import { Parser } from '../src/Parser';
@@ -62,11 +63,6 @@ describe('Defensive tests', () => {
             expect(BuiltInConverters.symbol('', fallback)).to.equal(fallback);
         });
 
-        it('returns fallback when array items collapse to nothing', () => {
-            const fallback = ['fallback'];
-            expect(BuiltInConverters.array(' , , ', fallback)).to.equal(fallback);
-        });
-
         it('returns fallback when integer parsing fails', () => {
             const fallback = 321;
             expect(BuiltInConverters.integer('not-an-integer', fallback)).to.equal(fallback);
@@ -77,23 +73,25 @@ describe('Defensive tests', () => {
             expect(BuiltInConverters.float('not-a-float', fallback)).to.equal(fallback);
         });
 
-        it('returns an empty array when raw input is blank for custom array converters', () => {
-            const result = BuiltInConverters.processArrayConverter('   ', undefined, { delimiter: ',' });
+        it('returns an empty array when raw input is blank for array converters', () => {
+            const result = BuiltInConverters.processArrayConverter('   ', Converters.array({ delimiter: ',' }));
             expect(result).to.deep.equal([]);
         });
 
-        it('returns fallback when custom array converter produces no items', () => {
-            const fallback = ['keep-me'];
-            const result = BuiltInConverters.processArrayConverter(' , , ', fallback, { delimiter: ',' });
-            expect(result).to.equal(fallback);
+        it('returns [] when items all collapse to empty after filtering', () => {
+            const result = BuiltInConverters.processArrayConverter(' , , ', Converters.array({ delimiter: ',' }));
+            expect(result).to.deep.equal([]);
         });
 
-        it('preserves original value when typed conversion fails inside array converter', () => {
-            const result = BuiltInConverters.processArrayConverter('1,abc', undefined, {
-                delimiter: ',',
-                type: 'number'
-            });
-            expect(result).to.deep.equal([1, 'abc']);
+        it('throws when a typed element conversion fails inside array converter', () => {
+            expect(() =>
+                BuiltInConverters.processArrayConverter(
+                    '1,abc',
+                    Converters.array({ of: Converters.Number, delimiter: ',' })
+                )
+            )
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.ArrayElementConversionFailed);
         });
 
         it('returns fallback for invalid numeric timestamp strings', () => {
@@ -148,10 +146,10 @@ describe('Defensive tests', () => {
             spy.mockRestore();
         });
 
-        it('returns null when array converter yields no items and no fallback exists', () => {
+        it('returns [] when array converter yields no items after filtering empty entries', () => {
             const parser = new Parser(new StubEnvService({ EMPTY_LIST: ' , , ' }));
-            const result = parser.convertValue('EMPTY_LIST', undefined, { delimiter: ',' }, false);
-            expect(result).to.be.null;
+            const result = parser.convertValue('EMPTY_LIST', undefined, Converters.array({ delimiter: ',' }), false);
+            expect(result).to.deep.equal([]);
         });
 
         it('maps primitive Symbol constructors directly via internal converter', () => {

--- a/packages/envapt/tests/018-array-typesafety.test.ts
+++ b/packages/envapt/tests/018-array-typesafety.test.ts
@@ -1,0 +1,225 @@
+import { resolve } from 'node:path';
+
+import { expect } from 'chai';
+import { expectTypeOf } from 'expect-type';
+import { describe, it, beforeAll } from 'vitest';
+
+import { Converters, Envapt, Envapter, EnvaptErrorCodes } from '../src';
+import { EnvaptError } from '../src/Error';
+
+import type { ArrayOf } from '../src';
+
+describe('ArrayConverter typesafety (v5) — runtime', () => {
+    beforeAll(() => (Envapter.envPaths = resolve(import.meta.dirname, '.env.018-array')));
+
+    describe('throws on element conversion failure', () => {
+        class F1Tests {
+            @Envapt('PORTS_BAD', { converter: Converters.array({ of: Converters.Number }), fallback: [] })
+            static readonly ports: number[];
+
+            @Envapt('FLAGS_BAD', { converter: Converters.array({ of: Converters.Boolean }), fallback: [] })
+            static readonly flags: boolean[];
+
+            @Envapt('TIMES_BAD', { converter: Converters.array({ of: Converters.Time }), fallback: [] })
+            static readonly times: number[];
+
+            @Envapt('URLS_BAD', { converter: Converters.array({ of: Converters.Url }), fallback: [] })
+            static readonly urls: URL[];
+
+            @Envapt('DATES_BAD', { converter: Converters.array({ of: Converters.Date }), fallback: [] })
+            static readonly dates: Date[];
+        }
+
+        const failureCases: ['ports' | 'flags' | 'times' | 'urls' | 'dates'][] = [
+            ['ports'],
+            ['flags'],
+            ['times'],
+            ['urls'],
+            ['dates']
+        ];
+
+        failureCases.forEach(([key]) => {
+            it(`throws ArrayElementConversionFailed for ${key}`, () => {
+                expect(() => F1Tests[key])
+                    .to.throw(EnvaptError)
+                    .with.property('code', EnvaptErrorCodes.ArrayElementConversionFailed);
+            });
+        });
+    });
+
+    describe('permissive default filters empty items, never throws on empties', () => {
+        class F2Tests {
+            @Envapt('LIST_WITH_GAPS', { converter: Converters.array({ of: Converters.Number }), fallback: [] })
+            static readonly list: number[];
+        }
+
+        it('filters empty/whitespace items before conversion', () => {
+            // env value is `1, , 2, ,,3` per the fixture; permissive default trims empties first
+            expect(F2Tests.list).to.deep.equal([1, 2, 3]);
+        });
+    });
+
+    describe('custom function as element converter', () => {
+        class S4Tests {
+            @Envapt('UPPERCASE_TAGS', {
+                converter: Converters.array({ of: (raw) => raw.toUpperCase() }),
+                fallback: []
+            })
+            static readonly upperTags: string[];
+
+            @Envapt('PARSED_NUMS', {
+                converter: Converters.array({ of: (raw) => Number.parseInt(raw, 16) }),
+                fallback: []
+            })
+            static readonly hexNums: number[];
+
+            @Envapt('FAILING_CUSTOM', {
+                converter: Converters.array({ of: (raw) => (raw === 'good' ? raw : undefined) as string }),
+                fallback: []
+            })
+            static readonly failing: string[];
+        }
+
+        it('runs each element through the custom function', () => {
+            expect(S4Tests.upperTags).to.deep.equal(['ALPHA', 'BETA', 'GAMMA']);
+        });
+
+        it('infers element type from the function return type', () => {
+            expect(S4Tests.hexNums).to.deep.equal([255, 16, 65535]);
+        });
+
+        it('throws ArrayElementConversionFailed when the custom function returns undefined', () => {
+            expect(() => S4Tests.failing)
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.ArrayElementConversionFailed);
+        });
+    });
+
+    describe('TimeFallback array symmetry', () => {
+        class S5Tests {
+            @Envapt('NONEXISTENT_TIMES_NUM', {
+                converter: Converters.array({ of: Converters.Time }),
+                fallback: [5000, 60000, 600000]
+            })
+            static readonly timesNumberFallback: number[];
+
+            @Envapt('NONEXISTENT_TIMES_STR', {
+                converter: Converters.array({ of: Converters.Time }),
+                fallback: ['5s', '1m', '10m']
+            })
+            static readonly timesStringFallback: number[];
+
+            @Envapt('TIMES_PRESENT', {
+                converter: Converters.array({ of: Converters.Time }),
+                fallback: ['1m']
+            })
+            static readonly timesPresent: number[];
+        }
+
+        it('accepts number[] fallback when of is Time', () => {
+            expect(S5Tests.timesNumberFallback).to.deep.equal([5000, 60000, 600000]);
+        });
+
+        it('accepts TimeFallback[] (string[]) fallback when of is Time and coerces to number[]', () => {
+            expect(S5Tests.timesStringFallback).to.deep.equal([5000, 60000, 600000]);
+        });
+
+        it('still parses raw env time-strings into number[] when env value is set', () => {
+            // fixture: TIMES_PRESENT=2s,3m,1h
+            expect(S5Tests.timesPresent).to.deep.equal([2000, 180000, 3600000]);
+        });
+    });
+
+    describe('Defaults and basic shape', () => {
+        class DefaultTests {
+            @Envapt('DEFAULT_CSV', { converter: Converters.array(), fallback: [] })
+            static readonly csv: string[];
+
+            @Envapt('PIPE_SEPARATED', { converter: Converters.array({ delimiter: '|' }), fallback: [] })
+            static readonly piped: string[];
+        }
+
+        it('defaults of=String, delimiter=","', () => {
+            expect(DefaultTests.csv).to.deep.equal(['a', 'b', 'c']);
+        });
+
+        it('honors a custom delimiter when of is omitted (still string[])', () => {
+            expect(DefaultTests.piped).to.deep.equal(['x', 'y', 'z']);
+        });
+    });
+
+    describe('variable indirection preserves inference', () => {
+        const portsBuilder = Converters.array({ of: Converters.Number });
+        const csvBuilder = Converters.array();
+
+        class F3Tests {
+            @Envapt('PORTS_INDIRECT', { converter: portsBuilder, fallback: [] })
+            static readonly ports: number[];
+
+            @Envapt('CSV_INDIRECT', { converter: csvBuilder, fallback: [] })
+            static readonly csv: string[];
+        }
+
+        it('decorator still resolves correctly when the builder is hoisted to a variable', () => {
+            expect(F3Tests.ports).to.deep.equal([8080, 8081]);
+            expect(F3Tests.csv).to.deep.equal(['alpha', 'beta']);
+        });
+    });
+});
+
+describe('ArrayConverter typesafety (v5) — compile-time (expect-type)', () => {
+    it('Converters.array({ of: Converters.Number }) infers ArrayOf<"number">', () => {
+        const t = Converters.array({ of: Converters.Number });
+        expectTypeOf(t).toEqualTypeOf<ArrayOf<'number'>>();
+        expectTypeOf(t.of).toEqualTypeOf<'number'>();
+    });
+
+    it('Converters.array() infers ArrayOf<"string">', () => {
+        const t = Converters.array();
+        expectTypeOf(t).toEqualTypeOf<ArrayOf<'string'>>();
+    });
+
+    it('custom function element preserves the function type', () => {
+        const fn = (raw: string): Date => new Date(raw);
+        const t = Converters.array({ of: fn });
+        expectTypeOf(t.of).toEqualTypeOf<typeof fn>();
+    });
+
+    it('assigning the builder result to a const preserves the literal element type', () => {
+        const builder = Converters.array({ of: Converters.Number });
+        expectTypeOf(builder).toEqualTypeOf<ArrayOf<'number'>>();
+
+        const widerVar: ArrayOf<'number'> = Converters.array({ of: Converters.Number });
+        expectTypeOf(widerVar.of).toEqualTypeOf<'number'>();
+    });
+
+    it('@Envapt accepts TimeFallback[] (string[]) fallback for of:Time arrays', () => {
+        // If this class type-checks, time-array fallback symmetry holds (the decorator's
+        // fallback slot typechecks as TimeFallback[] for `of: Converters.Time`).
+        class TimeArrayFallbackCheck extends Envapter {
+            @Envapt('X', {
+                converter: Converters.array({ of: Converters.Time }),
+                fallback: ['5s', '1m']
+            })
+            declare readonly stringFallback: number[];
+
+            @Envapt('Y', {
+                converter: Converters.array({ of: Converters.Time }),
+                fallback: [5000, 60000]
+            })
+            declare readonly numberFallback: number[];
+        }
+        expectTypeOf<TimeArrayFallbackCheck>().toHaveProperty('stringFallback');
+        expectTypeOf<TimeArrayFallbackCheck>().toHaveProperty('numberFallback');
+    });
+
+    it('rejects of: Converters.Json at the type level', () => {
+        // @ts-expect-error 'json' is excluded from ArrayElement
+        Converters.array({ of: Converters.Json });
+    });
+
+    it('rejects of: Converters.Regexp at the type level', () => {
+        // @ts-expect-error 'regexp' is excluded from ArrayElement
+        Converters.array({ of: Converters.Regexp });
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,10 @@ importers:
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+    devDependencies:
+      expect-type:
+        specifier: ^1.3.0
+        version: 1.3.0
 
 packages:
 


### PR DESCRIPTION


## Summary

Old: `{ delimiter, type }` config object for array converters. New: phantom-branded `Converters.array({ of?, delimiter? })` builder. Inference now survives variable indirection, and bad element values throw `EnvaptError` instead of silently shipping type-lying arrays.

### What was wrong

**1. The runtime was lying about element types.** With `PORTS=80,abc,443` and a `number[]`-declared property, the old `processArrayConverter` substituted the raw string back into the array whenever element conversion returned `undefined`:

```ts
@Envapt('PORTS', { converter: { delimiter: ',', type: Converters.Number }, fallback: [] })
static readonly ports: number[];
// declared: number[]
// runtime:  [80, 'abc', 443]   <-- string interloper, no warning
```

Same story for `Number`, `Boolean`, `Time`, `Url`, and `Date` element types. Five built-in element types silently producing wrong-typed arrays at runtime.

**2. Inference died the moment you stored the converter anywhere.** Two layered issues with the same root cause. The `{ delimiter, type }` shape required `type:` to stay literal through every assignment. As soon as it widened, both the constraint check and the return inference broke:

```ts
// Direct call works.
@Envapt('PORTS', { converter: { delimiter: ',', type: Converters.Number }, fallback: [] })
static readonly ports: number[];

// Same converter pulled into a variable: TS infers `cfg.type: Converters` (the
// full enum), which doesn't satisfy `ArrayElementConverter` because Converters.Array,
// Converters.Json, and Converters.Regexp are excluded. All overloads reject.
const cfg = { delimiter: ',', type: Converters.Number };
Envapter.getUsing('PORTS', cfg);   // ❌ no overload matches
```

**3. No IntelliSense for the array config shape.** `converter:` was typed as a union (`PrimitiveConstructor | Converters | ConverterValue | ArrayConverter | ConverterFunction`), so TS couldn't narrow to the `ArrayConverter` branch from an empty object literal. Editors showed nothing for `delimiter` / `type` until the user already knew the field names and typed one in. Discoverability for the array shape was basically zero unless you'd read the source or the docs.

```ts
// Old: type `converter: {` and... nothing useful comes up.
// The union doesn't know yet which branch you're filling in.
@Envapt('PORTS', { converter: { /* ??? what goes here ??? */ } })
```

### How the new shape fixes it

`Converters.array(...)` returns a phantom-branded `ArrayOf<TElement>`. The element type lives in the builder's return type instead of in a property the user has to keep narrow, so inference holds through any indirection. The builder's parameter list is also a single concrete object type, so `Converters.array({` immediately surfaces `of?` and `delimiter?` in autocomplete.

```ts
@Envapt('PORTS', { converter: Converters.array({ of: Converters.Number }), fallback: [] })
static readonly ports: number[];

// Same builder hoisted to a const: inference still holds.
const portsBuilder = Converters.array({ of: Converters.Number });
@Envapt('PORTS', { converter: portsBuilder, fallback: [] })
static readonly p2: number[];     // ✅ still number[]
```

Element conversion failure now throws `EnvaptError` (`ArrayElementConversionFailed`, code 206) with the failing item and its index. No more type lies:

```ts
// PORTS=80,abc,443
Tests.ports; // throws: 'Element "abc" at index 1 could not be converted to number.'
```

## Related issue

Closes #78 

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Internal refactor
- [x] Documentation

## Scope check

- [x] This pull request focuses on one feature or closely related set of changes
- [x] No new packages or top level projects are introduced inside this repository
- [x] No core files have been copy pasted into new folders
- [x] Changes are limited to the existing `envapt/src` tree and necessary tests or docs

## Implementation notes

- `Converters` moves from `enum` to `as const` object so envapt source stays compatible with `erasableSyntaxOnly` (Node's native TS execution). Call sites are unchanged (`Converters.Number === 'number'` still holds). The type-position union is now `ConverterToken`.
- `Converters.array({ of?, delimiter? })` returns an `ArrayOf<TElement>` token. The runtime brand (`__envaptKind: 'array'`) drives dispatch in `Parser`, and `TElement` carries through any indirection (`const builder = Converters.array(...)` keeps working).
- `of:` accepts a built-in scalar token (excluding `json` and `regexp`) or a custom `(raw: string) => T` function. The function's return type drives the array element type at the decorator site.
- `BuiltInConverters.processArrayConverter` now throws `ArrayElementConversionFailed` (new code 206) on element conversion failure, with positional info. Replaces the silent `return converted ?? item` substitution that produced type lies.
- `InferConverterFallbackType` extended so `Converters.array({ of: Converters.Time })` accepts `TimeFallback[]` (e.g. `['5s', '10m']`) as a fallback, matching the existing scalar `Converters.Time` asymmetry. String fallbacks coerce to milliseconds at resolve time.
- `Envapter.getUsing` now routes through the parser whenever a fallback is provided so `TimeFallback` and `TimeFallback[]` fallbacks coerce consistently with `@Envapt`. Fixes a pre-existing inconsistency where `Envapter.getUsing('MISSING', Converters.Time, '10s')` previously returned `'10s'` instead of `10000`. The no-value-no-fallback path still returns `undefined` to match primitive-method semantics.
- `Converters.Array` token, `ArrayConverter` interface, and `ValidArrayConverterBuiltInType` type are removed. Replaced by `Converters.array()`, `ArrayOf<TElement>`, and `ArrayElement`.

## TypeScript and safety

- [x] New code is written in strict TypeScript
- [x] No new `any` types were introduced (if they were, explain why)
- [x] No `value as any` style casts were added to bypass the type system
- [x] No unnecessary type casts were added
- [x] Existing strict TypeScript settings were not disabled or loosened
- [x] New code has complete type coverage (no `@ts-ignore` or missing types)
- [x] New code uses proper TypeScript generics or unions where applicable
- [x] Public types and signatures are well defined and documented where needed

## Tests

- [x] `pnpm lint` passes with zero lint errors (without the need for unnecessary `/* eslint-disable */` comments or changes to existing lint rules)
- [x] `pnpm test` passes locally
- [x] `pnpm coverage` passes locally without new coverage gaps
- [x] New or updated tests cover the behavior in this pull request

- New `tests/018-array-typesafety.test.ts` (22 tests): element-failure throws across all five affected element types, permissive empty-item filter, custom function element (success + failure), TimeFallback[] symmetry, default delimiter / `of`, variable-indirection regression, plus `expect-type` compile-time assertions including `@ts-expect-error` rejections for `of: Converters.Json` and `of: Converters.Regexp`.
- Migrated tests 002, 004, 005, 008, 009, 012, 013 to the new API. Test 013 was retargeted to assert the new throw behavior instead of the old type lie.
- Added `expect-type` as a devDep.

## Docs and changesets

- [x] README or other docs were updated if behavior changed
- [x] A changeset was added with `pnpm cs add`, uses the correct bump level, and has a clear summary

Changeset is `major` (breaking). README's "Array Converters" section was rewritten to use the new builder. TOC link updated.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] Commit messages and PR title follow Conventional Commits
- [x] CI is expected to pass for this branch

