### PR TITLE
feat: strict mode + required option + Envapter.require()

### DIFF
--- a/.changeset/strict-mode.md
+++ b/.changeset/strict-mode.md
@@ -1,0 +1,33 @@
+---
+'envapt': major
+---
+
+**Feature:** added global `Envapter.strict` flag, decorator + functional `required: true` option, and `Envapter.require()` for boot-time existence checks.
+
+**`Envapter.strict`** (default `false`). When enabled:
+
+- Whitespace-only values (`KEY="   "`) are treated as missing on read, same as `undefined` / empty.
+- Empty / whitespace items in array converters (e.g. `PORTS=80,,443`) throw `EmptyArrayElement` (207) instead of being silently filtered.
+- Unresolved `${VAR}` placeholders in `Envapter.resolve\`...\`` and inside cached values throw `MissingEnvValue` (305) instead of being preserved as literal text.
+- Toggling the flag refreshes the cache so previously-cached values get re-evaluated under the new rule.
+
+**`@Envapt(key, { required: true })`** decorator option. Throws `MissingEnvValue` on first access if the env value is missing or empty (post-trim). Independent of global `strict`. Mutually exclusive with `fallback`: the per-converter overload unions block the combination at compile time, and the runtime Validator throws `InvalidUserDefinedConfig` (302) for dynamic objects that bypass the type check.
+
+**Functional API options-bag form:**
+
+- `Envapter.getUsing(key, { converter, required: true })` returns the converter's narrowed type (no `| undefined`); throws `MissingEnvValue` on missing/empty.
+- `Envapter.getWith(key, { converter, required: true })` same behavior for custom converter functions.
+- The positional `(key, converter, fallback?)` form is unchanged.
+
+**`Envapter.require()`** existence-check helper:
+
+- `Envapter.require('DATABASE_URL')` returns the post-template-resolution string; throws `MissingEnvValue` if missing or empty.
+- `Envapter.require(['A', 'B', 'C'])` returns `void`; collects every missing key into one error message instead of failing one-at-a-time.
+- No converter, no fallback. For typed fail-fast, use the decorator or the functional options-bag form.
+
+**`Envapter.dotenvConfig`** type tightened. The `path` and `processEnv` fields are now compile-time errors with branded explanation messages (they were always rejected at runtime; now the TS error surfaces the reason instead of just "excess property").
+
+**New error codes:**
+
+- `EmptyArrayElement = 207` — strict-mode array empty / whitespace items.
+- `MissingEnvValue = 305` — required key absent or empty, `require()` failures, strict-mode unresolved templates.

--- a/.github/skills/code-quality/CODE-COMMENTING-GUIDELINES.md
+++ b/.github/skills/code-quality/CODE-COMMENTING-GUIDELINES.md
@@ -123,3 +123,65 @@ Before adding a comment, ask:
 4. Does the comment avoid repeating what the code already says?
 
 If the answer to the first two questions is no, do not add the comment.
+
+## Failure Patterns To Avoid
+
+The fastest way to slip past the checklist is to write a comment that LOOKS like a "why" but actually narrates the code first and then tacks the why on the end. Catch these:
+
+### Narrate-then-justify
+
+```ts
+// Anti: lead-in restates the next line; only the second sentence is load-bearing.
+// We anchor the write to BaseClass rather than `this`: subclass calls would otherwise
+// create an own property on the subclass while readers walk up to the base and miss it.
+BaseClass._strict = value;
+```
+
+```ts
+// Drop the lead-in. Lead with the why.
+// Anchored to BaseClass: `this._strict = value` creates an own-property on the subclass
+// that callers reading via the base won't see.
+BaseClass._strict = value;
+```
+
+### Type-system paraphrase
+
+If a comment explains a TYPE definition that's two lines above, the comment is redundant. Either the type is sufficient on its own, or the type needs a better name. Rewriting the type is almost always the right fix.
+
+```ts
+// Anti: re-states the type structure in prose right next to the type.
+// `EnvaptOptions` is a discriminated union over `required` so the compile-time check
+// rejects `required: true` paired with `fallback`. The runtime Validator catches the
+// dynamic case that bypasses the types.
+type EnvaptOptions =
+    | { required: false; fallback?: T }
+    | { required: true; fallback?: Err<'...'> };
+
+// Good: the brand-name and Err<> explanation belong on the brand type itself, once.
+// Consumers don't need a paragraph re-explaining the union.
+```
+
+### Overload narration
+
+Multiple overload signatures next to short `//` comments labeling each one ("Time-specific overload", "Required form, time-specific", "Required form, built-in/array") are noise — the signature already conveys this. If users need a map of overloads, write ONE TSDoc block on the implementation signature describing the family, not a per-overload caption.
+
+### Stale-after-refactor
+
+Every refactor invalidates some "why" comments. When you delete an overload, change a return type, or revert a design, **grep for the names you removed and clean up every comment that references them**. A stale comment is worse than a missing one: it actively misleads.
+
+### JSDoc on `@internal` helpers
+
+Internal helpers don't need IDE-hover documentation. Use a single `//` line when a why exists, and zero comments when the function's name + body are self-explanatory. The four-line `/** ... */` block on a one-line accessor is signal that the function name is too thin or the block is decoration.
+
+### "I'm doing X" wrapper
+
+Comments that lead `// We do X here because...` always contain redundancy: the next line shows you doing X. Drop the wrapper, keep the because.
+
+```ts
+// Anti: `// Resolve key, then check missing under strict, then throw.` narrates 3 lines below.
+// Good: NO comment. The three function calls below are self-evident.
+```
+
+## Why "Drop the comment" is usually right
+
+When in doubt: delete the comment, re-read the code without it, and ask "would a careful reader misunderstand this?" If the answer is no, the comment was decoration. The bar is "would mislead without it," not "would be slightly faster to read with it." Speed gains from prose-restating-code are smaller than the maintenance cost of keeping the comment honest across refactors.

--- a/packages/envapt/eslint.config.mjs
+++ b/packages/envapt/eslint.config.mjs
@@ -11,6 +11,11 @@ export default createConfig({
                 'max-nested-callbacks': ['warn', 10],
                 'max-lines': ['warn', { max: 600 }]
             }
+        },
+        {
+            // Type-error fixtures: intentionally broken code consumed by the compiler-API
+            // test at runtime. Excluded from the project's tsconfig + skipped by lint.
+            ignores: ['tests/type-error-fixtures/**']
         }
     ]
 });

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -38,6 +38,7 @@
         "fmt:check": "prettier --check '{src,tests,scripts}/**/*.{ts,tsx,json,md}' --cache",
         "fmt:all": "prettier --write .",
         "tc": "tsc --noEmit",
+        "tsd": "tsd",
         "test": "vitest run",
         "test:watch": "vitest dev",
         "coverage": "pnpm run test --coverage",

--- a/packages/envapt/src/BuiltInConverters.ts
+++ b/packages/envapt/src/BuiltInConverters.ts
@@ -182,14 +182,25 @@ export class BuiltInConverters {
      * - With a custom function element: runs each item through the function. Propagates user
      *   exceptions; treats `undefined` returns as conversion failures (same throw as scalar path).
      * - Returns `[]` when the raw value is empty/whitespace.
+     * - When `strict` is true, throws `EmptyArrayElement` on any empty/whitespace item instead
+     *   of silently filtering it out.
      */
-    static processArrayConverter(raw: string, config: ArrayOf): unknown[] {
+    static processArrayConverter(raw: string, config: ArrayOf, strict = false): unknown[] {
         if (raw.trim() === '') return [];
 
-        const items = raw
-            .split(config.delimiter)
-            .map((item) => String(item).trim())
-            .filter(Boolean);
+        const trimmedItems = raw.split(config.delimiter).map((item) => String(item).trim());
+
+        if (strict) {
+            const emptyIdx = trimmedItems.findIndex((item) => item === '');
+            if (emptyIdx !== -1) {
+                throw new EnvaptError(
+                    EnvaptErrorCodes.EmptyArrayElement,
+                    `Array element at index ${emptyIdx} is empty or whitespace only (strict mode).`
+                );
+            }
+        }
+
+        const items = trimmedItems.filter(Boolean);
 
         if (!items.length) return [];
 

--- a/packages/envapt/src/Dotenv.ts
+++ b/packages/envapt/src/Dotenv.ts
@@ -1,8 +1,15 @@
 import fs from 'node:fs';
 
+import type { Err } from './Types';
+
+type PathManagedByEnvapter =
+    Err<'`path` is managed by Envapter. Use `Envapter.envPaths` to configure which .env files load.'>;
+type ProcessEnvManagedByEnvapter = Err<'`processEnv` is managed internally by Envapter and cannot be overridden.'>;
+
 /**
  * Public options for the internal `.env` loader. Mirrors the subset of dotenv's
  * `config()` options that envapt actually supports (no DOTENV_KEY, no quiet).
+ *
  * @public
  */
 export interface DotenvConfigOptions {
@@ -12,6 +19,8 @@ export interface DotenvConfigOptions {
     override?: boolean;
     /** When true, prints `[dotenv]` messages to stderr while parsing. Default false. */
     debug?: boolean;
+    path?: PathManagedByEnvapter;
+    processEnv?: ProcessEnvManagedByEnvapter;
 }
 
 /**
@@ -19,7 +28,7 @@ export interface DotenvConfigOptions {
  * fields are managed by envapt and never user-supplied.
  * @internal
  */
-export interface LoadDotenvInput extends DotenvConfigOptions {
+export interface LoadDotenvInput extends Omit<DotenvConfigOptions, 'path' | 'processEnv'> {
     /** One or more `.env` paths to load, in declaration order. */
     path: string | string[];
     /** Target env map. Mutated in place with parsed values. */

--- a/packages/envapt/src/Envapt.ts
+++ b/packages/envapt/src/Envapt.ts
@@ -1,5 +1,6 @@
 import { EnvaptCache } from './core/EnvapterBase';
 import { Envapter } from './Envapter';
+import { EnvaptError, EnvaptErrorCodes } from './Error';
 import { Parser } from './Parser';
 
 import type { ArrayOf } from './Converters';
@@ -12,14 +13,20 @@ import type {
     InferConverterFallbackType,
     InferPrimitiveFallbackType,
     InferPrimitiveReturnType,
-    PrimitiveConstructor
+    PrimitiveConstructor,
+    RequiredAndFallbackMutex
 } from './Types';
+
+function formatKeyForError(key: EnvKeyInput): string {
+    return Array.isArray(key) ? `[${key.join(', ')}]` : String(key);
+}
 
 function createPropertyDecorator<TFallback>(
     key: EnvKeyInput,
     fallback: TFallback | undefined,
     converter: EnvaptConverter<TFallback> | undefined,
-    hasFallback: boolean
+    hasFallback: boolean,
+    required: boolean
 ): PropertyDecorator {
     return function (target: object, prop: string | symbol): void {
         const propKey = String(prop);
@@ -36,9 +43,20 @@ function createPropertyDecorator<TFallback>(
                 // If so, we need to re-evaluate our cached value
                 let value = EnvaptCache.get(cacheKey) as TFallback | null | undefined;
 
-                // Re-evaluate if we don't have a cached value
                 if (value === undefined) {
-                    const parser = new Parser(new Envapter());
+                    const envapter = new Envapter();
+
+                    if (required) {
+                        const rawValue = envapter.getRaw(key);
+                        if (rawValue === undefined || rawValue.trim() === '') {
+                            throw new EnvaptError(
+                                EnvaptErrorCodes.MissingEnvValue,
+                                `Required environment variable "${formatKeyForError(key)}" is missing or empty.`
+                            );
+                        }
+                    }
+
+                    const parser = new Parser(envapter);
                     value = parser.convertValue(key, fallback, converter, hasFallback);
                     EnvaptCache.set(cacheKey, value);
                 }
@@ -52,15 +70,16 @@ function createPropertyDecorator<TFallback>(
 }
 
 /**
- * Usage 1: Custom converter function with fallback provided
+ * Usage 1: Either a custom converter function + fallback (both required), OR a fallback
+ * only (no converter).
  *
  * @param key - Environment variable name(s) to load
- * @param options - Configuration options with custom converter and required fallback
+ * @param options - Configuration options
  * @public
  * @example
  * ```ts
- * // Custom converter that validates a non-empty API key
  * class Config extends Envapter {
+ *   // Custom converter that validates a non-empty API key
  *   \@Envapt('API_KEY', {
  *     fallback: 'default-key',
  *     converter(raw, _fallback) {
@@ -69,42 +88,66 @@ function createPropertyDecorator<TFallback>(
  *     }
  *   })
  *   static readonly apiKey: string;
+ *
+ *   // Fallback-only (no converter): string fallback
+ *   \@Envapt('LOG_FILE', { fallback: '/var/log/app.log' })
+ *   static readonly logFile: string;
+ *
+ *   // Fallback-only: arbitrary object fallback
+ *   \@Envapt('RETRY_POLICY', { fallback: { retries: 3, backoff: 'exponential' } })
+ *   static readonly retryPolicy: unknown;
  * }
  * ```
  */
 export function Envapt<TFallback>(
     key: EnvKeyInput,
-    options: { converter: (raw: string | undefined, fallback: TFallback) => TFallback; fallback: TFallback }
+    options:
+        | { converter: (raw: string | undefined, fallback: TFallback) => TFallback; fallback: TFallback }
+        | { fallback: TFallback; converter?: undefined }
 ): PropertyDecorator;
 
 /**
- * Usage 2: Custom converter function without fallback
+ * Usage 2: Custom converter function without fallback. Either omit `required` (returns the
+ * converter's output, possibly `undefined`) or pass `required: true` to throw `MissingEnvValue`
+ * on missing/empty values.
  *
  * @param key - Environment variable name(s) to load
- * @param options - Configuration options with custom converter only
+ * @param options - Configuration options with custom converter only, with optional `required: true`
  * @public
  * @example
  * ```ts
- * // Custom converter without providing a fallback
  * class Config extends Envapter {
  *   \@Envapt('FEATURE_FLAGS', { converter(raw) {
- *     // raw may be undefined — handle that here
  *     return raw ? raw.split('|').map(s => s.trim()) : [];
  *   } })
  *   static readonly featureFlags: string[];
+ *
+ *   \@Envapt('JWT_SECRET', {
+ *     converter: (raw) => Buffer.from(raw ?? '', 'base64'),
+ *     required: true
+ *   })
+ *   declare static readonly jwtSecret: Buffer;
  * }
  * ```
  */
 export function Envapt<TReturnType>(
     key: EnvKeyInput,
-    options: { converter: ConverterFunction<TReturnType> }
+    options:
+        | { converter: ConverterFunction<TReturnType>; required?: false }
+        | { converter: ConverterFunction<TReturnType>; required: true; fallback?: RequiredAndFallbackMutex }
 ): PropertyDecorator;
 
 /**
- * Usage 3: Built-in or array converter with optional fallback
+ * Usage 3: Built-in or array converter with optional fallback OR `required: true`.
+ *
+ * `InferConverterFallbackType` handles asymmetric cases: scalar `Converters.Time` accepts
+ * `TimeFallback`, and `ArrayOf<'time'>` accepts `TimeFallback[]`. Every other converter
+ * reduces to `InferConverterReturnType`. The two object-shape branches are mutually
+ * exclusive: either provide a `fallback`, or pass `required: true` to throw
+ * `MissingEnvValue` on missing/empty values.
  *
  * @param key - Environment variable name(s) to load
- * @param options - Configuration options with built-in or array converter
+ * @param options - Configuration options
  * @public
  * @example
  * ```ts
@@ -134,21 +177,16 @@ export function Envapt<TReturnType>(
  *   })
  *   static readonly allowedOrigins: string[];
  *
- *   // Array converter: pipe-separated ports -> number[]
- *   \@Envapt('PORTS', {
- *     converter: Converters.array({ of: Converters.Number, delimiter: '|' }),
- *     fallback: [3000]
- *   })
- *   static readonly ports: number[];
+ *   \@Envapt('DATABASE_URL', { converter: Converters.Url, required: true })
+ *   declare static readonly databaseUrl: URL;
  * }
  * ```
  */
-// `InferConverterFallbackType` handles asymmetric cases: scalar `Converters.Time`
-// accepts `TimeFallback`, and `ArrayOf<'time'>` accepts `TimeFallback[]`. Every
-// other converter reduces to `InferConverterReturnType`.
 export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
     key: EnvKeyInput,
-    options: { converter: TConverter; fallback?: InferConverterFallbackType<TConverter> | undefined }
+    options:
+        | { converter: TConverter; fallback?: InferConverterFallbackType<TConverter> | undefined; required?: false }
+        | { converter: TConverter; required: true; fallback?: RequiredAndFallbackMutex }
 ): PropertyDecorator;
 
 /**
@@ -171,34 +209,31 @@ export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
  */
 export function Envapt<TConstructor extends PrimitiveConstructor>(
     key: EnvKeyInput,
-    options: {
-        converter: TConstructor;
-        fallback?: InferPrimitiveReturnType<TConstructor>;
-    }
+    options:
+        | { converter: TConstructor; fallback?: InferPrimitiveReturnType<TConstructor>; required?: false }
+        | { converter: TConstructor; required: true; fallback?: RequiredAndFallbackMutex }
 ): PropertyDecorator;
 
 /**
- * Usage 5: Fallback only (no converter)
+ * Usage 5: Required, no converter (raw string). Throws `MissingEnvValue` on first access if
+ * the env value is missing or empty (post-trim). Independent of global `Envapter.strict`.
+ * Mutually exclusive with `fallback`: combining them fails to match any overload at compile
+ * time. The runtime Validator catches dynamic objects that bypass the types.
  *
  * @param key - Environment variable name(s) to load
- * @param options - Configuration options with fallback only
+ * @param options - `{ required: true }`
  * @public
  * @example
  * ```ts
- * // Fallback-only usage (no converter)
  * class Config extends Envapter {
- *   \@Envapt('LOG_FILE', { fallback: '/var/log/app.log' })
- *   static readonly logFile: string;
- *
- *   \@Envapt('RETRY_POLICY', { fallback: { retries: 3, backoff: 'exponential' } })
- *   static readonly retryPolicy: unknown;
+ *   \@Envapt('API_KEY', { required: true })
+ *   declare static readonly apiKey: string;
  * }
  * ```
  */
-export function Envapt<TFallback>(
+export function Envapt(
     key: EnvKeyInput,
-    // eslint-disable-next-line @typescript-eslint/unified-signatures
-    options: { fallback: TFallback; converter?: undefined }
+    options: { required: true; fallback?: RequiredAndFallbackMutex }
 ): PropertyDecorator;
 
 /**
@@ -245,6 +280,17 @@ export function Envapt<TFallback extends string | number | boolean | bigint | sy
     converter?: PrimitiveConstructor
 ): PropertyDecorator;
 
+// Repeat of Usage 3 as the LAST non-impl overload. TS's "no overload matches" diagnostic
+// reports against the last declared candidate; this placement makes that diagnostic
+// surface the `RequiredAndFallbackMutex` branded literal in the chain (otherwise TS
+// reports against the classic positional API above and the explanation is masked).
+export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
+    key: EnvKeyInput,
+    options:
+        | { converter: TConverter; fallback?: InferConverterFallbackType<TConverter> | undefined; required?: false }
+        | { converter: TConverter; required: true; fallback?: RequiredAndFallbackMutex }
+): PropertyDecorator;
+
 /**
  * Instance/Static Property decorator that automatically loads and converts environment variables.
  */
@@ -257,17 +303,29 @@ export function Envapt<TFallback = unknown>(
     let fallback: TFallback | undefined;
     let actualConverter: EnvaptConverter<TFallback> | undefined;
     let hasFallback = true;
+    let required = false;
 
     if (
         fallbackOrOptions &&
         typeof fallbackOrOptions === 'object' &&
-        ('fallback' in fallbackOrOptions || 'converter' in fallbackOrOptions)
+        ('fallback' in fallbackOrOptions || 'converter' in fallbackOrOptions || 'required' in fallbackOrOptions)
     ) {
-        // Modern API
-        const options = fallbackOrOptions;
+        const options = fallbackOrOptions as {
+            fallback?: TFallback;
+            converter?: EnvaptConverter<TFallback>;
+            required?: boolean;
+        };
         fallback = options.fallback;
         actualConverter = options.converter;
         hasFallback = 'fallback' in options;
+        required = options.required === true;
+
+        if (required && hasFallback && fallback !== undefined) {
+            throw new EnvaptError(
+                EnvaptErrorCodes.InvalidUserDefinedConfig,
+                '`required: true` and `fallback` are mutually exclusive on @Envapt options. Drop the fallback or call `Envapter.require()` separately.'
+            );
+        }
     } else {
         // Classic API
         fallback = fallbackOrOptions as TFallback;
@@ -275,5 +333,5 @@ export function Envapt<TFallback = unknown>(
         hasFallback = arguments.length > 1;
     }
 
-    return createPropertyDecorator(key, fallback, actualConverter, hasFallback);
+    return createPropertyDecorator(key, fallback, actualConverter, hasFallback, required);
 }

--- a/packages/envapt/src/Envapter.ts
+++ b/packages/envapt/src/Envapter.ts
@@ -1,4 +1,5 @@
 import { AdvancedMethods } from './core/AdvancedMethods';
+import { EnvaptError, EnvaptErrorCodes } from './Error';
 
 export { EnvaptCache } from './core/EnvapterBase';
 export { Environment } from './core/EnvironmentMethods';
@@ -43,10 +44,18 @@ export class Envapter extends AdvancedMethods {
      * ```
      */
     static resolve(strings: TemplateStringsArray, ...keys: string[]): string {
+        const strict = Envapter.strict;
         return strings.reduce((result, string, i) => {
             const envKey = keys[i];
-            const envValue = envKey ? super.get(envKey, '') : '';
-            return result + string + envValue;
+            if (!envKey) return result + string;
+            const raw = super.get(envKey, '');
+            if (strict && raw.trim() === '') {
+                throw new EnvaptError(
+                    EnvaptErrorCodes.MissingEnvValue,
+                    `Cannot resolve template variable "\${${envKey}}": value is missing or empty.`
+                );
+            }
+            return result + string + raw;
         }, '');
     }
 
@@ -55,5 +64,46 @@ export class Envapter extends AdvancedMethods {
      */
     resolve(strings: TemplateStringsArray, ...keys: string[]): string {
         return Envapter.resolve(strings, ...keys);
+    }
+
+    /**
+     * Assert that one or more environment variables are present and non-empty (post-trim,
+     * after template resolution). Throws `MissingEnvValue` listing every missing key.
+     *
+     * For typed fail-fast in functional code, use `Envapter.getUsing(key, { converter, required: true })`.
+     *
+     * @example
+     * ```ts
+     * Envapter.require('DATABASE_URL');
+     * Envapter.require('DATABASE_URL', 'API_KEY', 'SENTRY_DSN');
+     * ```
+     */
+    static require(...keys: [string, ...string[]]): void {
+        const missing: string[] = [];
+        for (const k of keys) {
+            if (Envapter.resolveAndValidate(k) === undefined) missing.push(k);
+        }
+
+        if (missing.length > 0) {
+            throw new EnvaptError(
+                EnvaptErrorCodes.MissingEnvValue,
+                `Missing required environment variables: ${missing.join(', ')}.`
+            );
+        }
+    }
+
+    private static resolveAndValidate(key: string): string | undefined {
+        const { value } = this.resolveKeyInput(key);
+        if (value === undefined) return undefined;
+        const resolved = this.parser.resolveTemplate(key, value);
+        if (resolved.trim() === '') return undefined;
+        return resolved;
+    }
+
+    /**
+     * @see {@link Envapter.require}
+     */
+    require(...keys: [string, ...string[]]): void {
+        Envapter.require(...keys);
     }
 }

--- a/packages/envapt/src/Error.ts
+++ b/packages/envapt/src/Error.ts
@@ -25,6 +25,8 @@ export enum EnvaptErrorCodes {
     PrimitiveCoercionFailed = 205,
     /** Thrown when an array element fails to convert to the configured element type */
     ArrayElementConversionFailed = 206,
+    /** Thrown under strict mode when an array element is empty or whitespace only */
+    EmptyArrayElement = 207,
 
     // Other errors
     /** Thrown when delimiter is missing in array converter configuration */
@@ -35,7 +37,9 @@ export enum EnvaptErrorCodes {
     /** Thrown when specified environment files don't exist */
     EnvFilesNotFound = 303,
     /** Thrown when no valid environment key is provided */
-    InvalidKeyInput = 304
+    InvalidKeyInput = 304,
+    /** Thrown when a required environment value is missing or empty (post-trim) */
+    MissingEnvValue = 305
 }
 
 /**

--- a/packages/envapt/src/Parser.ts
+++ b/packages/envapt/src/Parser.ts
@@ -11,6 +11,7 @@ import type { BuiltInConverter, EnvKeyInput, EnvaptConverter, PrimitiveConstruct
 export interface EnvapterService {
     getRaw(key: EnvKeyInput): string | undefined;
     get(key: EnvKeyInput, def?: string): string | undefined;
+    isStrict(): boolean;
 }
 
 /**
@@ -28,6 +29,7 @@ export class Parser {
      */
     resolveTemplate(key: string, value: string, stack: Set<string> = new Set<string>()): string {
         stack.add(key);
+        const strict = this.envService.isStrict();
 
         const out = value.replace(this.TEMPLATE_REGEX, (template) => {
             const variable = template.slice(2, -1);
@@ -35,7 +37,16 @@ export class Parser {
             if (stack.has(variable)) return template; // cycle, preserve
 
             const raw = this.envService.getRaw(variable);
-            if (!raw || raw === '') return template; // missing or empty, preserve
+            const isMissing = raw === undefined || raw === '' || (strict && raw.trim() === '');
+            if (isMissing) {
+                if (strict) {
+                    throw new EnvaptError(
+                        EnvaptErrorCodes.MissingEnvValue,
+                        `Cannot resolve template variable "\${${variable}}": value is missing or empty.`
+                    );
+                }
+                return template; // missing or empty, preserve
+            }
 
             const resolved = this.resolveTemplate(variable, raw, new Set(stack));
 
@@ -172,7 +183,7 @@ export class Parser {
             return fallback;
         }
 
-        const result = BuiltInConverters.processArrayConverter(parsed, resolvedConverter);
+        const result = BuiltInConverters.processArrayConverter(parsed, resolvedConverter, this.envService.isStrict());
         return result as TFallback;
     }
 

--- a/packages/envapt/src/Types.ts
+++ b/packages/envapt/src/Types.ts
@@ -42,20 +42,24 @@ type ConverterFunction<TFallback = unknown> = (raw: BaseInput, fallback?: TFallb
  */
 type EnvaptConverter<TFallback> = PrimitiveConstructor | BuiltInConverter | ArrayOf | ConverterFunction<TFallback>;
 
+// The brand makes `Err<>` unsatisfiable from user code: a `unique symbol` key cannot be
+// produced externally, so the literal message string can't be copy-pasted to bypass the type.
+// `Msg` stays in the alias name so TS errors surface the human-readable explanation.
+declare const _envaptErrBrand: unique symbol;
+type Err<Msg extends string> = Msg & { readonly [_envaptErrBrand]: never };
+
+type RequiredAndFallbackMutex =
+    Err<'`required: true` and `fallback` are mutually exclusive. Use `Envapter.require()` for explicit fail-fast checks instead.'>;
+
 /**
- * Options for the \@Envapt decorator (modern API)
+ * Options for the \@Envapt decorator (modern API). `required: true` is mutually exclusive
+ * with `fallback`; see the per-converter overloads in `Envapt.ts` for the type-level mutex.
  * @public
  */
 interface EnvaptOptions<TFallback = string> {
-    /**
-     * Default value to use if environment variable is not found
-     */
     fallback?: TFallback;
-    /**
-     * Built-in converter, custom converter function, or boxed-primitives (String, Number, Boolean, Symbol, BigInt)
-     * @see {@link EnvaptConverter} for details
-     */
     converter?: EnvaptConverter<TFallback>;
+    required?: boolean;
 }
 
 type JsonPrimitive = string | number | boolean | null;
@@ -231,6 +235,8 @@ type ProfilesConfig = Partial<Record<Environment, EnvProfile>> & {
 };
 
 export type {
+    Err,
+    RequiredAndFallbackMutex,
     BuiltInConverter,
     PrimitiveConstructor,
     ConverterFunction,

--- a/packages/envapt/src/core/AdvancedMethods.ts
+++ b/packages/envapt/src/core/AdvancedMethods.ts
@@ -1,3 +1,4 @@
+import { EnvaptError, EnvaptErrorCodes } from '../Error';
 import { PrimitiveMethods } from './PrimitiveMethods';
 
 import type { ArrayOf } from '../Converters';
@@ -7,8 +8,29 @@ import type {
     ConditionalReturn,
     ConverterFunction,
     EnvKeyInput,
+    InferConverterReturnType,
     TimeFallback
 } from '../Types';
+
+interface GetUsingRequiredOptions<TConverter> {
+    converter: TConverter;
+    required: true;
+}
+
+interface GetWithRequiredOptions<TReturnType> {
+    converter: ConverterFunction<TReturnType>;
+    required: true;
+}
+
+function isOptionsBag(value: unknown): value is { converter: unknown; required?: boolean; fallback?: unknown } {
+    // `ArrayOf` tokens have `of`/`delimiter` but no `converter` key, so the presence of
+    // `converter` discriminates the options-bag form from a positional converter token.
+    return typeof value === 'object' && value !== null && 'converter' in value;
+}
+
+function formatKeyForError(key: EnvKeyInput): string {
+    return Array.isArray(key) ? `[${key.join(', ')}]` : String(key);
+}
 
 /**
  * Mixin for advanced methods for environment variable conversion using built-in and custom converters
@@ -22,8 +44,8 @@ export class AdvancedMethods extends PrimitiveMethods {
      * produced by `Converters.array(...)`. The key can be a single name or an ordered list;
      * the first defined value wins.
      */
-    // Time-specific overload — constrains the fallback to TimeFallback (number | time-string).
-    // Must precede the generic BuiltInConverter overload so it wins overload resolution.
+    // Time-specific overload must precede the generic BuiltInConverter overload so it wins
+    // overload resolution (TimeFallback accepts time-strings like `'10s'`).
     static getUsing<TFallback extends TimeFallback | undefined = undefined>(
         key: EnvKeyInput,
         converter: 'time',
@@ -35,17 +57,38 @@ export class AdvancedMethods extends PrimitiveMethods {
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback>;
     static getUsing<TReturn>(key: EnvKeyInput, converter: BuiltInConverter | ArrayOf, fallback?: TReturn): TReturn;
+    static getUsing(key: EnvKeyInput, options: GetUsingRequiredOptions<'time'>): number;
+    static getUsing<TConverter extends BuiltInConverter | ArrayOf>(
+        key: EnvKeyInput,
+        options: GetUsingRequiredOptions<TConverter>
+    ): InferConverterReturnType<TConverter>;
     static getUsing<TConverter extends BuiltInConverter | ArrayOf, TFallback = undefined>(
         key: EnvKeyInput,
-        converter: TConverter,
+        converterOrOptions: TConverter | GetUsingRequiredOptions<TConverter>,
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback> {
+        if (isOptionsBag(converterOrOptions)) {
+            const options = converterOrOptions;
+            const { key: resolvedKey, value } = this.resolveKeyInput(key);
+
+            if (value === undefined || value.trim() === '') {
+                throw new EnvaptError(
+                    EnvaptErrorCodes.MissingEnvValue,
+                    `Required environment variable "${formatKeyForError(key)}" is missing or empty.`
+                );
+            }
+
+            const result = this.parser.convertValue(resolvedKey, undefined, options.converter as TConverter, false);
+            return result as AdvancedConverterReturn<TConverter, TFallback>;
+        }
+
+        const converter = converterOrOptions as TConverter;
         const { key: resolvedKey, value } = this.resolveKeyInput(key);
 
         // No env value AND no fallback: return undefined to match primitive-method semantics.
         // Otherwise route through the parser so asymmetric fallback types (TimeFallback,
         // TimeFallback[] for `of: time` arrays) get coerced to the declared return type.
-        if (!value && fallback === undefined) {
+        if (this.treatAsMissing(value) && fallback === undefined) {
             return undefined as AdvancedConverterReturn<TConverter, TFallback>;
         }
 
@@ -69,12 +112,20 @@ export class AdvancedMethods extends PrimitiveMethods {
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback>;
     getUsing<TReturn>(key: EnvKeyInput, converter: BuiltInConverter | ArrayOf, fallback?: TReturn): TReturn;
+    getUsing(key: EnvKeyInput, options: GetUsingRequiredOptions<'time'>): number;
+    getUsing<TConverter extends BuiltInConverter | ArrayOf>(
+        key: EnvKeyInput,
+        options: GetUsingRequiredOptions<TConverter>
+    ): InferConverterReturnType<TConverter>;
     getUsing<TConverter extends BuiltInConverter | ArrayOf, TFallback = undefined>(
         key: EnvKeyInput,
-        converter: TConverter,
+        converterOrOptions: TConverter | GetUsingRequiredOptions<TConverter>,
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback> {
-        return AdvancedMethods.getUsing(key, converter, fallback);
+        return AdvancedMethods.getUsing(key, converterOrOptions as TConverter, fallback) as AdvancedConverterReturn<
+            TConverter,
+            TFallback
+        >;
     }
 
     /**
@@ -85,17 +136,43 @@ export class AdvancedMethods extends PrimitiveMethods {
         key: EnvKeyInput,
         converter: ConverterFunction<TReturnType>,
         fallback?: TFallback
+    ): ConditionalReturn<TReturnType, TFallback>;
+    static getWith<TReturnType>(key: EnvKeyInput, options: GetWithRequiredOptions<TReturnType>): TReturnType;
+    static getWith<TReturnType, TFallback extends TReturnType | undefined = undefined>(
+        key: EnvKeyInput,
+        converterOrOptions: ConverterFunction<TReturnType> | GetWithRequiredOptions<TReturnType>,
+        fallback?: TFallback
     ): ConditionalReturn<TReturnType, TFallback> {
+        if (isOptionsBag(converterOrOptions)) {
+            const options = converterOrOptions;
+            const { key: resolvedKey, value } = this.resolveKeyInput(key);
+
+            if (value === undefined || value.trim() === '') {
+                throw new EnvaptError(
+                    EnvaptErrorCodes.MissingEnvValue,
+                    `Required environment variable "${formatKeyForError(key)}" is missing or empty.`
+                );
+            }
+
+            const result = this.parser.convertValue(
+                resolvedKey,
+                undefined,
+                options.converter as ConverterFunction<undefined>,
+                false
+            );
+            return result as ConditionalReturn<TReturnType, TFallback>;
+        }
+
         // Check if variable exists first, for consistency with primitive methods
         const { key: resolvedKey, value } = this.resolveKeyInput(key);
-        if (!value) return fallback as ConditionalReturn<TReturnType, TFallback>;
+        if (this.treatAsMissing(value)) return fallback as ConditionalReturn<TReturnType, TFallback>;
 
         const hasFallback = fallback !== undefined;
         // Convert the converter to match the expected signature via unknown
         const result = this.parser.convertValue(
             resolvedKey,
             fallback,
-            converter as unknown as ConverterFunction<TFallback>,
+            converterOrOptions as unknown as ConverterFunction<TFallback>,
             hasFallback
         );
 
@@ -109,7 +186,13 @@ export class AdvancedMethods extends PrimitiveMethods {
         key: EnvKeyInput,
         converter: ConverterFunction<TReturnType>,
         fallback?: TFallback
+    ): ConditionalReturn<TReturnType, TFallback>;
+    getWith<TReturnType>(key: EnvKeyInput, options: GetWithRequiredOptions<TReturnType>): TReturnType;
+    getWith<TReturnType, TFallback extends TReturnType | undefined = undefined>(
+        key: EnvKeyInput,
+        converterOrOptions: ConverterFunction<TReturnType> | GetWithRequiredOptions<TReturnType>,
+        fallback?: TFallback
     ): ConditionalReturn<TReturnType, TFallback> {
-        return AdvancedMethods.getWith(key, converter, fallback);
+        return AdvancedMethods.getWith(key, converterOrOptions as ConverterFunction<TReturnType>, fallback);
     }
 }

--- a/packages/envapt/src/core/EnvapterBase.ts
+++ b/packages/envapt/src/core/EnvapterBase.ts
@@ -22,6 +22,31 @@ export abstract class EnvapterBase {
     protected static _envPaths: string[] = ['.env']; // default path
     protected static _envPathsExplicitlySet = false;
     protected static _userDefinedDotenvConfig: DotenvConfigOptions = {};
+    protected static _strict = false;
+
+    /**
+     * Enable or disable strict mode. Default `false`. Setting refreshes the cache so
+     * previously-cached converted values get re-evaluated under the new rule.
+     */
+    static set strict(value: boolean) {
+        // `this._strict = value` would create an own property on the subclass that invoked the
+        // setter; readers walking up from `PrimitiveMethods` would still see the base default.
+        // Pin the write to the base class so the flag is canonical across the chain.
+        EnvapterBase._strict = value;
+        // `this.refreshCache()` so subclass overrides of `resolveEffectivePaths` (the
+        // dotenv-flow cascade on `EnvironmentMethods`) are honored on the rebuild.
+        this.refreshCache();
+    }
+
+    static get strict(): boolean {
+        return EnvapterBase._strict;
+    }
+
+    protected static treatAsMissing(value: string | undefined): boolean {
+        if (value === undefined || value === '') return true;
+        if (EnvapterBase._strict && value.trim() === '') return true;
+        return false;
+    }
 
     /**
      * Set custom .env file paths. Accepts either a single path or array of paths.
@@ -116,9 +141,9 @@ export abstract class EnvapterBase {
 
             try {
                 loadDotenv({
+                    ...this._userDefinedDotenvConfig,
                     path: effectivePaths,
-                    processEnv: isolatedEnv,
-                    ...this._userDefinedDotenvConfig
+                    processEnv: isolatedEnv
                 });
             } catch {}
             // populate the Map with global environment variables

--- a/packages/envapt/src/core/PrimitiveMethods.ts
+++ b/packages/envapt/src/core/PrimitiveMethods.ts
@@ -1,5 +1,6 @@
 import { BuiltInConverters } from '../BuiltInConverters';
 import { Parser, type EnvapterService } from '../Parser';
+import { EnvapterBase } from './EnvapterBase';
 import { EnvironmentMethods } from './EnvironmentMethods';
 
 import type { ConditionalReturn, EnvKeyInput } from '../Types';
@@ -22,14 +23,21 @@ enum Primitive {
 export class PrimitiveMethods extends EnvironmentMethods implements EnvapterService {
     protected static readonly parser: Parser = new Parser(new PrimitiveMethods());
 
+    // Read `EnvapterBase.strict` directly: `PrimitiveMethods._strict` would resolve to the
+    // BaseClass default because a `Envapter.strict = true` write lands as an own-property
+    // on `Envapter`, which is a descendant of `PrimitiveMethods`, not an ancestor.
+    isStrict(): boolean {
+        return EnvapterBase.strict;
+    }
+
     private static _get<EnvVarReturnType, DefaultType extends EnvVarReturnType | undefined = undefined>(
         key: EnvKeyInput,
         type: Primitive,
         def?: DefaultType
     ): ConditionalReturn<EnvVarReturnType, DefaultType> {
         const { key: resolvedKey, value } = this.resolveKeyInput(key);
+        if (this.treatAsMissing(value)) return def as ConditionalReturn<EnvVarReturnType, DefaultType>;
         const rawVal = value as string | number | boolean | undefined;
-        if (!rawVal) return def as ConditionalReturn<EnvVarReturnType, DefaultType>;
 
         const parsed = this.parser.resolveTemplate(resolvedKey, String(rawVal));
 

--- a/packages/envapt/tests/.env.strict-mode
+++ b/packages/envapt/tests/.env.strict-mode
@@ -1,0 +1,21 @@
+# Fixture for 020-strict-mode.test.ts
+
+# Set values for happy-path checks.
+SET_VALUE=hello
+SET_NUMBER=42
+DATABASE_URL=postgres://localhost/db
+API_KEY=secret-key
+
+# Empty value (KEY=).
+EMPTY_VALUE=
+
+# Whitespace-only value (must be quoted to survive trimming).
+WHITESPACE_ONLY="   "
+
+# Template references (unresolved when ABSENT is missing).
+TEMPLATED_OK=value-${SET_VALUE}
+TEMPLATED_MISSING=value-${ABSENT}
+
+# Array converter inputs.
+PORTS_CLEAN=80,443,8080
+PORTS_WITH_EMPTY=80,,443

--- a/packages/envapt/tests/005-runtime-validation.test.ts
+++ b/packages/envapt/tests/005-runtime-validation.test.ts
@@ -98,9 +98,9 @@ describe('Runtime Validation', () => {
 
     describe('Converter fallback validation', () => {
         class FallbackTests {
-            // @ts-expect-error Inconsistent fallback type
             @Envapt('NONEXISTENT_ARRAY_VAR', {
                 converter: Converters.array(),
+                // @ts-expect-error fallback must be string[] (matches `of: Converters.String`), not a bare string
                 fallback: 'not-an-array'
             })
             static readonly invalidArrayFallback: string[];
@@ -128,9 +128,9 @@ describe('Runtime Validation', () => {
             @Envapt('CUSTOM_CONVERTER_VAR', { converter: 'lol' })
             static readonly customConverter: string;
 
-            // @ts-expect-error Inconsistent fallback type
             @Envapt('CUSTOM_CONVERTER_INCONSISTENT_FALLBACK_TYPE', {
                 fallback: 42,
+                // @ts-expect-error custom-converter function doesn't fit a BuiltInConverter slot once TFallback narrows to number
                 converter: (_raw, fallback) => String(fallback)
             })
             static readonly customConverterInconsistentFallbackType: string;
@@ -265,23 +265,23 @@ describe('Runtime Validation', () => {
 
     describe('Array converter fallback element type validation', () => {
         class ArrayConverterValidationTests {
-            // @ts-expect-error Inconsistent fallback element types
             @Envapt('NONEXISTENT_ARRAY_VAR', {
                 converter: Converters.array({ of: Converters.String }),
+                // @ts-expect-error mixed-type fallback array; `42` doesn't fit `of: Converters.String`
                 fallback: ['string', 42, 'another-string']
             })
             static readonly arrayWithMixedTypeElements: string[];
 
-            // @ts-expect-error Fallback elements don't match the declared `of` token
             @Envapt('NONEXISTENT_ARRAY_VAR', {
                 converter: Converters.array({ of: Converters.Number }),
+                // @ts-expect-error fallback element types don't match the declared `of` token
                 fallback: ['not-a-number', 'also-not-a-number']
             })
             static readonly arrayWithWrongElementType: number[];
 
-            // @ts-expect-error Default Converters.array() returns string[]; mixed-type fallback rejected
             @Envapt('NONEXISTENT_ARRAY_VAR', {
                 converter: Converters.array(),
+                // @ts-expect-error default `Converters.array()` returns string[]; `42` and `true` are not strings
                 fallback: ['string', 42, true]
             })
             static readonly defaultArrayWithMixedTypes: string[];

--- a/packages/envapt/tests/013-defensive-tests.test.ts
+++ b/packages/envapt/tests/013-defensive-tests.test.ts
@@ -12,7 +12,10 @@ import type { EnvapterService } from '../src/Parser';
 import type { BuiltInConverter, EnvKeyInput, PrimitiveConstructor } from '../src/Types';
 
 class StubEnvService implements EnvapterService {
-    constructor(private readonly values: Record<string, string | undefined>) {}
+    constructor(
+        private readonly values: Record<string, string | undefined>,
+        private readonly strict = false
+    ) {}
 
     getRaw(key: string): string | undefined {
         return this.values[key];
@@ -20,6 +23,10 @@ class StubEnvService implements EnvapterService {
 
     get(key: string): string | undefined {
         return this.values[key];
+    }
+
+    isStrict(): boolean {
+        return this.strict;
     }
 }
 

--- a/packages/envapt/tests/020-strict-mode.test.ts
+++ b/packages/envapt/tests/020-strict-mode.test.ts
@@ -1,0 +1,406 @@
+import { resolve } from 'node:path';
+
+import { expect } from 'chai';
+import { expectTypeOf } from 'expect-type';
+import { afterEach, beforeAll, describe, it } from 'vitest';
+
+import { Converters, Envapt, Envapter, EnvaptErrorCodes } from '../src';
+import { EnvaptError } from '../src/Error';
+
+describe('Strict mode + required (v5)', () => {
+    beforeAll(() => {
+        Envapter.envPaths = resolve(import.meta.dirname, '.env.strict-mode');
+    });
+
+    afterEach(() => {
+        // Always reset strict to false so test isolation holds: leaking strict=true into the
+        // next file would change get* semantics globally.
+        Envapter.strict = false;
+    });
+
+    describe('Envapter.strict toggle', () => {
+        it('defaults to false', () => {
+            expect(Envapter.strict).to.equal(false);
+        });
+
+        it('round-trips set/get', () => {
+            Envapter.strict = true;
+            expect(Envapter.strict).to.equal(true);
+            Envapter.strict = false;
+            expect(Envapter.strict).to.equal(false);
+        });
+
+        it('toggling refreshes cache so subsequent reads see new rules', () => {
+            Envapter.strict = false;
+            expect(Envapter.get('WHITESPACE_ONLY')).to.equal('   ');
+
+            Envapter.strict = true;
+            expect(Envapter.get('WHITESPACE_ONLY')).to.equal(undefined);
+        });
+    });
+
+    describe('Strict mode + empty values on read', () => {
+        it('treats whitespace-only as missing (no fallback)', () => {
+            Envapter.strict = true;
+            expect(Envapter.get('WHITESPACE_ONLY')).to.equal(undefined);
+        });
+
+        it('uses the fallback when the value is whitespace-only', () => {
+            Envapter.strict = true;
+            expect(Envapter.get('WHITESPACE_ONLY', 'default')).to.equal('default');
+        });
+
+        it('off-mode keeps whitespace-only intact (no behavior change)', () => {
+            Envapter.strict = false;
+            expect(Envapter.get('WHITESPACE_ONLY')).to.equal('   ');
+        });
+    });
+
+    describe('Strict mode + array empty items', () => {
+        it('throws EmptyArrayElement on empty/whitespace items', () => {
+            Envapter.strict = true;
+            expect(() => Envapter.getUsing('PORTS_WITH_EMPTY', Converters.array({ of: Converters.Number })))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.EmptyArrayElement);
+        });
+
+        it('does NOT throw under strict OFF (existing permissive behavior preserved)', () => {
+            Envapter.strict = false;
+            const ports = Envapter.getUsing('PORTS_WITH_EMPTY', Converters.array({ of: Converters.Number }));
+            expect(ports).to.deep.equal([80, 443]);
+        });
+
+        it('processes clean arrays normally under strict ON', () => {
+            Envapter.strict = true;
+            const ports = Envapter.getUsing('PORTS_CLEAN', Converters.array({ of: Converters.Number }));
+            expect(ports).to.deep.equal([80, 443, 8080]);
+        });
+    });
+
+    describe('Strict mode + unresolved templates', () => {
+        it('throws MissingEnvValue when a ${VAR} cannot be resolved', () => {
+            Envapter.strict = true;
+            expect(() => Envapter.get('TEMPLATED_MISSING'))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('preserves the literal ${VAR} under strict OFF (existing behavior)', () => {
+            Envapter.strict = false;
+            expect(Envapter.get('TEMPLATED_MISSING')).to.equal('value-${ABSENT}');
+        });
+
+        it('resolves templates normally when the referenced var IS set', () => {
+            Envapter.strict = true;
+            expect(Envapter.get('TEMPLATED_OK')).to.equal('value-hello');
+        });
+
+        it('strict applies to resolve() tagged template too', () => {
+            Envapter.strict = true;
+            expect(() => Envapter.resolve`hello ${'ABSENT'}`)
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+    });
+
+    describe('Decorator @Envapt({ required: true })', () => {
+        class RequiredOk {
+            @Envapt('API_KEY', { required: true })
+            declare static readonly key: string;
+        }
+
+        class RequiredMissing {
+            @Envapt('NEVER_SET_KEY', { required: true })
+            declare static readonly key: string;
+        }
+
+        class RequiredEmpty {
+            @Envapt('EMPTY_VALUE', { required: true })
+            declare static readonly key: string;
+        }
+
+        class RequiredWhitespace {
+            @Envapt('WHITESPACE_ONLY', { required: true })
+            declare static readonly key: string;
+        }
+
+        class RequiredWithConverter {
+            @Envapt('DATABASE_URL', { converter: Converters.Url, required: true })
+            declare static readonly url: URL;
+        }
+
+        // Exercises the `Array.isArray(key)` arm of `formatKeyForError`; both keys must be
+        // absent so the throw path runs.
+        class RequiredArrayKeyAllMissing {
+            @Envapt(['NEVER_SET_KEY', 'ALSO_NEVER_SET'], { required: true })
+            declare static readonly key: string;
+        }
+
+        it('returns the value when the env variable is set', () => {
+            expect(RequiredOk.key).to.equal('secret-key');
+        });
+
+        it('throws MissingEnvValue when the key is absent', () => {
+            expect(() => RequiredMissing.key)
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('throws MissingEnvValue on empty value (KEY=)', () => {
+            expect(() => RequiredEmpty.key)
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('throws MissingEnvValue on whitespace-only value (independent of global strict)', () => {
+            Envapter.strict = false;
+            expect(() => RequiredWhitespace.key)
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('returns the typed value when required is paired with a converter', () => {
+            expect(RequiredWithConverter.url).to.be.instanceOf(URL);
+            expect(RequiredWithConverter.url.toString()).to.equal('postgres://localhost/db');
+        });
+
+        it('formats the error message with `[K1, K2]` when given an array of keys (all missing)', () => {
+            try {
+                void RequiredArrayKeyAllMissing.key;
+                expect.fail('should have thrown');
+            } catch (err) {
+                expect(err).to.be.instanceOf(EnvaptError);
+                const e = err as EnvaptError;
+                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
+                expect(e.message).to.include('[NEVER_SET_KEY, ALSO_NEVER_SET]');
+            }
+        });
+
+        it('rejects required + fallback at runtime with InvalidUserDefinedConfig', () => {
+            const buildBadDecorator = (): void => {
+                class Bad {
+                    // The compile-time Err<msg> guards against this at the type level; the runtime
+                    // check is defense-in-depth for dynamic objects that bypass the types.
+                    @Envapt('NEVER_SET_KEY', {
+                        required: true,
+                        // intentionally bad combo, runtime should reject -- justified
+                        fallback: 'should-not-be-here'
+                    } as unknown as { required: true })
+                    declare static readonly key: string;
+                }
+                void Bad;
+            };
+            expect(buildBadDecorator)
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.InvalidUserDefinedConfig);
+        });
+    });
+
+    describe('Functional API options-bag with required: true', () => {
+        it('getUsing throws MissingEnvValue on missing/empty', () => {
+            expect(() => Envapter.getUsing('NEVER_SET_KEY', { converter: Converters.Number, required: true }))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+
+            expect(() => Envapter.getUsing('EMPTY_VALUE', { converter: Converters.Number, required: true }))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('getUsing returns the typed value when present', () => {
+            const n = Envapter.getUsing('SET_NUMBER', { converter: Converters.Number, required: true });
+            expect(n).to.equal(42);
+        });
+
+        it('getWith throws MissingEnvValue on missing/empty', () => {
+            expect(() =>
+                Envapter.getWith('NEVER_SET_KEY', { converter: (raw) => (raw ?? '').toUpperCase(), required: true })
+            )
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('getWith returns the value from the custom converter when present', () => {
+            const v = Envapter.getWith('SET_VALUE', { converter: (raw) => (raw ?? '').toUpperCase(), required: true });
+            expect(v).to.equal('HELLO');
+        });
+
+        it('getUsing formats the array-key error message via formatKeyForError', () => {
+            try {
+                Envapter.getUsing(['NEVER_SET_KEY', 'ALSO_NEVER_SET'], {
+                    converter: Converters.Number,
+                    required: true
+                });
+                expect.fail('should have thrown');
+            } catch (err) {
+                expect(err).to.be.instanceOf(EnvaptError);
+                const e = err as EnvaptError;
+                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
+                expect(e.message).to.include('[NEVER_SET_KEY, ALSO_NEVER_SET]');
+            }
+        });
+
+        it('getWith formats the array-key error message via formatKeyForError', () => {
+            try {
+                Envapter.getWith(['NEVER_SET_KEY', 'ALSO_NEVER_SET'], {
+                    converter: (raw) => (raw ?? '').toUpperCase(),
+                    required: true
+                });
+                expect.fail('should have thrown');
+            } catch (err) {
+                expect(err).to.be.instanceOf(EnvaptError);
+                const e = err as EnvaptError;
+                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
+                expect(e.message).to.include('[NEVER_SET_KEY, ALSO_NEVER_SET]');
+            }
+        });
+    });
+
+    describe('Envapter.require()', () => {
+        it('does not throw when a single key is set', () => {
+            expect(() => Envapter.require('API_KEY')).to.not.throw();
+        });
+
+        it('templates that resolve to a non-empty value pass the check', () => {
+            expect(() => Envapter.require('TEMPLATED_OK')).to.not.throw();
+        });
+
+        it('throws MissingEnvValue when a single key is absent', () => {
+            expect(() => Envapter.require('NEVER_SET_KEY'))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('throws MissingEnvValue on empty value', () => {
+            expect(() => Envapter.require('EMPTY_VALUE'))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('throws MissingEnvValue on whitespace-only value (independent of global strict)', () => {
+            Envapter.strict = false;
+            expect(() => Envapter.require('WHITESPACE_ONLY'))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('returns void when every key is present', () => {
+            expect(() => Envapter.require('API_KEY', 'SET_VALUE', 'DATABASE_URL')).to.not.throw();
+        });
+
+        it('throws and lists every missing key in one error', () => {
+            try {
+                Envapter.require('API_KEY', 'NEVER_SET_KEY', 'EMPTY_VALUE', 'SET_VALUE');
+                expect.fail('should have thrown');
+            } catch (err) {
+                expect(err).to.be.instanceOf(EnvaptError);
+                const e = err as EnvaptError;
+                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
+                expect(e.message).to.include('NEVER_SET_KEY');
+                expect(e.message).to.include('EMPTY_VALUE');
+                expect(e.message).to.not.include('API_KEY');
+                expect(e.message).to.not.include('SET_VALUE');
+            }
+        });
+
+        it('instance counterpart delegates to static', () => {
+            const env = new Envapter();
+            expect(() => env.require('API_KEY')).to.not.throw();
+            expect(() => env.require('NEVER_SET_KEY'))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+    });
+
+    describe('compile-time type checks (expect-type)', () => {
+        it('getUsing options-bag with required: true narrows away undefined for built-in converters', () => {
+            const port = Envapter.getUsing('SET_NUMBER', { converter: Converters.Number, required: true });
+            expectTypeOf(port).toEqualTypeOf<number>();
+
+            const url = Envapter.getUsing('DATABASE_URL', { converter: Converters.Url, required: true });
+            expectTypeOf(url).toEqualTypeOf<URL>();
+        });
+
+        it('getUsing options-bag with required: true narrows array converters too', () => {
+            const ports = Envapter.getUsing('PORTS_CLEAN', {
+                converter: Converters.array({ of: Converters.Number }),
+                required: true
+            });
+            expectTypeOf(ports).toEqualTypeOf<number[]>();
+        });
+
+        it('getWith options-bag with required: true returns the converter function return type', () => {
+            const upper = Envapter.getWith('SET_VALUE', {
+                converter: (raw) => (raw ?? '').toUpperCase(),
+                required: true
+            });
+            expectTypeOf(upper).toEqualTypeOf<string>();
+        });
+
+        it('Envapter.require returns void for any number of keys', () => {
+            const single = Envapter.require('API_KEY');
+            const bulk = Envapter.require('API_KEY', 'DATABASE_URL');
+            /* eslint-disable @typescript-eslint/no-invalid-void-type -- expect-type's toEqualTypeOf<void>() is the documented assertion form for a void return. */
+            expectTypeOf(single).toEqualTypeOf<void>();
+            expectTypeOf(bulk).toEqualTypeOf<void>();
+            /* eslint-enable @typescript-eslint/no-invalid-void-type */
+        });
+
+        it('positional getUsing still narrows by fallback presence (unchanged)', () => {
+            const noFallback = Envapter.getUsing('SET_NUMBER', Converters.Number);
+            expectTypeOf(noFallback).toEqualTypeOf<number | undefined>();
+
+            const withFallback = Envapter.getUsing('SET_NUMBER', Converters.Number, 3000);
+            expectTypeOf(withFallback).toEqualTypeOf<number>();
+        });
+
+        it('decorator: required + fallback combo is a TS error AND a runtime error', () => {
+            expect(() => {
+                class Bad {
+                    // @ts-expect-error `required: true` and `fallback` are mutually exclusive
+                    @Envapt('PORT', { converter: Converters.Number, required: true, fallback: 3000 })
+                    declare static readonly port: number;
+                }
+                void Bad;
+            })
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.InvalidUserDefinedConfig);
+        });
+
+        it('functional getUsing: required + fallback combo is a TS error (excess property)', () => {
+            // No runtime mutex check on the functional path, so only the compile-time
+            // directive is asserted here.
+            // @ts-expect-error fallback not allowed when required: true
+            Envapter.getUsing('SET_NUMBER', { converter: Converters.Number, required: true, fallback: 3000 });
+        });
+
+        it('dotenvConfig forbidden keys are compile-time errors AND runtime errors', () => {
+            // @ts-expect-error `path` is managed by Envapter.envPaths
+            expect(() => (Envapter.dotenvConfig = { path: 'whatever' }))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.InvalidUserDefinedConfig);
+
+            // @ts-expect-error `processEnv` is managed internally by Envapter
+            expect(() => (Envapter.dotenvConfig = { processEnv: {} }))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.InvalidUserDefinedConfig);
+
+            // Reset to clean state so following tests aren't affected.
+            Envapter.dotenvConfig = {};
+        });
+    });
+
+    describe('Strict mode does NOT make missing keys throw on get*', () => {
+        // Locked behavior: strict tightens "empty value" semantics; it doesn't auto-require
+        // every absent key. That stays an explicit opt-in via `required:` or `Envapter.require()`.
+        it('returns undefined for missing keys under strict (no fallback)', () => {
+            Envapter.strict = true;
+            expect(Envapter.get('NEVER_SET_KEY')).to.equal(undefined);
+        });
+
+        it('returns the fallback for missing keys under strict', () => {
+            Envapter.strict = true;
+            expect(Envapter.get('NEVER_SET_KEY', 'default')).to.equal('default');
+        });
+    });
+});

--- a/packages/envapt/tests/021-type-error-messages.test.ts
+++ b/packages/envapt/tests/021-type-error-messages.test.ts
@@ -1,0 +1,131 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { expect } from 'chai';
+import * as ts from 'typescript';
+import { describe, it } from 'vitest';
+
+/**
+ * Compile-time TS error verification via the TypeScript compiler API. Neither `expect-type`
+ * nor `tsd` checks the TEXT of a diagnostic message, only that an error is produced. The
+ * branded `Err<...>` pattern relies on a specific literal appearing in TS's "no overload
+ * matches" chain, so we run `tsc` directly against fixtures and assert message fragments.
+ *
+ * Fixtures live in `tests/type-error-fixtures/` and are excluded from both the package's
+ * tsconfig and eslint. A dedicated tsconfig inside that directory exists so the IDE shows
+ * the same diagnostic this test sees (a default tsconfig would emit TS1206 for the
+ * decorators and mask the actual error).
+ */
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(TEST_DIR, 'type-error-fixtures');
+const PROJECT_ROOT = resolve(TEST_DIR, '..');
+const FIXTURE_TIMEOUT_MS = 10_000;
+
+interface ParsedDiagnostic {
+    code: number;
+    line: number;
+    message: string;
+}
+
+function compileFixture(fixtureRelativePath: string): ParsedDiagnostic[] {
+    const fixturePath = resolve(FIXTURE_DIR, fixtureRelativePath);
+
+    const configFileName = resolve(PROJECT_ROOT, 'tsconfig.json');
+    const configFile = ts.readConfigFile(configFileName, (path) => readFileSync(path, 'utf8'));
+    const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, PROJECT_ROOT);
+
+    const program = ts.createProgram({
+        rootNames: [fixturePath],
+        options: { ...parsed.options, noEmit: true }
+    });
+
+    return ts
+        .getPreEmitDiagnostics(program)
+        .filter((d) => d.file?.fileName === fixturePath)
+        .map((d) => {
+            const pos =
+                d.file && d.start !== undefined
+                    ? d.file.getLineAndCharacterOfPosition(d.start)
+                    : { line: -1, character: -1 };
+            return {
+                code: d.code,
+                line: pos.line + 1,
+                message: ts.flattenDiagnosticMessageText(d.messageText, '\n')
+            };
+        });
+}
+
+function joinedMessages(diagnostics: readonly ParsedDiagnostic[]): string {
+    return diagnostics.map((d) => `TS${d.code}: ${d.message}`).join('\n');
+}
+
+describe('TS error message verification (compiler API)', () => {
+    it(
+        'baseline: valid fixture compiles cleanly (proves experimentalDecorators is picked up)',
+        { timeout: FIXTURE_TIMEOUT_MS },
+        () => {
+            const diagnostics = compileFixture('clean-baseline.ts');
+            if (diagnostics.length > 0) {
+                // Surface the actual diagnostics so a harness misconfiguration is visible.
+                throw new Error(
+                    `clean-baseline.ts should compile cleanly but produced:\n${joinedMessages(diagnostics)}`
+                );
+            }
+        }
+    );
+
+    describe('dotenvConfig forbidden fields surface the branded explanation', () => {
+        it(
+            '`path` rejection is TS2322 with the explanation literal in the message',
+            { timeout: FIXTURE_TIMEOUT_MS },
+            () => {
+                const diagnostics = compileFixture('dotenv-path-forbidden.ts');
+                expect(diagnostics).to.have.lengthOf(1);
+
+                const [diagnostic] = diagnostics;
+                if (!diagnostic) throw new Error('expected exactly one diagnostic');
+                expect(diagnostic.code, 'expected TS2322 (type-not-assignable)').to.equal(2322);
+                expect(diagnostic.message).to.include('`path` is managed by Envapter');
+                expect(diagnostic.message).to.include('Envapter.envPaths');
+            }
+        );
+
+        it(
+            '`processEnv` rejection is TS2322 with the explanation literal in the message',
+            { timeout: FIXTURE_TIMEOUT_MS },
+            () => {
+                const diagnostics = compileFixture('dotenv-process-env-forbidden.ts');
+                expect(diagnostics).to.have.lengthOf(1);
+
+                const [diagnostic] = diagnostics;
+                if (!diagnostic) throw new Error('expected exactly one diagnostic');
+                expect(diagnostic.code, 'expected TS2322 (type-not-assignable)').to.equal(2322);
+                expect(diagnostic.message).to.include('`processEnv` is managed internally by Envapter');
+            }
+        );
+    });
+
+    describe('decorator `required: true` + `fallback` mutex produces the branded compile error', () => {
+        // Asserting the specific code (TS2769) means a misconfigured compiler that emits
+        // a different code (e.g. TS1206 from missing experimentalDecorators) fails the test
+        // instead of silently passing on "any error was produced."
+        it(
+            'produces exactly one TS2769 diagnostic carrying the branded mutex literal',
+            { timeout: FIXTURE_TIMEOUT_MS },
+            () => {
+                const diagnostics = compileFixture('required-fallback-mutex.ts');
+                expect(diagnostics).to.have.lengthOf(1);
+
+                const [diagnostic] = diagnostics;
+                if (!diagnostic) throw new Error('expected exactly one diagnostic');
+                expect(diagnostic.code, 'expected TS2769 (no-overload-matches)').to.equal(2769);
+                expect(diagnostic.message).to.include('No overload matches this call');
+                expect(diagnostic.message).to.include('RequiredAndFallbackMutex');
+                expect(diagnostic.message).to.include('`required: true` and `fallback` are mutually exclusive');
+                expect(diagnostic.message).to.include('Envapter.require()');
+            }
+        );
+    });
+});

--- a/packages/envapt/tests/type-error-fixtures/clean-baseline.ts
+++ b/packages/envapt/tests/type-error-fixtures/clean-baseline.ts
@@ -1,0 +1,9 @@
+import { Converters, Envapt } from '../../src';
+
+export class CleanBaseline {
+    @Envapt('PORT', { converter: Converters.Number, fallback: 3000 })
+    declare static readonly port: number;
+
+    @Envapt('API_KEY', { required: true })
+    declare static readonly apiKey: string;
+}

--- a/packages/envapt/tests/type-error-fixtures/dotenv-path-forbidden.ts
+++ b/packages/envapt/tests/type-error-fixtures/dotenv-path-forbidden.ts
@@ -1,0 +1,3 @@
+import { Envapter } from '../../src';
+
+Envapter.dotenvConfig = { path: 'whatever' };

--- a/packages/envapt/tests/type-error-fixtures/dotenv-process-env-forbidden.ts
+++ b/packages/envapt/tests/type-error-fixtures/dotenv-process-env-forbidden.ts
@@ -1,0 +1,3 @@
+import { Envapter } from '../../src';
+
+Envapter.dotenvConfig = { processEnv: { FOO: 'bar' } };

--- a/packages/envapt/tests/type-error-fixtures/required-fallback-mutex.ts
+++ b/packages/envapt/tests/type-error-fixtures/required-fallback-mutex.ts
@@ -1,0 +1,6 @@
+import { Converters, Envapt } from '../../src';
+
+export class IntentionallyBroken {
+    @Envapt('PORT', { converter: Converters.Number, required: true, fallback: 3000 })
+    declare static readonly port: number;
+}

--- a/packages/envapt/tests/type-error-fixtures/tsconfig.json
+++ b/packages/envapt/tests/type-error-fixtures/tsconfig.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json.schemastore.org/tsconfig.json",
+    "compilerOptions": {
+        "target": "ES2024",
+        "module": "esnext",
+        "moduleResolution": "bundler",
+        "lib": ["ESNext", "esnext.disposable", "Decorators", "Decorators.Legacy"],
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
+        "esModuleInterop": true,
+        "skipLibCheck": true,
+        "strict": true,
+        "noImplicitAny": true,
+        "noEmit": true,
+        "isolatedModules": true,
+        "resolveJsonModule": true,
+        "allowImportingTsExtensions": false,
+        "types": ["node"]
+    },
+    "include": ["*.ts"]
+}

--- a/packages/envapt/tsconfig.json
+++ b/packages/envapt/tsconfig.json
@@ -6,5 +6,5 @@
         "rootDir": "."
     },
     "include": ["src/**/*", "tests/**/*", "tsdown.config.ts"],
-    "exclude": ["node_modules", "dist"]
+    "exclude": ["node_modules", "dist", "tests/type-error-fixtures/**"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,36 +619,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.2':
     resolution: {integrity: sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.2':
     resolution: {integrity: sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.2':
     resolution: {integrity: sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.2':
     resolution: {integrity: sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.2':
     resolution: {integrity: sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.2':
     resolution: {integrity: sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==}
@@ -918,41 +924,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2044,24 +2058,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
# Strict mode + `required: true` + `Envapter.require()`

Three new v5 features for fail-fast environment handling, plus a small type-level layer for compile-time error messages that future v5 work will reuse.

Closes #81 

## What's new

### `Envapter.strict = true`

Global flag, default `false`. When on:

- Whitespace-only values (`KEY="   "`) are treated as missing on read.
- Empty/whitespace items inside an array converter throw `EmptyArrayElement` (207) instead of being silently filtered.
- Unresolved `${VAR}` placeholders in cached values and in `Envapter.resolve` throw `MissingEnvValue` (305) instead of being preserved as literal text.

Setting the flag refreshes the cache so previously-cached converted values get re-evaluated under the new rule.

```ts
Envapter.strict = true;

Envapter.get('WHITESPACE_ONLY'); // undefined
Envapter.getUsing('PORTS', Converters.array({ of: 'number' }));
// PORTS=80,,443  ->  throws EmptyArrayElement
Envapter.resolve`hi ${'ABSENT'}`; // throws MissingEnvValue
```

### `required: true` on the decorator and functional API

Per-field opt-in. Throws `MissingEnvValue` lazily on first access if the env value is missing or empty (post-trim). Independent of `Envapter.strict`. Mutually exclusive with `fallback` at both compile time (branded `Err<...>` literal in the union) and runtime (Validator throws `InvalidUserDefinedConfig`).

Decorator:

```ts
class Config extends Envapter {
    @Envapt('DATABASE_URL', { converter: Converters.Url, required: true })
    declare static readonly databaseUrl: URL;

    @Envapt('API_KEY', { required: true })
    declare static readonly apiKey: string;
}
```

Functional (new options-bag overload on `getUsing` / `getWith`):

```ts
const port = Envapter.getUsing('PORT', { converter: Converters.Number, required: true });
//    ^? number  (not number | undefined)

const url = Envapter.getWith('JWT', {
    converter: (raw) => Buffer.from(raw ?? '', 'base64'),
    required: true
});
//    ^? Buffer
```

### `Envapter.require(...keys)`

Pure existence check that resolves templates before checking. Variadic rest signature; always returns `void`. Throws `MissingEnvValue` listing every missing key in one error.

```ts
Envapter.require('DATABASE_URL');
Envapter.require('DATABASE_URL', 'API_KEY', 'SENTRY_DSN');
// ^ throws ONE error listing every missing key, not one-at-a-time

Envapter.require();
// ^ compile-time error: at least one key required.
```

No converter or fallback at this layer. For typed fail-fast in functional code, use the options-bag form of `getUsing`.

### `Envapter.dotenvConfig.path` / `processEnv` compile-time errors

Both fields are managed by Envapter. Previously they were rejected only at runtime; now the branded `Err<...>` literal on the field type makes the TS error carry the explanation directly:

```ts
Envapter.dotenvConfig = { path: '/foo' };
// TS error:
//   Type '"/foo"' is not assignable to type 'PathManagedByEnvapter'.
//     Type '"/foo"' is not assignable to type
//     '"`path` is managed by Envapter. Use `Envapter.envPaths` to configure which .env files load."'.
```

## Implementation notes

- `Envapter.strict` is anchored on `EnvapterBase` (not on `this`) so subclass-side writes propagate to readers walking up from `PrimitiveMethods`. JS static inheritance is one-directional; writing `Envapter._strict = true` creates an own-property on `Envapter` that descendants don't see.
- The decorator `required` check fires lazily at first property access, not at module load. Matches the existing `@Envapt` getter pattern.
- The compile-time mutex relies on a brand symbol (`unique symbol` key) on top of the literal-message type so users can't satisfy the field by copy-pasting the message string.
- Usage 3 (built-in/array converter) is declared twice in the overload chain: once in its natural position for valid-call matching, and once at the end so TS's "no overload matches" diagnostic surfaces the `RequiredAndFallbackMutex` brand instead of falling through to the classic positional API. Documented inline at the second declaration.

## Tests

- `tests/020-strict-mode.test.ts`: covers strict semantics, decorator/functional `required:`, the new `require()` rest signature, and the runtime mutex defense. Includes `expect-type` assertions on the new return-type narrowing.
- `tests/021-type-error-messages.test.ts`: uses the TS compiler API to verify the EXACT diagnostic codes and message fragments produced by the fixtures in `tests/type-error-fixtures/`. Includes a clean-baseline fixture so harness regressions (e.g., a future config change that drops `experimentalDecorators`) fail loudly instead of silently passing.
- A dedicated `tsconfig.json` inside `tests/type-error-fixtures/` gives the IDE the same options the runtime test uses, so hover diagnostics match what `pnpm test` sees.

## New error codes

| Code | Name                | Triggered by                                                                  |
| ---- | ------------------- | ----------------------------------------------------------------------------- |
| 207  | `EmptyArrayElement` | strict-mode empty/whitespace items inside an array converter                  |
| 305  | `MissingEnvValue`   | `Envapter.require()`, decorator `required:`, strict-mode unresolved templates |

## Test plan

- [ ] `pnpm prePush` exits clean.
- [ ] Coverage stays at 100% on touched files.
- [ ] Hovering an intentionally-broken `{ converter, required: true, fallback: X }` in the IDE shows the `RequiredAndFallbackMutex` literal in the error chain.
- [ ] Hovering `Envapter.dotenvConfig = { path: '...' }` shows the `PathManagedByEnvapter` literal in the error chain.
- [ ] `seedcord`'s `vi.mock('envapt', ...)` pattern still works (strict defaults to off, no module-level state changes).
