### PR TITLE
feat: debug mode

### DIFF
--- a/.changeset/debug-mode.md
+++ b/.changeset/debug-mode.md
@@ -1,0 +1,13 @@
+---
+'envapt': major
+---
+
+Add `Envapter.debug` three-level log toggle. Removes `DotenvConfigOptions.debug`.
+
+- New `Envapter.debug = 'silent' | 'warn' | 'verbose'` (default `silent`). Output goes to stderr prefixed with `[envapt]`.
+- New `ENVAPT_DEBUG` env var. Read lazily on first access if the setter was never called; the setter wins after that.
+- `warn` level: failed `.env` reads, unresolved `${VAR}` templates (non-strict path), fallback values used in place of missing env.
+- `verbose` level: everything in `warn` plus effective `.env` paths during cache rebuild, the cache-cleared notice, per-file key counts, and per-key load lines.
+- New `DebugLevel` type re-exported from the package root.
+- Invalid setter values throw `EnvaptError(InvalidUserDefinedConfig)` with a list of the accepted levels.
+- **Breaking**: `DotenvConfigOptions.debug` removed. Use `Envapter.debug = 'verbose'` (or `ENVAPT_DEBUG=verbose`) instead. The corresponding `[dotenv]`-prefixed lines are gone; all debug output now flows through the unified `[envapt]` surface.

--- a/packages/envapt/src/Debug.ts
+++ b/packages/envapt/src/Debug.ts
@@ -1,0 +1,70 @@
+import process from 'node:process';
+
+import { EnvaptError, EnvaptErrorCodes } from './Error';
+
+/**
+ * Debug log levels for {@link Envapter.debug}. `silent` (default) emits nothing.
+ * `warn` covers signals that might indicate misconfiguration: failed file reads,
+ * unresolved templates (when not strict), fallback values used in place of missing
+ * env. `verbose` adds every loaded file, per-file key count, per-key load lines, and
+ * effective-paths / cache-rebuild notices.
+ * @public
+ */
+export type DebugLevel = 'silent' | 'warn' | 'verbose';
+
+const VALID_LEVELS: ReadonlySet<string> = new Set<DebugLevel>(['silent', 'warn', 'verbose']);
+
+let currentLevel: DebugLevel = 'silent';
+let initialized = false;
+
+function isDebugLevel(value: string | undefined): value is DebugLevel {
+    return value !== undefined && VALID_LEVELS.has(value);
+}
+
+// Reads `ENVAPT_DEBUG` lazily on first access. Setter wins after that.
+function resolveLevel(): DebugLevel {
+    if (!initialized) {
+        const fromEnv = process.env.ENVAPT_DEBUG;
+        currentLevel = isDebugLevel(fromEnv) ? fromEnv : 'silent';
+        initialized = true;
+    }
+    return currentLevel;
+}
+
+/** @internal */
+export function setDebugLevel(level: DebugLevel): void {
+    if (!isDebugLevel(level)) {
+        throw new EnvaptError(
+            EnvaptErrorCodes.InvalidUserDefinedConfig,
+            `Invalid debug level "${String(level)}". Expected 'silent' | 'warn' | 'verbose'.`
+        );
+    }
+    currentLevel = level;
+    initialized = true;
+}
+
+/** @internal */
+export function getDebugLevel(): DebugLevel {
+    return resolveLevel();
+}
+
+/** @internal */
+export function resetDebugForTesting(): void {
+    currentLevel = 'silent';
+    initialized = false;
+}
+
+/** @internal */
+export function debugWarn(message: string): void {
+    const level = resolveLevel();
+    if (level === 'warn' || level === 'verbose') {
+        process.stderr.write(`[envapt] ${message}\n`);
+    }
+}
+
+/** @internal */
+export function debugVerbose(message: string): void {
+    if (resolveLevel() === 'verbose') {
+        process.stderr.write(`[envapt] ${message}\n`);
+    }
+}

--- a/packages/envapt/src/Dotenv.ts
+++ b/packages/envapt/src/Dotenv.ts
@@ -1,5 +1,7 @@
 import fs from 'node:fs';
 
+import { debugVerbose, debugWarn } from './Debug';
+
 import type { Err } from './Types';
 
 type PathManagedByEnvapter =
@@ -9,6 +11,7 @@ type ProcessEnvManagedByEnvapter = Err<'`processEnv` is managed internally by En
 /**
  * Public options for the internal `.env` loader. Mirrors the subset of dotenv's
  * `config()` options that envapt actually supports (no DOTENV_KEY, no quiet).
+ * For debug output, use `Envapter.debug` (or the `ENVAPT_DEBUG` env var).
  *
  * @public
  */
@@ -17,8 +20,6 @@ export interface DotenvConfigOptions {
     encoding?: BufferEncoding;
     /** When true, later files override earlier ones (and existing processEnv values). Default false (first-wins). */
     override?: boolean;
-    /** When true, prints `[dotenv]` messages to stderr while parsing. Default false. */
-    debug?: boolean;
     path?: PathManagedByEnvapter;
     processEnv?: ProcessEnvManagedByEnvapter;
 }
@@ -29,9 +30,7 @@ export interface DotenvConfigOptions {
  * @internal
  */
 export interface LoadDotenvInput extends Omit<DotenvConfigOptions, 'path' | 'processEnv'> {
-    /** One or more `.env` paths to load, in declaration order. */
     path: string | string[];
-    /** Target env map. Mutated in place with parsed values. */
     processEnv: Record<string, string>;
 }
 
@@ -211,19 +210,18 @@ export function loadDotenv(input: LoadDotenvInput): void {
         try {
             src = fs.readFileSync(filePath, encoding);
         } catch {
-            // Debug logging intentionally goes to stderr to mirror dotenv's behavior -- justified
-            // eslint-disable-next-line no-console
-            if (input.debug) console.error(`[dotenv] could not read ${filePath}`);
+            debugWarn(`could not read ${filePath}`);
             continue;
         }
 
         const parsed = parseDotenv(src);
+        debugVerbose(`loaded ${filePath}: ${parsed.size} ${parsed.size === 1 ? 'key' : 'keys'}`);
         for (const [key, value] of parsed) {
             const exists = Object.prototype.hasOwnProperty.call(input.processEnv, key);
-            if (!exists || override) input.processEnv[key] = value;
-            // Debug logging intentionally goes to stderr to mirror dotenv's behavior -- justified
-            // eslint-disable-next-line no-console
-            if (input.debug) console.error(`[dotenv] ${filePath} -> ${key}`);
+            if (!exists || override) {
+                input.processEnv[key] = value;
+                debugVerbose(`${filePath} -> ${key}`);
+            }
         }
     }
 }

--- a/packages/envapt/src/Parser.ts
+++ b/packages/envapt/src/Parser.ts
@@ -1,4 +1,5 @@
 import { BuiltInConverters } from './BuiltInConverters';
+import { debugWarn } from './Debug';
 import { EnvaptError, EnvaptErrorCodes } from './Error';
 import { Validator } from './Validators';
 
@@ -50,6 +51,7 @@ export class Parser {
                         `Cannot resolve template variable "\${${variable}}": value is missing or empty.`
                     );
                 }
+                debugWarn(`unresolved template \${${variable}} preserved as literal`);
                 return template; // missing or empty, preserve
             }
 

--- a/packages/envapt/src/Validators.ts
+++ b/packages/envapt/src/Validators.ts
@@ -231,13 +231,13 @@ export class Validator {
             );
         }
 
-        const validKeys = new Set(['encoding', 'debug', 'override']);
+        const validKeys = new Set(['encoding', 'override']);
         const invalidKeys = Object.keys(config).filter((key) => !validKeys.has(key));
 
         if (invalidKeys.length > 0) {
             throw new EnvaptError(
                 EnvaptErrorCodes.InvalidUserDefinedConfig,
-                `Invalid dotenvConfig options: ${invalidKeys.join(', ')}. Allowed options: ${Array.from(validKeys).join(', ')}`
+                `Invalid dotenvConfig options: ${invalidKeys.join(', ')}. Allowed options: ${Array.from(validKeys).join(', ')}. For debug output, use Envapter.debug or the ENVAPT_DEBUG env var.`
             );
         }
 

--- a/packages/envapt/src/core/EnvapterBase.ts
+++ b/packages/envapt/src/core/EnvapterBase.ts
@@ -1,9 +1,11 @@
 import process from 'node:process';
 
+import { debugVerbose, getDebugLevel, setDebugLevel } from '../Debug';
 import { loadDotenv } from '../Dotenv';
 import { EnvaptError, EnvaptErrorCodes } from '../Error';
 import { Validator } from '../Validators';
 
+import type { DebugLevel } from '../Debug';
 import type { DotenvConfigOptions } from '../Dotenv';
 import type { EnvKeyInput } from '../Types';
 
@@ -40,6 +42,19 @@ export abstract class EnvapterBase {
 
     static get strict(): boolean {
         return EnvapterBase._strict;
+    }
+
+    /**
+     * Set the debug log level. Defaults to `silent`. When unset, reads `ENVAPT_DEBUG` from
+     * `process.env` on first access; the setter overrides any env-var value. Output goes
+     * to stderr prefixed with `[envapt]`.
+     */
+    static set debug(level: DebugLevel) {
+        setDebugLevel(level);
+    }
+
+    static get debug(): DebugLevel {
+        return getDebugLevel();
     }
 
     protected static treatAsMissing(value: string | undefined): boolean {
@@ -89,6 +104,7 @@ export abstract class EnvapterBase {
 
     protected static refreshCache(): void {
         EnvaptCache.clear();
+        debugVerbose('cache cleared, reloading config');
         void this.config; // reload config to repopulate cache
     }
 
@@ -138,6 +154,7 @@ export abstract class EnvapterBase {
             // Path resolution (outside the try below). Surfaces EnvaptError early when an
             // explicitly configured profile path is missing. dotenv parse errors stay caught.
             const effectivePaths = this.resolveEffectivePaths();
+            debugVerbose(`effective .env paths: ${effectivePaths.length === 0 ? '(none)' : effectivePaths.join(', ')}`);
 
             try {
                 loadDotenv({
@@ -148,6 +165,7 @@ export abstract class EnvapterBase {
             } catch {}
             // populate the Map with global environment variables
             for (const [key, value] of Object.entries(isolatedEnv)) EnvaptCache.set(key, value);
+            debugVerbose(`cache populated: ${EnvaptCache.size} keys total`);
         }
 
         return EnvaptCache;

--- a/packages/envapt/src/core/PrimitiveMethods.ts
+++ b/packages/envapt/src/core/PrimitiveMethods.ts
@@ -1,4 +1,5 @@
 import { BuiltInConverters } from '../BuiltInConverters';
+import { debugWarn } from '../Debug';
 import { Parser, type EnvapterService } from '../Parser';
 import { EnvapterBase } from './EnvapterBase';
 import { EnvironmentMethods } from './EnvironmentMethods';
@@ -36,7 +37,10 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         def?: DefaultType
     ): ConditionalReturn<EnvVarReturnType, DefaultType> {
         const { key: resolvedKey, value } = this.resolveKeyInput(key);
-        if (this.treatAsMissing(value)) return def as ConditionalReturn<EnvVarReturnType, DefaultType>;
+        if (this.treatAsMissing(value)) {
+            if (def !== undefined) debugWarn(`${resolvedKey} not found, using fallback ${String(def)}`);
+            return def as ConditionalReturn<EnvVarReturnType, DefaultType>;
+        }
         const rawVal = value as string | number | boolean | undefined;
 
         const parsed = this.parser.resolveTemplate(resolvedKey, String(rawVal));

--- a/packages/envapt/src/index.ts
+++ b/packages/envapt/src/index.ts
@@ -2,6 +2,7 @@ export { Envapt } from './Envapt';
 export { Envapter, Environment } from './Envapter';
 export { Converters, isArrayOf } from './Converters';
 export type { ArrayElement, ArrayOf, ConverterToken, CustomElementConverter } from './Converters';
+export type { DebugLevel } from './Debug';
 export type { DotenvConfigOptions } from './Dotenv';
 export type { InferSchemaInput, InferSchemaOutput, StandardSchemaV1 } from './StandardSchema';
 export * from './Error';

--- a/packages/envapt/tests/.env.debug-mode
+++ b/packages/envapt/tests/.env.debug-mode
@@ -1,0 +1,5 @@
+# Fixture for 023-debug-mode.test.ts
+
+KNOWN_KEY=hello
+TEMPLATED=value-${KNOWN_KEY}
+TEMPLATED_UNRESOLVED=value-${ABSENT_KEY}

--- a/packages/envapt/tests/003-envapter.test.ts
+++ b/packages/envapt/tests/003-envapter.test.ts
@@ -126,7 +126,7 @@ describe('Envapter', () => {
             });
 
             it('should set and get valid dotenvConfig', () => {
-                const newConfig = { debug: true, override: true };
+                const newConfig = { override: true };
                 Envapter.dotenvConfig = newConfig;
                 expect(Envapter.dotenvConfig).to.deep.equal(newConfig);
             });

--- a/packages/envapt/tests/005-runtime-validation.test.ts
+++ b/packages/envapt/tests/005-runtime-validation.test.ts
@@ -431,13 +431,7 @@ describe('Runtime Validation', () => {
 
     describe('dotenv config validation', () => {
         it('should accept valid dotenv config options', () => {
-            const validConfigs = [
-                { debug: false },
-                { override: true },
-                { encoding: 'utf8' },
-                { debug: false, override: true },
-                { encoding: 'utf8', debug: false, override: true }
-            ];
+            const validConfigs = [{ override: true }, { encoding: 'utf8' }, { encoding: 'utf8', override: true }];
 
             for (const config of validConfigs) {
                 expect(() => Validator.validateDotenvConfig(config)).to.not.throw();

--- a/packages/envapt/tests/019-dotenv-parser.test.ts
+++ b/packages/envapt/tests/019-dotenv-parser.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { expect } from 'chai';
-import { afterAll, afterEach, beforeAll, describe, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, describe, it } from 'vitest';
 
 import { loadDotenv, parseDotenv } from '../src/Dotenv';
 
@@ -196,22 +196,6 @@ describe('Dotenv parser', () => {
             const target: Record<string, string> = {};
             loadDotenv({ path, processEnv: target, encoding: 'latin1' });
             expect(target.GREETING).to.equal('hello');
-        });
-
-        it('emits debug lines to stderr when debug is on', () => {
-            const path = writeEnv('debug.env', 'FOO=bar');
-            const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-            loadDotenv({ path, processEnv: {}, debug: true });
-            expect(spy.mock.calls.flat().some((arg) => String(arg).includes('FOO'))).to.be.true;
-            spy.mockRestore();
-        });
-
-        it('logs the missing file path under debug when a file cannot be read', () => {
-            const ghost = join(tmpDir, 'still-missing.env');
-            const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
-            loadDotenv({ path: ghost, processEnv: {}, debug: true });
-            expect(spy.mock.calls.flat().some((arg) => String(arg).includes(ghost))).to.be.true;
-            spy.mockRestore();
         });
 
         afterEach(() => {

--- a/packages/envapt/tests/023-debug-mode.test.ts
+++ b/packages/envapt/tests/023-debug-mode.test.ts
@@ -1,0 +1,252 @@
+import { resolve } from 'node:path';
+import process from 'node:process';
+
+import { expect } from 'chai';
+import { expectTypeOf } from 'expect-type';
+import { afterEach, beforeAll, beforeEach, describe, it, vi } from 'vitest';
+
+import { Envapter, EnvaptErrorCodes } from '../src';
+import { resetDebugForTesting } from '../src/Debug';
+import { loadDotenv } from '../src/Dotenv';
+import { EnvaptError } from '../src/Error';
+
+import type { DebugLevel } from '../src';
+
+interface StderrCapture {
+    lines: string[];
+    restore: () => void;
+}
+
+function captureStderr(): StderrCapture {
+    const lines: string[] = [];
+    const spy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: unknown) => {
+        lines.push(typeof chunk === 'string' ? chunk : String(chunk));
+        return true;
+    });
+    return { lines, restore: () => spy.mockRestore() };
+}
+
+function lastEnvaptLine(capture: StderrCapture): string | undefined {
+    const envaptLines = capture.lines.filter((l) => l.includes('[envapt]'));
+    return envaptLines.at(-1);
+}
+
+describe('Debug mode (v5)', () => {
+    beforeAll(() => {
+        Envapter.envPaths = resolve(import.meta.dirname, '.env.debug-mode');
+    });
+
+    beforeEach(() => {
+        delete process.env.ENVAPT_DEBUG;
+        resetDebugForTesting();
+    });
+
+    afterEach(() => {
+        resetDebugForTesting();
+    });
+
+    describe('Envapter.debug toggle', () => {
+        it('defaults to silent', () => {
+            expect(Envapter.debug).to.equal('silent');
+        });
+
+        it('round-trips set/get for each level', () => {
+            Envapter.debug = 'warn';
+            expect(Envapter.debug).to.equal('warn');
+            Envapter.debug = 'verbose';
+            expect(Envapter.debug).to.equal('verbose');
+            Envapter.debug = 'silent';
+            expect(Envapter.debug).to.equal('silent');
+        });
+
+        it('throws EnvaptError(InvalidUserDefinedConfig) on an invalid level', () => {
+            expect(() => {
+                Envapter.debug = 'loud' as DebugLevel;
+            })
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.InvalidUserDefinedConfig);
+        });
+    });
+
+    describe('Lazy ENVAPT_DEBUG env-var resolution', () => {
+        it('picks up ENVAPT_DEBUG when set and the setter has not run', () => {
+            process.env.ENVAPT_DEBUG = 'verbose';
+            expect(Envapter.debug).to.equal('verbose');
+        });
+
+        it('ignores invalid ENVAPT_DEBUG values, defaulting to silent', () => {
+            process.env.ENVAPT_DEBUG = 'bogus';
+            expect(Envapter.debug).to.equal('silent');
+        });
+
+        it('setter overrides the env var after first call', () => {
+            process.env.ENVAPT_DEBUG = 'verbose';
+            Envapter.debug = 'warn';
+            expect(Envapter.debug).to.equal('warn');
+        });
+    });
+
+    describe('silent (default) emits nothing', () => {
+        it('does not log anything from get() on missing key with fallback', () => {
+            const capture = captureStderr();
+            try {
+                Envapter.get('NEVER_SET_KEY', 'fallback');
+                expect(capture.lines.some((l) => l.includes('[envapt]'))).to.equal(false);
+            } finally {
+                capture.restore();
+            }
+        });
+    });
+
+    describe('warn level', () => {
+        it('logs when a fallback is used in place of a missing env value', () => {
+            Envapter.debug = 'warn';
+            const capture = captureStderr();
+            try {
+                Envapter.get('NEVER_SET_KEY', 'fallback');
+                const line = lastEnvaptLine(capture);
+                expect(line).to.exist;
+                expect(line).to.include('NEVER_SET_KEY');
+                expect(line).to.include('fallback');
+            } finally {
+                capture.restore();
+            }
+        });
+
+        it('does NOT log when a key is found in the env (no fallback path)', () => {
+            Envapter.debug = 'warn';
+            const capture = captureStderr();
+            try {
+                Envapter.get('KNOWN_KEY');
+                expect(capture.lines.some((l) => l.includes('[envapt]'))).to.equal(false);
+            } finally {
+                capture.restore();
+            }
+        });
+
+        it('logs an unresolved template (non-strict path) preserved as literal', () => {
+            Envapter.debug = 'warn';
+            const capture = captureStderr();
+            try {
+                Envapter.get('TEMPLATED_UNRESOLVED');
+                const found = capture.lines.find((l) => l.includes('ABSENT_KEY'));
+                expect(found, 'expected an unresolved-template warn').to.exist;
+            } finally {
+                capture.restore();
+            }
+        });
+
+        it('does NOT emit verbose-only lines (cache cleared / loaded files)', () => {
+            Envapter.debug = 'warn';
+            const capture = captureStderr();
+            try {
+                Envapter.envPaths = resolve(import.meta.dirname, '.env.debug-mode');
+                expect(capture.lines.some((l) => l.includes('cache cleared'))).to.equal(false);
+                expect(capture.lines.some((l) => l.includes('effective .env paths'))).to.equal(false);
+            } finally {
+                capture.restore();
+            }
+        });
+    });
+
+    describe('verbose level', () => {
+        it('logs effective .env paths during cache rebuild', () => {
+            Envapter.debug = 'verbose';
+            const capture = captureStderr();
+            try {
+                Envapter.envPaths = resolve(import.meta.dirname, '.env.debug-mode');
+                expect(capture.lines.some((l) => l.includes('effective .env paths'))).to.equal(true);
+            } finally {
+                capture.restore();
+            }
+        });
+
+        it('logs "(none)" when the resolver returns zero effective paths', () => {
+            // `configureProfiles({ useDefaults: false })` with no per-env profile entry
+            // collapses the resolver to an empty array. Triggers the `(none)` arm.
+            Envapter.debug = 'verbose';
+            const capture = captureStderr();
+            try {
+                Envapter.resetProfiles();
+                Envapter.configureProfiles({ useDefaults: false });
+                expect(capture.lines.some((l) => l.includes('effective .env paths: (none)'))).to.equal(true);
+            } finally {
+                capture.restore();
+                Envapter.resetProfiles();
+                Envapter.envPaths = resolve(import.meta.dirname, '.env.debug-mode');
+            }
+        });
+
+        it('logs the cache-cleared line on refresh', () => {
+            Envapter.debug = 'verbose';
+            const capture = captureStderr();
+            try {
+                Envapter.envPaths = resolve(import.meta.dirname, '.env.debug-mode');
+                expect(capture.lines.some((l) => l.includes('cache cleared'))).to.equal(true);
+            } finally {
+                capture.restore();
+            }
+        });
+
+        it('logs the per-file key count after a successful load', () => {
+            Envapter.debug = 'verbose';
+            const capture = captureStderr();
+            try {
+                Envapter.envPaths = resolve(import.meta.dirname, '.env.debug-mode');
+                expect(capture.lines.some((l) => /loaded .*: \d+ keys?/u.test(l))).to.equal(true);
+            } finally {
+                capture.restore();
+            }
+        });
+
+        it('logs per-key load lines for each key from a file', () => {
+            Envapter.debug = 'verbose';
+            const capture = captureStderr();
+            try {
+                Envapter.envPaths = resolve(import.meta.dirname, '.env.debug-mode');
+                expect(capture.lines.some((l) => l.includes('-> KNOWN_KEY'))).to.equal(true);
+            } finally {
+                capture.restore();
+            }
+        });
+
+        it('still emits warn-level lines (fallback used)', () => {
+            Envapter.debug = 'verbose';
+            const capture = captureStderr();
+            try {
+                Envapter.get('NEVER_SET_KEY', 'fallback');
+                const line = lastEnvaptLine(capture);
+                expect(line).to.include('NEVER_SET_KEY');
+            } finally {
+                capture.restore();
+            }
+        });
+    });
+
+    describe('Failed file reads (warn)', () => {
+        // The envPaths setter validates that the file exists, so we hit the loader's
+        // catch-and-warn path directly. This is the realistic case: a path slips past the
+        // validator (e.g., race-deleted between checks) and the loader has to log + skip.
+        it('emits a "could not read" warn when loadDotenv hits a missing file', () => {
+            Envapter.debug = 'warn';
+            const ghost = resolve(import.meta.dirname, '.env.does-not-exist-at-all');
+            const capture = captureStderr();
+            try {
+                loadDotenv({ path: ghost, processEnv: {} });
+                const line = capture.lines.find((l) => l.includes(ghost));
+                expect(line, 'expected a could-not-read warn').to.exist;
+                expect(line).to.include('could not read');
+            } finally {
+                capture.restore();
+            }
+        });
+    });
+
+    describe('Compile-time type narrowing (expect-type)', () => {
+        it('Envapter.debug is typed as DebugLevel', () => {
+            const current = Envapter.debug;
+            expectTypeOf(current).toEqualTypeOf<DebugLevel>();
+            expectTypeOf<DebugLevel>().toEqualTypeOf<'silent' | 'warn' | 'verbose'>();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

`Envapter.debug = 'silent' | 'warn' | 'verbose'` (default `silent`). Also seeded from `ENVAPT_DEBUG`. Output goes to stderr, `[envapt]` prefix. Replaces the old `DotenvConfigOptions.debug` flag (which is removed).

## Related issue

- Closes #82

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Internal refactor
- [ ] Documentation

## Scope check

- [x] This pull request focuses on one feature or closely related set of changes
- [x] No new packages or top level projects are introduced inside this repository
- [x] No core files have been copy pasted into new folders
- [x] Changes are limited to the existing `envapt/src` tree and necessary tests or docs

## Implementation notes

```ts
Envapter.debug = 'verbose';
// or:  ENVAPT_DEBUG=verbose node app.js

Envapter.debug = 'warn';
Envapter.get('NEVER_SET', 'fallback');
// [envapt] NEVER_SET not found, using fallback fallback

Envapter.debug = 'verbose';
Envapter.envPaths = '.env.production';
// [envapt] cache cleared, reloading config
// [envapt] effective .env paths: .env.production
// [envapt] loaded .env.production: 4 keys
// [envapt] .env.production -> DATABASE_URL
// [envapt] cache populated: 247 keys total
```

- New `src/Debug.ts`: holds the level, lazy env-var read, `debugWarn` / `debugVerbose`. One-way import (`EnvapterBase` → `Debug`), no cycles.
- `EnvapterBase.debug` getter/setter chains through `Debug.ts`. Invalid setter value throws `EnvaptError(InvalidUserDefinedConfig)`; invalid `ENVAPT_DEBUG` value silently falls back to `silent`.
- Toggling does NOT refresh the cache. Different from `strict`, which changes read semantics.
- `DotenvConfigOptions.debug` removed. `Validator.validateDotenvConfig` no longer accepts it; the rejection message points at the new flag. `loadDotenv`'s `[dotenv]` console.error calls are gone.

Log sites:

- `Dotenv.loadDotenv`: warn on failed read; verbose for per-file key count and each loaded key.
- `EnvapterBase.config` / `refreshCache`: verbose for cache-cleared, effective paths, cache-populated count.
- `Parser.resolveTemplate`: warn for an unresolved `${VAR}` on the non-strict path (strict throws).
- `PrimitiveMethods._get`: warn when a fallback is used because the key is missing.

The two `[dotenv]` debug tests in `tests/019-dotenv-parser.test.ts` were testing the removed surface and got deleted; coverage moved to `tests/023`.

## TypeScript and safety

- [x] New code is written in strict TypeScript
- [x] No new `any` types were introduced (if they were, explain why)
- [x] No `value as any` style casts were added to bypass the type system
- [x] No unnecessary type casts were added
- [x] Existing strict TypeScript settings were not disabled or loosened
- [x] New code has complete type coverage (no `@ts-ignore` or missing types)
- [x] New code uses proper TypeScript generics or unions where applicable
- [x] Public types and signatures are well defined and documented where needed

`DebugLevel` re-exported from the package root. `tests/023` asserts the type narrows to `'silent' | 'warn' | 'verbose'` via `expect-type`.

## Tests

- [x] `pnpm lint` passes with zero lint errors (without the need for unnecessary `/* eslint-disable */` comments or changes to existing lint rules)
- [x] `pnpm test` passes locally
- [x] `pnpm coverage` passes locally without new coverage gaps
- [x] New or updated tests cover the behavior in this pull request

`tests/023-debug-mode.test.ts` (19 cases):

- Toggle default + set/get + invalid value throws.
- Lazy `ENVAPT_DEBUG` read, invalid env-var value defaults to silent, setter overrides env var.
- silent emits nothing.
- warn: fallback line fires, successful gets stay quiet, unresolved-template line fires, no verbose-only lines leak.
- verbose: effective paths, cache cleared, per-file key count, per-key load lines, warn lines still fire, `(none)` arm when the resolver returns an empty array.
- Failed file read: `loadDotenv` direct call to a missing path produces a `could not read` warn.

Existing tests touched:

- `tests/003-envapter.test.ts`: dropped `debug: true` from one config literal.
- `tests/005-runtime-validation.test.ts`: dropped three entries from the valid-config list.
- `tests/019-dotenv-parser.test.ts`: deleted two tests for the removed surface.

100% coverage on every touched source file. Full suite: 23 files, 471 tests.

## Docs and changesets

- [ ] README or other docs were updated if behavior changed
- [x] A changeset was added with `pnpm cs add`, uses the correct bump level, and has a clear summary

`.changeset/debug-mode.md`: `major` bump for the `DotenvConfigOptions.debug` removal. README update deferred to the docs-site rebuild (#87).

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] Commit messages and PR title follow Conventional Commits
- [x] CI is expected to pass for this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)