### PR TITLE
ci: add a reusable setup action and harden the workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,32 @@
+name: 'Setup workspace'
+description: 'Install pnpm, set up Node with the pnpm cache, and restore deps via pnpm install --frozen-lockfile.'
+
+inputs:
+    node-version:
+        description: 'Node.js version'
+        required: false
+        default: '24.16.0'
+    registry-url:
+        description: 'npm registry URL (set on publish jobs so npm auth resolves)'
+        required: false
+        default: ''
+    install:
+        description: 'Run pnpm install --frozen-lockfile as the final step'
+        required: false
+        default: 'true'
+
+runs:
+    using: composite
+    steps:
+        - name: Set up pnpm
+          uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6
+        - name: Set up Node.js
+          uses: actions/setup-node@v6
+          with:
+              node-version: ${{ inputs.node-version }}
+              cache: pnpm
+              registry-url: ${{ inputs.registry-url }}
+        - name: Install dependencies
+          if: ${{ inputs.install == 'true' }}
+          shell: bash
+          run: pnpm install --frozen-lockfile

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,16 +3,34 @@ name: checks
 on:
     workflow_call:
     pull_request:
+        types: [opened, reopened, synchronize, ready_for_review]
+        paths-ignore:
+            - '**/*.md'
+            - '.vscode/**'
+            - '.changeset/**'
+            - '.github/ISSUE_TEMPLATE/**'
+            - '.github/PULL_REQUEST_TEMPLATE.md'
     push:
         branches-ignore: [main, next]
+        paths-ignore:
+            - '**/*.md'
+            - '.vscode/**'
+            - '.changeset/**'
+            - '.github/ISSUE_TEMPLATE/**'
+            - '.github/PULL_REQUEST_TEMPLATE.md'
 
 concurrency:
     group: checks-${{ github.ref }}
     cancel-in-progress: true
 
+permissions:
+    contents: read
+
 jobs:
     run-checks:
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
         runs-on: ubuntu-latest
+        timeout-minutes: 25
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
@@ -24,21 +42,16 @@ jobs:
                   turbo_token: ${{ secrets.TURBO_TOKEN }}
                   turbo_team: ${{ vars.TURBO_TEAM }}
                   enable_fallback_cache: 'true'
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-            - name: Setup Node.js
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24.16.0
-                  cache: pnpm
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup workspace
+              uses: ./.github/actions/setup
             - name: Build project
               run: pnpm build
             - name: Verify portable builds are node-free
               run: pnpm --filter envapt build:verify
             - name: Run type check
               run: pnpm tc
+            - name: Check formatting
+              run: pnpm fmt:check
             - name: Run lint
               run: pnpm lint
             - name: Run tests

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
     commitlint:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
         concurrency:
             group: commitlint-${{ github.ref }}
             cancel-in-progress: true
@@ -18,15 +19,8 @@ jobs:
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-            - name: Setup Node.js
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24.16.0
-                  cache: pnpm
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup workspace
+              uses: ./.github/actions/setup
             - name: Lint last commit
               if: github.event_name == 'push'
               run: pnpm exec commitlint --last --verbose

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,26 +4,26 @@ on:
     pull_request:
     push:
 
+permissions:
+    contents: read
+
 env:
     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
 jobs:
     coverage:
         runs-on: ubuntu-latest
+        timeout-minutes: 25
         steps:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - uses: pnpm/action-setup@v6
-            - uses: actions/setup-node@v6
-              with:
-                  node-version: 24.16.0
-                  cache: pnpm
-            - run: pnpm install --frozen-lockfile
+            - name: Setup workspace
+              uses: ./.github/actions/setup
             - run: pnpm build
             - run: pnpm tc
             - run: pnpm coverage
-            - uses: codecov/codecov-action@v6
+            - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
               with:
                   files: coverage/lcov.info
                   fail_ci_if_error: true

--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -18,16 +18,13 @@ jobs:
     build:
         name: Build dist artifact
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         steps:
             - uses: actions/checkout@v6
               with:
                   fetch-depth: 1
-            - uses: pnpm/action-setup@v6
-            - uses: actions/setup-node@v6
-              with:
-                  node-version: 24.16.0
-                  cache: pnpm
-            - run: pnpm install --frozen-lockfile
+            - name: Setup workspace
+              uses: ./.github/actions/setup
             - run: pnpm --filter envapt build
             - uses: actions/upload-artifact@v4
               with:
@@ -42,6 +39,7 @@ jobs:
         name: node ${{ matrix.node }} / ${{ matrix.os }}
         needs: build
         runs-on: ${{ matrix.os }}
+        timeout-minutes: 15
         strategy:
             fail-fast: false
             matrix:
@@ -65,8 +63,9 @@ jobs:
         name: bun / ubuntu
         needs: build
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
-            - uses: oven-sh/setup-bun@v2
+            - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
               with:
                   bun-version: 1.3.x
             - uses: actions/download-artifact@v4
@@ -79,8 +78,9 @@ jobs:
         name: deno / ubuntu
         needs: build
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         steps:
-            - uses: denoland/setup-deno@v2
+            - uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
               with:
                   deno-version: v2.7.x
             - uses: actions/download-artifact@v4
@@ -94,6 +94,7 @@ jobs:
         needs: [test-node, test-bun, test-deno]
         if: always()
         runs-on: ubuntu-latest
+        timeout-minutes: 5
         steps:
             - name: Verify every runtime job succeeded
               run: |

--- a/.github/workflows/deploy-guide.yml
+++ b/.github/workflows/deploy-guide.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
     deploy:
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
@@ -36,15 +37,8 @@ jobs:
                   turbo_token: ${{ secrets.TURBO_TOKEN }}
                   turbo_team: ${{ vars.TURBO_TEAM }}
                   enable_fallback_cache: 'true'
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-            - name: Setup Node.js
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24.16.0
-                  cache: pnpm
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup workspace
+              uses: ./.github/actions/setup
             - name: Build
               run: pnpm build
               env:
@@ -52,7 +46,7 @@ jobs:
 
             - name: Deploy production
               if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-              uses: cloudflare/wrangler-action@v4
+              uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -62,7 +56,7 @@ jobs:
 
             - name: Deploy next docs
               if: github.event_name == 'push' && github.ref == 'refs/heads/next'
-              uses: cloudflare/wrangler-action@v4
+              uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
@@ -73,8 +67,10 @@ jobs:
             - name: Compute preview alias
               if: github.event_name == 'pull_request'
               id: alias
+              env:
+                  HEAD_REF: ${{ github.head_ref }}
               run: |
-                  alias="$(printf '%s' "${{ github.head_ref }}" \
+                  alias="$(printf '%s' "$HEAD_REF" \
                     | tr '[:upper:]' '[:lower:]' \
                     | tr -c 'a-z0-9' '-' \
                     | sed -E 's/-+/-/g; s/^-+//; s/-+$//' \
@@ -84,7 +80,7 @@ jobs:
                   echo "url=https://$alias-envapt.materwelon.workers.dev" >> "$GITHUB_OUTPUT"
             - name: Deploy preview
               if: github.event_name == 'pull_request'
-              uses: cloudflare/wrangler-action@v4
+              uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4
               with:
                   apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                   accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -1,0 +1,28 @@
+name: lint-actions
+
+on:
+    pull_request:
+        paths:
+            - '.github/workflows/**'
+            - '.github/actions/**'
+    push:
+        branches:
+            - main
+            - next
+        paths:
+            - '.github/workflows/**'
+            - '.github/actions/**'
+
+permissions:
+    contents: read
+
+jobs:
+    actionlint:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        steps:
+            - uses: actions/checkout@v6
+            - name: actionlint
+              run: |
+                  curl -sSfL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash | bash -s -- 1.7.12
+                  ./actionlint -color

--- a/.github/workflows/publish-deno-only.yml
+++ b/.github/workflows/publish-deno-only.yml
@@ -60,9 +60,9 @@ jobs:
               run: |
                   pkg="${{ github.event.inputs.package }}"
                   if [ -n "$pkg" ]; then
-                    echo "search_root=packages/$pkg" >> $GITHUB_OUTPUT
+                    echo "search_root=packages/$pkg" >> "$GITHUB_OUTPUT"
                   else
-                    echo "search_root=packages" >> $GITHUB_OUTPUT
+                    echo "search_root=packages" >> "$GITHUB_OUTPUT"
                   fi
         outputs:
             search_root: ${{ steps.set_root.outputs.search_root }}

--- a/.github/workflows/publish-deno-only.yml
+++ b/.github/workflows/publish-deno-only.yml
@@ -21,20 +21,23 @@ jobs:
         name: Publish to JSR (Deno) only
         needs: determine_search_root
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
 
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
+            - name: Setup workspace
+              uses: ./.github/actions/setup
+              with:
+                  install: 'false'
 
             - name: Install dependencies (hoisted node_modules for Deno)
               run: pnpm install --frozen-lockfile --shamefully-hoist
 
             - name: Setup Deno
-              uses: denoland/setup-deno@v2
+              uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
               with:
                   deno-version: 2.7.14
                   cache: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,20 +27,14 @@ jobs:
     dry-run-npm:
         needs: [checks]
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-            - name: Setup Node.js
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24.16.0
-                  cache: pnpm
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup workspace
+              uses: ./.github/actions/setup
             - name: Publish package (dry run)
               run: pnpm publish --dry-run --no-git-checks
 
@@ -48,17 +42,16 @@ jobs:
         needs: [checks]
         if: ${{ github.ref_name == 'main' }}
         runs-on: ubuntu-latest
+        timeout-minutes: 20
         steps:
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup workspace
+              uses: ./.github/actions/setup
             - name: Setup Deno
-              uses: denoland/setup-deno@v2
+              uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
               with:
                   deno-version: 2.7.14
             - name: Deno publish dry run
@@ -76,6 +69,7 @@ jobs:
             && needs.dry-run-npm.result == 'success'
             && (needs.dry-run-jsr.result == 'success' || needs.dry-run-jsr.result == 'skipped') }}
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         outputs:
             published: ${{ steps.changesets.outputs.published }}
         permissions:
@@ -94,13 +88,9 @@ jobs:
                   turbo_token: ${{ secrets.TURBO_TOKEN }}
                   turbo_team: ${{ vars.TURBO_TEAM }}
                   enable_fallback_cache: 'true'
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-            - name: Setup Node.js
-              uses: actions/setup-node@v6
+            - name: Setup workspace
+              uses: ./.github/actions/setup
               with:
-                  node-version: 24.16.0
-                  cache: pnpm
                   registry-url: https://registry.npmjs.org
             - name: Update npm to latest
               run: npm i -g npm@latest
@@ -108,8 +98,6 @@ jobs:
               run: node -v && npm -v
             - name: Check npm registry and ping
               run: npm config get registry && npm ping
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
             - name: Release preflight
               id: preflight
               run: pnpm tsx scripts/release-preflight.ts
@@ -125,7 +113,7 @@ jobs:
             - name: Run changesets
               id: changesets
               if: ${{ steps.preflight.outputs.run == 'true' }}
-              uses: changesets/action@v1
+              uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
               with:
                   version: pnpm run release:version
                   publish: pnpm run release
@@ -149,12 +137,10 @@ jobs:
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v6
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+            - name: Setup workspace
+              uses: ./.github/actions/setup
             - name: Setup Deno
-              uses: denoland/setup-deno@v2
+              uses: denoland/setup-deno@667a34cdef165d8d2b2e98dde39547c9daac7282 # v2
               with:
                   deno-version: 2.7.14
                   cache: true

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -8,13 +8,14 @@ permissions:
 jobs:
     labels:
         runs-on: ubuntu-latest
+        timeout-minutes: 10
 
         steps:
             - uses: actions/checkout@v6
               with:
                   sparse-checkout: .github/labels.yml
 
-            - uses: EndBug/label-sync@v2
+            - uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2
               with:
                   config-file: .github/labels.yml
                   delete-other-labels: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,6 @@
     "files.insertFinalNewline": true,
     "files.trimFinalNewlines": true,
     "editor.codeActionsOnSave": {
-        "source.fixAll": "explicit",
         "source.fixAll.eslint": "explicit"
     },
 
@@ -22,6 +21,7 @@
     "eslint.format.enable": false,
     "eslint.lintTask.enable": true,
     "eslint.codeActionsOnSave.mode": "all",
+    "eslint.codeActionsOnSave.rules": ["!prettier/prettier", "*"],
     "eslint.workingDirectories": [{ "mode": "auto" }],
 
     // EditorConfig Support

--- a/apps/guide/components/EnvLoading.tsx
+++ b/apps/guide/components/EnvLoading.tsx
@@ -66,7 +66,7 @@ function CascadeStack(): ReactNode {
                 load order · most-specific wins
             </p>
             <ol className="flex flex-col gap-2">
-                <li className="rounded-lg border border-fd-border border-l-2 border-l-(--ev-teal) bg-(--ev-panel)">
+                <li className="rounded-lg border border-l-2 border-fd-border border-l-(--ev-teal) bg-(--ev-panel)">
                     <div className="flex items-center justify-between px-3 py-2">
                         <span className="font-mono text-[12.5px]">.env.production.local</span>
                         <span className="font-mono text-[11px] text-(--ev-teal)">wins</span>


### PR DESCRIPTION
## Summary

- Harden the CI workflows and dedupe the per-job pnpm and Node setup

## Related issue

- None

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Internal refactor
- [ ] Documentation

## Scope check

- [x] This pull request focuses on one feature or closely related set of changes
- [x] No new packages or top level projects are introduced inside this repository
- [x] No core files have been copy pasted into new folders
- [ ] Changes are limited to the existing `envapt/src` tree and necessary tests or docs

## Implementation notes

- Add a `setup` composite action used across the workflows, so the Node and pnpm versions are defined once
- Pin every third-party action to a commit SHA
- Add a `lint-actions` workflow that runs actionlint on `.github` changes
- Run `fmt:check` in the `checks` workflow
- Skip `checks` on draft PRs and markdown-only changes
- Add `timeout-minutes` to the jobs

## TypeScript and safety

- [x] New code is written in strict TypeScript
- [x] No new `any` types were introduced (if they were, explain why)
- [x] No `value as any` style casts were added to bypass the type system
- [x] No unnecessary type casts were added
- [x] Existing strict TypeScript settings were not disabled or loosened
- [x] New code has complete type coverage (no `@ts-ignore` or missing types)
- [x] New code uses proper TypeScript generics or unions where applicable
- [x] Public types and signatures are well defined and documented where needed

## Tests

- [x] `pnpm lint` passes with zero lint errors (without the need for unnecessary `/* eslint-disable */` comments or changes to existing lint rules)
- [x] `pnpm test` passes locally
- [x] `pnpm coverage` passes locally without new coverage gaps
- [ ] New or updated tests cover the behavior in this pull request

- No tests changed. Validated with actionlint and `fmt:check`, and CI is green on the branch

## Docs and changesets

- [ ] README or other docs were updated if behavior changed
- [ ] A changeset was added with `pnpm cs add`, uses the correct bump level, and has a clear summary

## Checklist

- [ ] I have read and followed `CONTRIBUTING.md`
- [x] Commit messages and PR title follow Conventional Commits
- [x] CI is expected to pass for this branch
