### PR TITLE
feat: cross-runtime integration test matrix (#85)

### DIFF
--- a/.changeset/cross-runtime-tests.md
+++ b/.changeset/cross-runtime-tests.md
@@ -1,0 +1,14 @@
+---
+'envapt': patch
+---
+
+Add cross-runtime integration test layer under `packages/envapt/tests/integration/`.
+
+- Hand-rolled `node:assert`-based smoke (6 portable suites + 1 Deno-only suite, ~30 assertions): basic get, every built-in converter, fallbacks, missing-file recovery, the `@Envapt` decorator's runtime install path, the v5 features (strict, debug, syncProcessEnv, require), and `@Envapt` syntax compiled by the host runtime's TS transpiler.
+- Runs identically under Node, Bun, and Deno; consumes only the built `dist/index.mjs`.
+- New `test:integration` package script for local Node runs.
+- New GitHub Actions workflow `cross-runtime.yml`: build once, fanout across Node `[20, 22, 24]` on ubuntu plus Node 22 on macos and windows, plus Bun on ubuntu and Deno on ubuntu. Branch protection should gate on the aggregator `cross-runtime ok` job.
+
+**Known limitation: Bun direct-`.ts` execution with `@Envapt` syntax.** Bun 1.3.10+ ignores the `experimentalDecorators` tsconfig flag and emits TC39 Stage 3 decorators ([bun#27575](https://github.com/oven-sh/bun/issues/27575)); envapt's `@Envapt` is a legacy TypeScript decorator and the call shapes are incompatible. Bun users who want the decorator API should precompile with `tsc` / `tsdown` / Vite first, then run the compiled output with Bun. The functional API (`Envapter.get`, `getNumber`, etc.) works without any build step under direct-`.ts` execution.
+
+No public API change.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -31,13 +31,13 @@ jobs:
                   cache: pnpm
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
-            - name: Run lint
-              run: pnpm lint
+            - name: Build project
+              run: pnpm build
             - name: Run type check
               run: pnpm tc
+            - name: Run lint
+              run: pnpm lint
             - name: Run tests
               run: pnpm test
             - name: Run audit
               run: pnpm audit --audit-level=high
-            - name: Build project
-              run: pnpm build

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -20,6 +20,7 @@ jobs:
                   node-version: 24.16.0
                   cache: pnpm
             - run: pnpm install --frozen-lockfile
+            - run: pnpm build
             - run: pnpm tc
             - run: pnpm coverage
             - uses: codecov/codecov-action@v6

--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -1,0 +1,126 @@
+name: cross-runtime
+
+on:
+    pull_request:
+        paths-ignore:
+            - '**/*.md'
+            - '.vscode/**'
+            - '.changeset/**'
+            - '.github/ISSUE_TEMPLATE/**'
+            - '.github/PULL_REQUEST_TEMPLATE.md'
+    push:
+        branches: [main, next]
+        paths-ignore:
+            - '**/*.md'
+            - '.vscode/**'
+            - '.changeset/**'
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    build:
+        name: Build dist artifact
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1
+            - uses: pnpm/action-setup@v6
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: 24.16.0
+                  cache: pnpm
+            - run: pnpm install --frozen-lockfile
+            - run: pnpm --filter envapt build
+            - uses: actions/upload-artifact@v4
+              with:
+                  name: envapt-dist-and-suites
+                  # Already-minified ESM compresses poorly; level 0 saves CPU on both ends.
+                  compression-level: 0
+                  path: |
+                      packages/envapt/dist/
+                      packages/envapt/tests/integration/
+                  if-no-files-found: error
+
+    test-node:
+        # Multi-OS only at the LTS cell. Path-separator and CRLF risks live at the OS
+        # boundary; doubling the OS triplet across every Node version adds zero new
+        # bug-class coverage for a pure-JS lib with no native deps.
+        name: node ${{ matrix.node }} / ${{ matrix.os }}
+        needs: build
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    - { node: '20', os: ubuntu-latest }
+                    - { node: '22', os: ubuntu-latest }
+                    - { node: '24', os: ubuntu-latest }
+                    - { node: '22', os: macos-latest }
+                    - { node: '22', os: windows-latest }
+        steps:
+            - uses: actions/setup-node@v6
+              with:
+                  node-version: ${{ matrix.node }}
+            - uses: actions/download-artifact@v4
+              with:
+                  name: envapt-dist-and-suites
+                  path: packages/envapt/
+            - run: node packages/envapt/tests/integration/run.mjs
+
+    test-bun:
+        # Ubuntu-only: Bun's Windows/macOS variance catches Bun engine bugs (e.g.
+        # bun#16907, bun#23831), not envapt bugs. Engine flakes would just gate PRs
+        # on something we can't fix.
+        name: bun / ubuntu
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: oven-sh/setup-bun@v2
+              with:
+                  bun-version: 1.3.x
+            - uses: actions/download-artifact@v4
+              with:
+                  name: envapt-dist-and-suites
+                  path: packages/envapt/
+            - run: bun packages/envapt/tests/integration/run.mjs
+
+    test-deno:
+        # Ubuntu-only for the same reason as Bun. `--config` forces the local deno.json
+        # so `experimentalDecorators: true` actually applies: Deno historically ignored
+        # this flag silently (denoland/deno#15968 fixed 2024-07), so without an explicit
+        # config the .ts decorator suite would not exercise the legacy transpile path.
+        name: deno / ubuntu
+        needs: build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: denoland/setup-deno@v2
+              with:
+                  deno-version: v2.7.x
+            - uses: actions/download-artifact@v4
+              with:
+                  name: envapt-dist-and-suites
+                  path: packages/envapt/
+            - run: deno run -A --config packages/envapt/tests/integration/deno.json packages/envapt/tests/integration/run.mjs
+
+    cross-runtime-ok:
+        # Single aggregator. Set this as the required check in branch protection so
+        # renaming matrix variables (e.g. node 24 -> 26) does not break gating.
+        name: cross-runtime ok
+        needs: [test-node, test-bun, test-deno]
+        if: always()
+        runs-on: ubuntu-latest
+        steps:
+            - name: Verify every runtime job succeeded
+              run: |
+                  results='${{ toJSON(needs) }}'
+                  echo "$results"
+                  failed=$(echo "$results" | jq -r 'to_entries[] | select(.value.result != "success") | .key')
+                  if [ -n "$failed" ]; then
+                      echo "Failed jobs:"
+                      echo "$failed"
+                      exit 1
+                  fi
+                  echo "All cross-runtime jobs succeeded."

--- a/packages/envapt/eslint.config.mjs
+++ b/packages/envapt/eslint.config.mjs
@@ -16,6 +16,16 @@ export default createConfig({
             // Type-error fixtures: intentionally broken code consumed by the compiler-API
             // test at runtime. Excluded from the project's tsconfig + skipped by lint.
             ignores: ['tests/type-error-fixtures/**']
+        },
+        {
+            // Deno requires explicit `.mjs` on relative imports; the target is the built
+            // dist/ (off the node_modules resolver); assertion literals are intentional.
+            files: ['tests/integration/**/*.mjs', 'tests/integration/**/*.ts'],
+            rules: {
+                'import/no-useless-path-segments': 'off',
+                'import/no-unresolved': 'off',
+                'no-magic-numbers': 'off'
+            }
         }
     ]
 });

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -41,6 +41,7 @@
         "tsd": "tsd",
         "test": "vitest run",
         "test:watch": "vitest dev",
+        "test:integration": "node tests/integration/run.mjs",
         "coverage": "pnpm run test --coverage",
         "cs": "changeset",
         "cs:publish": "changeset publish",

--- a/packages/envapt/tests/integration/deno.json
+++ b/packages/envapt/tests/integration/deno.json
@@ -1,0 +1,5 @@
+{
+    "compilerOptions": {
+        "experimentalDecorators": true
+    }
+}

--- a/packages/envapt/tests/integration/fixture.env
+++ b/packages/envapt/tests/integration/fixture.env
@@ -1,0 +1,16 @@
+# Fixture for the integration suites. Editing keys here requires updating the assertions.
+
+BASIC_KEY=hello
+TEMPLATED_KEY=greeting-${BASIC_KEY}
+
+NUMBER_KEY=42
+BOOL_KEY=true
+BIGINT_KEY=9007199254740993
+JSON_KEY={"name":"x","n":1}
+URL_KEY=https://example.com/path
+DATE_KEY=2025-01-01T00:00:00.000Z
+ARRAY_NUMBERS=1,2,3
+
+WHITESPACE_KEY="   "
+
+PROFILE_BASE=base-value

--- a/packages/envapt/tests/integration/run.mjs
+++ b/packages/envapt/tests/integration/run.mjs
@@ -1,0 +1,52 @@
+import process from 'node:process';
+
+import basicGet from './suites/01-basic-get.mjs';
+import converters from './suites/02-converters.mjs';
+import fallbacks from './suites/03-fallbacks.mjs';
+import missingFile from './suites/04-missing-file.mjs';
+import decorator from './suites/05-decorator.mjs';
+import v5Features from './suites/06-v5-features.mjs';
+
+const suites = [
+    ['01-basic-get', basicGet],
+    ['02-converters', converters],
+    ['03-fallbacks', fallbacks],
+    ['04-missing-file', missingFile],
+    ['05-decorator', decorator],
+    ['06-v5-features', v5Features]
+];
+
+const runtime = detectRuntime();
+process.stdout.write(`[integration] runtime=${runtime}\n`);
+
+// Bun 1.3.10+ ignores `experimentalDecorators` (bun#27575) and emits Stage 3, which
+// envapt's legacy decorator helper can't accept. The Deno deprecation warning is the
+// canary: when Deno removes the flag, this suite will break.
+if (runtime === 'deno') {
+    const mod = await import('./suites/05b-decorator-syntax.ts');
+    suites.push(['05b-decorator-syntax', mod.default]);
+}
+
+let failed = 0;
+for (const [name, fn] of suites) {
+    try {
+        await fn();
+        process.stdout.write(`  ✓ ${name}\n`);
+    } catch (err) {
+        failed++;
+        const stack = err instanceof Error ? (err.stack ?? err.message) : String(err);
+        process.stderr.write(`  ✗ ${name}\n${stack}\n`);
+    }
+}
+
+if (failed > 0) {
+    process.stderr.write(`[integration] ${failed} suite(s) failed\n`);
+    process.exit(1);
+}
+process.stdout.write(`[integration] all ${suites.length} suites passed\n`);
+
+function detectRuntime() {
+    if (typeof Deno !== 'undefined') return 'deno';
+    if (typeof Bun !== 'undefined') return 'bun';
+    return 'node';
+}

--- a/packages/envapt/tests/integration/suites/01-basic-get.mjs
+++ b/packages/envapt/tests/integration/suites/01-basic-get.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+
+import { FIXTURE_PATH } from './_helpers.mjs';
+import { Envapter } from '../../../dist/index.mjs';
+
+export default async function basicGet() {
+    Envapter.envPaths = FIXTURE_PATH;
+
+    assert.equal(Envapter.get('BASIC_KEY'), 'hello');
+    assert.equal(Envapter.get('TEMPLATED_KEY'), 'greeting-hello');
+    assert.equal(Envapter.get('MISSING_KEY'), undefined);
+
+    const instance = new Envapter();
+    assert.equal(instance.getRaw('BASIC_KEY'), 'hello');
+    assert.equal(instance.getRaw('MISSING_KEY'), undefined);
+}

--- a/packages/envapt/tests/integration/suites/02-converters.mjs
+++ b/packages/envapt/tests/integration/suites/02-converters.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+
+import { FIXTURE_PATH } from './_helpers.mjs';
+import { Converters, Envapter } from '../../../dist/index.mjs';
+
+export default async function converters() {
+    Envapter.envPaths = FIXTURE_PATH;
+
+    assert.equal(Envapter.getNumber('NUMBER_KEY'), 42);
+    assert.equal(Envapter.getBoolean('BOOL_KEY'), true);
+    assert.equal(Envapter.getBigInt('BIGINT_KEY'), 9007199254740993n);
+
+    const json = Envapter.getUsing('JSON_KEY', Converters.Json);
+    assert.deepEqual(json, { name: 'x', n: 1 });
+
+    const url = Envapter.getUsing('URL_KEY', Converters.Url);
+    assert.ok(url instanceof URL);
+    assert.equal(url.host, 'example.com');
+
+    const date = Envapter.getUsing('DATE_KEY', Converters.Date);
+    assert.ok(date instanceof Date);
+    assert.equal(date.toISOString(), '2025-01-01T00:00:00.000Z');
+
+    const numbers = Envapter.getUsing('ARRAY_NUMBERS', Converters.array({ of: Converters.Number, delimiter: ',' }));
+    assert.deepEqual(numbers, [1, 2, 3]);
+}

--- a/packages/envapt/tests/integration/suites/03-fallbacks.mjs
+++ b/packages/envapt/tests/integration/suites/03-fallbacks.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+
+import { FIXTURE_PATH } from './_helpers.mjs';
+import { Converters, EnvaptError, EnvaptErrorCodes, Envapter } from '../../../dist/index.mjs';
+
+export default async function fallbacks() {
+    Envapter.envPaths = FIXTURE_PATH;
+
+    assert.equal(Envapter.get('MISSING_KEY', 'default'), 'default');
+    assert.equal(Envapter.getNumber('MISSING_KEY', 7), 7);
+    assert.equal(Envapter.getBoolean('MISSING_KEY', false), false);
+
+    // Fallback-type validation only fires through `getUsing` / decorators, not on
+    // typed primitive getters like `getNumber`.
+    assert.throws(
+        () => Envapter.getUsing('MISSING_KEY', Converters.Number, 'not-a-number'),
+        (err) => err instanceof EnvaptError && err.code === EnvaptErrorCodes.FallbackConverterTypeMismatch
+    );
+}

--- a/packages/envapt/tests/integration/suites/04-missing-file.mjs
+++ b/packages/envapt/tests/integration/suites/04-missing-file.mjs
@@ -1,0 +1,19 @@
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+import { FIXTURE_PATH } from './_helpers.mjs';
+import { EnvaptError, EnvaptErrorCodes, Envapter } from '../../../dist/index.mjs';
+
+export default async function missingFile() {
+    const ghost = resolve(FIXTURE_PATH, '../this-fixture-does-not-exist.env');
+
+    assert.throws(
+        () => {
+            Envapter.envPaths = ghost;
+        },
+        (err) => err instanceof EnvaptError && err.code === EnvaptErrorCodes.EnvFilesNotFound
+    );
+
+    Envapter.envPaths = FIXTURE_PATH;
+    assert.equal(Envapter.get('BASIC_KEY'), 'hello');
+}

--- a/packages/envapt/tests/integration/suites/05-decorator.mjs
+++ b/packages/envapt/tests/integration/suites/05-decorator.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+
+import { FIXTURE_PATH } from './_helpers.mjs';
+import { Envapt, Envapter } from '../../../dist/index.mjs';
+
+// `.mjs` has no `@Envapt` syntax. Calling the decorator as a function exercises
+// the same install path tsdown-emitted user code hits at runtime.
+export default async function decorator() {
+    Envapter.envPaths = FIXTURE_PATH;
+
+    class Config {}
+    Envapt('BASIC_KEY', { fallback: 'default' })(Config, 'BASIC_KEY');
+    Envapt('MISSING_DECORATOR_KEY', { fallback: 'fb-value' })(Config, 'MISSING_DECORATOR_KEY');
+    Envapt('NUMBER_KEY', { fallback: 0, converter: Number })(Config, 'NUMBER_KEY');
+
+    assert.equal(Config.BASIC_KEY, 'hello');
+    assert.equal(Config.MISSING_DECORATOR_KEY, 'fb-value');
+    assert.equal(Config.NUMBER_KEY, 42);
+
+    class Bag {}
+    Envapt('BOOL_KEY', { fallback: false })(Bag.prototype, 'enabled');
+    const bag = new Bag();
+    assert.equal(bag.enabled, true);
+}

--- a/packages/envapt/tests/integration/suites/05b-decorator-syntax.ts
+++ b/packages/envapt/tests/integration/suites/05b-decorator-syntax.ts
@@ -1,0 +1,25 @@
+import assert from 'node:assert/strict';
+
+import { FIXTURE_PATH } from './_helpers.mjs';
+import { Envapt, Envapter } from '../../../dist/index.mjs';
+
+// Deno-only suite. Bun 1.3.10+ permanently emits Stage 3 decorators (bun#27575),
+// incompatible with envapt's legacy install signature. Node has no native TS.
+// Pairs with the runtime-helper test in 05-decorator.mjs.
+class Config {
+    @Envapt('BASIC_KEY', { fallback: 'default' })
+    declare static readonly BASIC_KEY: string;
+
+    @Envapt('NUMBER_KEY', { fallback: 0, converter: Number })
+    declare static readonly NUMBER_KEY: number;
+
+    @Envapt('MISSING_DECORATOR_KEY', { fallback: 'fb-value' })
+    declare static readonly MISSING_DECORATOR_KEY: string;
+}
+
+export default function decoratorSyntax(): void {
+    Envapter.envPaths = FIXTURE_PATH;
+    assert.equal(Config.BASIC_KEY, 'hello');
+    assert.equal(Config.NUMBER_KEY, 42);
+    assert.equal(Config.MISSING_DECORATOR_KEY, 'fb-value');
+}

--- a/packages/envapt/tests/integration/suites/06-v5-features.mjs
+++ b/packages/envapt/tests/integration/suites/06-v5-features.mjs
@@ -1,0 +1,71 @@
+import assert from 'node:assert/strict';
+import process from 'node:process';
+
+import { FIXTURE_PATH } from './_helpers.mjs';
+import { EnvaptError, EnvaptErrorCodes, Envapter } from '../../../dist/index.mjs';
+
+export default async function v5Features() {
+    await strictMode();
+    await debugMode();
+    await syncProcessEnv();
+    await requireHelper();
+}
+
+async function strictMode() {
+    Envapter.strict = false;
+    Envapter.envPaths = FIXTURE_PATH;
+    assert.equal(Envapter.get('WHITESPACE_KEY'), '   ');
+
+    Envapter.strict = true;
+    try {
+        assert.equal(Envapter.get('WHITESPACE_KEY'), undefined);
+        assert.equal(Envapter.get('WHITESPACE_KEY', 'default'), 'default');
+    } finally {
+        Envapter.strict = false;
+    }
+}
+
+async function debugMode() {
+    Envapter.envPaths = FIXTURE_PATH;
+    const captured = [];
+    const orig = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (chunk) => {
+        captured.push(typeof chunk === 'string' ? chunk : String(chunk));
+        return true;
+    };
+    try {
+        Envapter.debug = 'verbose';
+        Envapter.envPaths = FIXTURE_PATH;
+        const emitted = captured.some((line) => line.includes('[envapt]') && line.includes('cache cleared'));
+        assert.ok(emitted, 'expected [envapt] cache-cleared line under verbose');
+    } finally {
+        process.stderr.write = orig;
+        Envapter.debug = 'silent';
+    }
+}
+
+async function syncProcessEnv() {
+    Envapter.envPaths = FIXTURE_PATH;
+    Reflect.deleteProperty(process.env, 'BASIC_KEY');
+    try {
+        Envapter.syncProcessEnv = false;
+        assert.equal(Envapter.get('BASIC_KEY'), 'hello');
+        assert.equal(process.env.BASIC_KEY, undefined);
+
+        Envapter.syncProcessEnv = true;
+        assert.equal(process.env.BASIC_KEY, 'hello');
+    } finally {
+        Envapter.syncProcessEnv = false;
+        Reflect.deleteProperty(process.env, 'BASIC_KEY');
+    }
+}
+
+async function requireHelper() {
+    Envapter.envPaths = FIXTURE_PATH;
+    Envapter.require('BASIC_KEY', 'NUMBER_KEY');
+
+    assert.throws(
+        () => Envapter.require('MISSING_REQUIRED_KEY'),
+        (err) => err instanceof EnvaptError && err.code === EnvaptErrorCodes.MissingEnvValue
+    );
+}

--- a/packages/envapt/tests/integration/suites/_helpers.d.mts
+++ b/packages/envapt/tests/integration/suites/_helpers.d.mts
@@ -1,0 +1,1 @@
+export const FIXTURE_PATH: string;

--- a/packages/envapt/tests/integration/suites/_helpers.mjs
+++ b/packages/envapt/tests/integration/suites/_helpers.mjs
@@ -1,0 +1,7 @@
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// `import.meta.dirname` is Node 20.11+; the matrix covers Node 20.0+, Bun, and Deno.
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export const FIXTURE_PATH = resolve(HERE, '../fixture.env');


### PR DESCRIPTION
## Summary

Adds an integration smoke under `packages/envapt/tests/integration/` that imports the built `dist/index.mjs` and uses only `node:assert`, so it runs identically under Node, Bun, and Deno. CI matrix is 7 cells: Node 20/22/24 on ubuntu, Node 22 on macos + windows, Bun on ubuntu, Deno on ubuntu.

## Related issue

- Closes #85

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Internal refactor
- [ ] Documentation

## Scope check

- [x] This pull request focuses on one feature or closely related set of changes
- [x] No new packages or top level projects are introduced inside this repository
- [x] No core files have been copy pasted into new folders
- [x] Changes are limited to the existing `envapt/src` tree and necessary tests or docs

## Implementation notes

### Architecture

```
packages/envapt/tests/integration/
  fixture.env                      # 10 keys covering every converter shape
  run.mjs                          # runtime detect + hardcoded suite list + exit code
  deno.json                        # experimentalDecorators: true for the Deno cell
  suites/
    _helpers.mjs                   # FIXTURE_PATH (portable across Node 20.0+, Bun, Deno)
    _helpers.d.mts                 # TS declarations so 05b can import from _helpers.mjs
    01-basic-get.mjs               # get/raw/missing
    02-converters.mjs              # number, boolean, bigint, json, url, date, array
    03-fallbacks.mjs               # fallback used + type-mismatch throws via getUsing
    04-missing-file.mjs            # EnvFilesNotFound throw + recovery
    05-decorator.mjs               # manual `Envapt(...)(Class, prop)` (runtime helper path)
    05b-decorator-syntax.ts        # `@Envapt` syntax via Deno's TS transpiler (Deno only)
    06-v5-features.mjs             # strict, debug verbose, syncProcessEnv, require
```

### CI matrix

```
build (ubuntu-latest, node 24.16.0)
  uploads packages/envapt/{dist,tests/integration} as one artifact
  compression-level: 0 (already-minified ESM compresses poorly)

  test-node   Node 20 / ubuntu
              Node 22 / ubuntu
              Node 24 / ubuntu
              Node 22 / macos
              Node 22 / windows
  test-bun    Bun 1.3.x / ubuntu
  test-deno   Deno 2.7.x / ubuntu (--config packages/envapt/tests/integration/deno.json)

cross-runtime-ok  (needs: all above, if: always())     <- the required check
```

Multi-OS coverage at the Node 22 cell catches Windows path separators and CRLF line endings in `.env` parsing. Bun and Deno are ubuntu-only because their OS-variant divergences are engine bugs, not envapt bugs (see e.g. [bun#16907](https://github.com/oven-sh/bun/issues/16907), [bun#23831](https://github.com/oven-sh/bun/issues/23831)). Docker base images are not tested because a pure-JS library with no native deps gives identical behavior on alpine/musl/glibc vs ubuntu/glibc.

### Runtime portability

- **Path resolution**: `_helpers.mjs` uses `dirname(fileURLToPath(import.meta.url))` because `import.meta.dirname` is Node 20.11+ only and `engines.node` floor is 20.0.
- **05-decorator.mjs**: calls `Envapt(key, opts)(Class, prop)` directly. This is the runtime-helper call shape consumers hit when their bundler (`tsc` / `tsdown` / Vite) emits `__decorate(...)` for `@Envapt`. Works on every runtime.
- **05b-decorator-syntax.ts**: exercises real `@Envapt` syntax through the host's TS transpiler. Deno only (see Known Limitation).
- **deno.json**: `experimentalDecorators: true` so Deno emits legacy decorator semantics. Deno emits a deprecation warning (`"experimentalDecorators compiler option is deprecated and may be removed at any time"`) which is the canary: when Deno removes the flag, 05b fails and we act.
- **No `pnpm install` in matrix cells**: cells need only the runtime binary plus the downloaded artifact, so install is skipped.

### Known limitation: Bun direct-`.ts` execution with `@Envapt`

**Bun 1.3.10+ ignores `experimentalDecorators` and always emits TC39 Stage 3 decorators** ([bun#27575](https://github.com/oven-sh/bun/issues/27575)). envapt's `@Envapt` is a legacy TypeScript decorator with a 2-arg `(target, propKey)` install signature; Stage 3 calls with `(value, context)`. The shapes are incompatible.

Practical impact for Bun users:

| Workflow                                                                | Result |
| ----------------------------------------------------------------------- | ------ |
| `Envapter.get()` etc. (functional API), any path                        | Works  |
| `@Envapt` syntax, precompiled with tsc/tsdown/Vite, `bun ./dist/app.js` | Works  |
| `@Envapt` syntax, `bun ./app.ts` direct                                 | Broken |

The compiled `dist/index.mjs` envapt publishes to npm is fine in every runtime; the breakage is at the **user's call site**, depending on who transpiled their decorator syntax. tsdown/tsc honor `experimentalDecorators`; Bun does not.

A Stage 3 migration is blocked by (a) [tsdown / Rolldown / Oxc do not emit Stage 3 yet](https://tsdown.dev/options/target) and (b) `experimentalDecorators: true` is per-compilation in the consumer's project ([TS PR #50820](https://github.com/microsoft/TypeScript/pull/50820)), so a Stage 3 envapt would silently break every TypeORM / NestJS user who needs that flag on. envapt stays on legacy for v5; the limitation is documented in the changeset, and the upcoming docs rebuild (#87) will surface it on the compatibility page.

## TypeScript and safety

- [x] New code is written in strict TypeScript
- [x] No new `any` types were introduced (if they were, explain why)
- [x] No `value as any` style casts were added to bypass the type system
- [x] No unnecessary type casts were added
- [x] Existing strict TypeScript settings were not disabled or loosened
- [x] New code has complete type coverage (no `@ts-ignore` or missing types)
- [x] New code uses proper TypeScript generics or unions where applicable
- [x] Public types and signatures are well defined and documented where needed

`_helpers.d.mts` provides type declarations so `05b-decorator-syntax.ts` can import `FIXTURE_PATH` from the plain-JS `_helpers.mjs` without an implicit-any. Integration `.mjs` files are excluded from `tsc` by extension and from the package `lint` script's `.{ts,tsx}` glob; the eslint override on `tests/integration/**` is for IDE diagnostics only.

## Tests

- [x] `pnpm lint` passes with zero lint errors
- [x] `pnpm test` passes locally
- [x] `pnpm coverage` passes locally without new coverage gaps
- [x] New or updated tests cover the behavior in this pull request

Local pre-push verification (all on macOS host):

- Node 25.9.0: 6/6 suites pass (05b skipped per runtime gate)
- Bun 1.3.14: 6/6 suites pass (05b skipped per runtime gate)
- Deno 2.7.12 with `--config deno.json`: 7/7 suites pass (05b included; expected deprecation warning)

Windows cells, the Node 20/22/24 / ubuntu cells, and CI orchestration are first-pass-verified by the workflow when this PR runs.

Full Vitest suite untouched: 24 files, 500 tests, 100% coverage on every source file.

## Docs and changesets

- [ ] README or other docs were updated if behavior changed
- [x] A changeset was added with `pnpm cs add`, uses the correct bump level, and has a clear summary

`.changeset/cross-runtime-tests.md`: `patch` bump. Calls out the Bun direct-`.ts` limitation in the user-visible changelog so npm users hit the workaround guidance before they hit the error.

## Checklist

- [x] I have read and followed `CONTRIBUTING.md`
- [x] Commit messages and PR title follow Conventional Commits
- [x] CI is expected to pass for this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)