### PR TITLE
Add real-runtime test suites and JSR prerelease publishing

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -102,6 +102,18 @@ Pull requests that do not pass CI will not be reviewed in detail.
 - Add regression tests for bug fixes
 - Tests should be clear and easy to understand
 
+### Running the tests
+
+`pnpm test` runs the fast offline unit suite (Node) and covers most changes. The portable build also ships to Cloudflare Workers and the browser, so those runtimes have dedicated suites that stay out of the default run and read the built `dist/`:
+
+- `pnpm --filter envapt test:integration`, the Node, Bun, and Deno suites (Bun and Deno are skipped when not installed)
+- `pnpm --filter envapt test:workers`, the workerd suite on real workerd via `@cloudflare/vitest-pool-workers`
+- `pnpm --filter envapt test:browser`, the browser suite in headless Chromium (one-time `pnpm --filter envapt exec playwright install chromium`)
+- `pnpm --filter envapt test:consumer-build`, bundles `envapt` with esbuild for the browser and workerd conditions and asserts no `node:` built-ins leak in
+- `pnpm --filter envapt test:all`, builds once then runs every suite in parallel, skipping the browser suite when Chromium is absent
+
+Build the package before running the workerd or browser suite on its own, or use `test:all`, which builds first. CI runs all of them as parallel jobs.
+
 ## Questions?
 
 If you have questions or need help:

--- a/.github/workflows/cross-runtime.yml
+++ b/.github/workflows/cross-runtime.yml
@@ -89,9 +89,54 @@ jobs:
                   path: packages/envapt/
             - run: deno run -A --config packages/envapt/tests/integration/deno.json packages/envapt/tests/integration/run.mjs
 
+    test-workerd:
+        name: workerd
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1
+            - name: Setup workspace
+              uses: ./.github/actions/setup
+            - run: pnpm --filter envapt build
+            - run: pnpm --filter envapt test:workers
+
+    test-browser:
+        name: browser
+        runs-on: ubuntu-latest
+        timeout-minutes: 20
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1
+            - name: Setup workspace
+              uses: ./.github/actions/setup
+            - name: Cache Playwright browsers
+              uses: actions/cache@v4
+              with:
+                  path: ~/.cache/ms-playwright
+                  key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+            - run: pnpm --filter envapt exec playwright install --with-deps chromium
+            - run: pnpm --filter envapt build
+            - run: pnpm --filter envapt test:browser
+
+    test-consumer-build:
+        name: consumer-build
+        runs-on: ubuntu-latest
+        timeout-minutes: 15
+        steps:
+            - uses: actions/checkout@v6
+              with:
+                  fetch-depth: 1
+            - name: Setup workspace
+              uses: ./.github/actions/setup
+            - run: pnpm --filter envapt build
+            - run: pnpm --filter envapt test:consumer-build
+
     cross-runtime-ok:
         name: cross-runtime ok
-        needs: [test-node, test-bun, test-deno]
+        needs: [test-node, test-bun, test-deno, test-workerd, test-browser, test-consumer-build]
         if: always()
         runs-on: ubuntu-latest
         timeout-minutes: 5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,29 @@ jobs:
         uses: ./.github/workflows/cross-runtime.yml
         secrets: inherit
 
-    dry-run-npm:
+    preflight:
         needs: [checks]
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
+        outputs:
+            run: ${{ steps.preflight.outputs.run }}
+            publish_jsr: ${{ steps.preflight.outputs.publish_jsr }}
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v6
+              with:
+                  fetch-depth: 0
+            - name: Setup workspace
+              uses: ./.github/actions/setup
+            - name: Release preflight
+              id: preflight
+              run: pnpm tsx scripts/release-preflight.ts
+              env:
+                  GITHUB_REF_NAME: ${{ github.ref_name }}
+
+    dry-run-npm:
+        needs: [preflight]
+        if: ${{ needs.preflight.outputs.run == 'true' || needs.preflight.outputs.publish_jsr == 'true' }}
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
@@ -39,8 +60,8 @@ jobs:
               run: pnpm publish --dry-run --no-git-checks
 
     dry-run-jsr:
-        needs: [checks]
-        if: ${{ github.ref_name == 'main' }}
+        needs: [preflight]
+        if: ${{ needs.preflight.outputs.run == 'true' || needs.preflight.outputs.publish_jsr == 'true' }}
         runs-on: ubuntu-latest
         timeout-minutes: 20
         steps:
@@ -61,17 +82,15 @@ jobs:
                   dry-run: 'true'
 
     npm-publish:
-        needs: [checks, cross-runtime, dry-run-npm, dry-run-jsr]
+        needs: [preflight, cross-runtime, dry-run-npm, dry-run-jsr]
         if: >-
             ${{ !cancelled()
-            && needs.checks.result == 'success'
+            && needs.preflight.outputs.run == 'true'
             && needs.cross-runtime.result == 'success'
             && needs.dry-run-npm.result == 'success'
-            && (needs.dry-run-jsr.result == 'success' || needs.dry-run-jsr.result == 'skipped') }}
+            && needs.dry-run-jsr.result == 'success' }}
         runs-on: ubuntu-latest
         timeout-minutes: 30
-        outputs:
-            published: ${{ steps.changesets.outputs.published }}
         permissions:
             contents: write
             id-token: write
@@ -98,21 +117,12 @@ jobs:
               run: node -v && npm -v
             - name: Check npm registry and ping
               run: npm config get registry && npm ping
-            - name: Release preflight
-              id: preflight
-              run: pnpm tsx scripts/release-preflight.ts
-              env:
-                  GITHUB_REF_NAME: ${{ github.ref_name }}
             - name: Determine release metadata
               id: release_meta
-              if: ${{ steps.preflight.outputs.run == 'true' }}
               uses: ./.github/actions/release-metadata
             - name: Run prepublishOnly script
-              if: ${{ steps.preflight.outputs.run == 'true' }}
               run: pnpm run prepublishOnly
             - name: Run changesets
-              id: changesets
-              if: ${{ steps.preflight.outputs.run == 'true' }}
               uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
               with:
                   version: pnpm run release:version
@@ -125,8 +135,13 @@ jobs:
                   HUSKY: 0
 
     jsr-publish:
-        needs: [npm-publish]
-        if: ${{ needs.npm-publish.outputs.published == 'true' && github.ref_name == 'main' }}
+        needs: [preflight, cross-runtime, dry-run-npm, dry-run-jsr]
+        if: >-
+            ${{ !cancelled()
+            && needs.preflight.outputs.publish_jsr == 'true'
+            && needs.cross-runtime.result == 'success'
+            && needs.dry-run-npm.result == 'success'
+            && needs.dry-run-jsr.result == 'success' }}
         runs-on: ubuntu-latest
         timeout-minutes: 30
         permissions:

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "scripts": {
         "build": "turbo build",
         "dev": "turbo dev",
-        "lint": "turbo lint",
-        "lint:fix": "turbo lint:fix",
+        "lint": "turbo lint && eslint 'scripts/**/*.{ts,mjs,cjs}' --cache",
+        "lint:fix": "turbo lint:fix && eslint 'scripts/**/*.{ts,mjs,cjs}' --fix --cache",
         "lint:md": "markdownlint-cli2",
         "lint:fix:md": "markdownlint-cli2 --fix",
         "knip": "knip",

--- a/packages/envapt/eslint.config.mjs
+++ b/packages/envapt/eslint.config.mjs
@@ -4,24 +4,22 @@ export default createConfig({
     tsconfigRootDir: import.meta.dirname,
     userConfigs: [
         {
-            // Test files.
             files: ['tests/**/*.test.ts'],
             rules: {
                 '@typescript-eslint/no-unused-expressions': 'off',
                 'max-nested-callbacks': ['warn', 10],
                 'max-lines': ['warn', { max: 600 }],
 
-                // Decorator fixtures are static-only classes by design
+                // decorator fixtures are static-only classes by design
                 '@typescript-eslint/no-extraneous-class': 'off'
             }
         },
         {
-            // Type-error fixtures: intentionally broken code consumed by the compiler-API
-            // test at runtime. Excluded from the project's tsconfig + skipped by lint.
+            // intentionally broken code the compiler-API test reads at runtime, so it is excluded from tsconfig and skipped here
             ignores: ['tests/type-error-fixtures/**']
         },
         {
-            // Integration suites import the built dist/ off the node_modules resolver, so the linter
+            // integration suites import the built dist/ off the node_modules resolver, so the linter
             // cannot resolve those types and the decorator fixtures are static-only by design. Deno
             // also requires explicit `.mjs` on relative imports, and the assertion literals are intentional.
             files: ['tests/integration/**/*.mjs', 'tests/integration/**/*.ts'],
@@ -32,6 +30,36 @@ export default createConfig({
                 '@typescript-eslint/no-extraneous-class': 'off',
                 '@typescript-eslint/no-unsafe-call': 'off',
                 '@typescript-eslint/no-unsafe-member-access': 'off'
+            }
+        },
+        {
+            // Workers tests run on workerd via their own tsconfig (built dist + cloudflare:workers
+            // virtual module), neither of which the default project resolves.
+            files: ['tests/workers/**/*.ts'],
+            languageOptions: {
+                parserOptions: {
+                    project: ['./tests/workers/tsconfig.json'],
+                    tsconfigRootDir: import.meta.dirname
+                }
+            },
+            rules: {
+                'import/no-unresolved': 'off',
+                'import/no-useless-path-segments': 'off'
+            }
+        },
+        {
+            // Browser tests run in chromium via their own tsconfig (built dist + DOM + import.meta.env),
+            // none of which the default project resolves.
+            files: ['tests/browser/**/*.ts'],
+            languageOptions: {
+                parserOptions: {
+                    project: ['./tests/browser/tsconfig.json'],
+                    tsconfigRootDir: import.meta.dirname
+                }
+            },
+            rules: {
+                'import/no-unresolved': 'off',
+                'import/no-useless-path-segments': 'off'
             }
         }
     ]

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -77,8 +77,8 @@
         "build": "pnpm run clean && tsdown",
         "build:verify": "pnpm tsx scripts/verify-no-node.ts",
         "dev": "tsc --watch",
-        "lint": "eslint '{src,tests,scripts}/**/*.{ts,tsx}' --cache",
-        "lint:fix": "eslint '{src,tests,scripts}/**/*.{ts,tsx}' --fix --cache",
+        "lint": "eslint '{src,tests,scripts}/**/*.{ts,tsx,mjs,cjs}' --cache",
+        "lint:fix": "eslint '{src,tests,scripts}/**/*.{ts,tsx,mjs,cjs}' --fix --cache",
         "fmt": "prettier --write '{src,tests,scripts}/**/*.{ts,tsx,json,md}' --cache",
         "fmt:check": "prettier --check '{src,tests,scripts}/**/*.{ts,tsx,json,md}' --cache",
         "fmt:all": "prettier --write .",
@@ -87,6 +87,10 @@
         "test": "vitest run",
         "test:watch": "vitest dev",
         "test:integration": "node tests/integration/run.mjs",
+        "test:workers": "tsc --noEmit -p tests/workers/tsconfig.json && vitest run --config vitest.workers.config.ts",
+        "test:browser": "tsc --noEmit -p tests/browser/tsconfig.json && vitest run --config vitest.browser.config.ts",
+        "test:consumer-build": "node tests/consumer-build/run.mjs",
+        "test:all": "node ../../scripts/test-all.mjs",
         "coverage": "pnpm run test --coverage",
         "cs": "changeset",
         "cs:publish": "changeset publish",
@@ -134,7 +138,13 @@
         "provenance": true
     },
     "devDependencies": {
+        "@cloudflare/vitest-pool-workers": "0.16.14",
+        "@cloudflare/workers-types": "^4.20260609.1",
+        "@vitest/browser": "4.1.7",
+        "@vitest/browser-playwright": "4.1.7",
         "arktype": "^2.2.0",
+        "esbuild": "^0.28.0",
+        "playwright": "1.60.0",
         "valibot": "^1.4.1",
         "zod": "catalog:dev"
     }

--- a/packages/envapt/tests/browser/01-typed-reads.test.ts
+++ b/packages/envapt/tests/browser/01-typed-reads.test.ts
@@ -1,0 +1,16 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { Converters, Envapter, ManualEnvSource } from '../../dist/browser/index.mjs';
+
+describe('envapt in the browser', () => {
+    beforeEach(() => {
+        Envapter.useSource(new ManualEnvSource({ APP: 'web', PORT: '443', FLAG: 'true', API: 'https://api.test/v1' }));
+    });
+
+    it('reads typed values from an injected source', () => {
+        expect(Envapter.get('APP')).toBe('web');
+        expect(Envapter.getNumber('PORT')).toBe(443);
+        expect(Envapter.getBoolean('FLAG')).toBe(true);
+        expect(Envapter.getUsing('API', Converters.Url)?.href).toBe('https://api.test/v1');
+    });
+});

--- a/packages/envapt/tests/browser/02-injection.test.ts
+++ b/packages/envapt/tests/browser/02-injection.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { Envapter, ManualEnvSource } from '../../dist/browser/index.mjs';
+
+describe('browser config injection', () => {
+    it('reads typed values from an import.meta.env-shaped object', () => {
+        const injected = { ...import.meta.env, VITE_API: 'https://x.test', VITE_PORT: '3000' };
+        Envapter.useSource(new ManualEnvSource(injected));
+        expect(Envapter.get('VITE_API')).toBe('https://x.test');
+        expect(Envapter.getNumber('VITE_PORT')).toBe(3000);
+    });
+
+    it('reads from a window.__ENV__ runtime injection', () => {
+        const win = window as Window & { __ENV__?: Record<string, unknown> };
+        win.__ENV__ = { RUNTIME_FLAG: 'true', LIMIT: '5' };
+        Envapter.useSource(new ManualEnvSource(win.__ENV__));
+        expect(Envapter.getBoolean('RUNTIME_FLAG')).toBe(true);
+        expect(Envapter.getNumber('LIMIT')).toBe(5);
+    });
+});

--- a/packages/envapt/tests/browser/03-canaries.test.ts
+++ b/packages/envapt/tests/browser/03-canaries.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Envapter, EnvaptError, EnvaptErrorCodes, ManualEnvSource } from '../../dist/browser/index.mjs';
+
+afterEach(() => {
+    Envapter.strict = false;
+    Envapter.debug = 'silent';
+});
+
+describe('browser portability canaries', () => {
+    it('a missing strict read throws EnvaptError, never a process ReferenceError', () => {
+        Envapter.useSource(new ManualEnvSource({ PRESENT: 'x' }));
+        Envapter.strict = true;
+        let err: unknown;
+        try {
+            Envapter.resolve`${'ABSENT'}`;
+        } catch (e) {
+            err = e;
+        }
+        expect(err).toBeInstanceOf(EnvaptError);
+        expect((err as EnvaptError).code).toBe(EnvaptErrorCodes.MissingEnvValue);
+    });
+
+    it('routes debug output to console, not process.stderr', () => {
+        Envapter.useSource(new ManualEnvSource({ PRESENT: 'x' }));
+        Envapter.debug = 'warn';
+        const spy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+        Envapter.get('MISSING_VAR', 'fallback-value');
+        expect(spy).toHaveBeenCalled();
+        expect(spy.mock.calls.some((call) => String(call[0]).includes('[envapt]'))).toBe(true);
+        spy.mockRestore();
+    });
+});

--- a/packages/envapt/tests/browser/tsconfig.json
+++ b/packages/envapt/tests/browser/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "../..",
+        "lib": ["ESNext", "DOM"],
+        "types": ["vite/client"]
+    },
+    "include": ["**/*.ts", "../../dist/browser/index.d.mts"],
+    "exclude": []
+}

--- a/packages/envapt/tests/consumer-build/run.mjs
+++ b/packages/envapt/tests/consumer-build/run.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as esbuild from 'esbuild';
+
+const resolveDir = dirname(fileURLToPath(import.meta.url));
+
+const program = (specifier) =>
+    `import { Envapter, WorkerEnvSource, ManualEnvSource, Converters } from '${specifier}';` +
+    `globalThis.__envapt = [Envapter, WorkerEnvSource, ManualEnvSource, Converters];`;
+
+// the browser/neutral platform makes esbuild hard-fail on any unresolved node built-in, so a clean
+// build is the real proof the resolved bundle is node-free and the output check below is a backup
+const cases = [
+    { name: "import 'envapt' (browser)", specifier: 'envapt', platform: 'browser', conditions: [] },
+    { name: "import 'envapt' (workerd)", specifier: 'envapt', platform: 'neutral', conditions: ['workerd'] },
+    { name: "import 'envapt/browser'", specifier: 'envapt/browser', platform: 'browser', conditions: [] },
+    { name: "import 'envapt/workerd'", specifier: 'envapt/workerd', platform: 'neutral', conditions: ['workerd'] }
+];
+
+let failures = 0;
+for (const testCase of cases) {
+    try {
+        const result = await esbuild.build({
+            stdin: { contents: program(testCase.specifier), resolveDir, loader: 'js' },
+            bundle: true,
+            write: false,
+            format: 'esm',
+            platform: testCase.platform,
+            conditions: testCase.conditions,
+            logLevel: 'silent'
+        });
+        const output = result.outputFiles[0].text;
+        assert.ok(!/["']node:[a-z]/.test(output), `${testCase.name}: bundle contains a node: specifier`);
+        process.stdout.write(`consumer-build ${testCase.name}: OK (${output.length} bytes, node-free)\n`);
+    } catch (err) {
+        failures += 1;
+        process.stderr.write(`consumer-build ${testCase.name}: FAIL\n`);
+        process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    }
+}
+
+if (failures > 0) {
+    process.stderr.write(`consumer-build: ${failures} bundle(s) pulled in node built-ins\n`);
+    process.exit(1);
+}
+process.stdout.write('consumer-build: every resolved bundle is node-free\n');

--- a/packages/envapt/tests/workers/01-worker-env-source.test.ts
+++ b/packages/envapt/tests/workers/01-worker-env-source.test.ts
@@ -1,0 +1,30 @@
+import { env } from 'cloudflare:workers';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { Converters, Envapter, WorkerEnvSource } from '../../dist/workerd/index.mjs';
+
+describe('WorkerEnvSource on workerd', () => {
+    beforeEach(() => {
+        Envapter.useSource(new WorkerEnvSource(env as Record<string, unknown>));
+    });
+
+    it('reads typed values from the Worker env binding', () => {
+        expect(Envapter.get('APP_NAME')).toBe('envapt');
+        expect(Envapter.getNumber('PORT')).toBe(8787);
+        expect(Envapter.getBoolean('DEBUG')).toBe(true);
+        expect(Envapter.getUsing('API_URL', Converters.Url)?.href).toBe('https://api.example.com/v1');
+    });
+
+    it('applies the array and json converters to bindings', () => {
+        expect(Envapter.getUsing('TAGS', Converters.array())).toEqual(['a', 'b', 'c']);
+        expect(Envapter.getUsing('FEATURES', Converters.Json)).toEqual({ beta: true });
+    });
+
+    it('expands ${VAR} template references inside a binding value', () => {
+        expect(Envapter.get('GREETING')).toBe('Hello envapt');
+    });
+
+    it('resolves the tagged template against bindings', () => {
+        expect(Envapter.resolve`${'APP_NAME'}:${'PORT'}`).toBe('envapt:8787');
+    });
+});

--- a/packages/envapt/tests/workers/02-portability-guards.test.ts
+++ b/packages/envapt/tests/workers/02-portability-guards.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+
+import { Envapter, EnvaptError, EnvaptErrorCodes, ManualEnvSource } from '../../dist/workerd/index.mjs';
+
+describe('portable build guards on workerd', () => {
+    it('throws FileApiUnsupported (306) when a filesystem API is used', () => {
+        Envapter.useSource(new ManualEnvSource({ FOO: 'bar' }));
+        try {
+            (Envapter as unknown as { baseDir: string }).baseDir = '/tmp';
+            expect.unreachable('baseDir setter should throw');
+        } catch (err) {
+            expect(err).toBeInstanceOf(EnvaptError);
+            expect((err as EnvaptError).code).toBe(EnvaptErrorCodes.FileApiUnsupported);
+        }
+    });
+
+    it('reads injected config from a ManualEnvSource', () => {
+        Envapter.useSource(new ManualEnvSource({ FLAG: 'true', COUNT: '42' }));
+        expect(Envapter.getBoolean('FLAG')).toBe(true);
+        expect(Envapter.getNumber('COUNT')).toBe(42);
+    });
+});

--- a/packages/envapt/tests/workers/03-converters-and-strict.test.ts
+++ b/packages/envapt/tests/workers/03-converters-and-strict.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Converters, Envapter, EnvaptError, EnvaptErrorCodes, ManualEnvSource } from '../../dist/workerd/index.mjs';
+
+afterEach(() => {
+    Envapter.strict = false;
+});
+
+describe('converters on workerd', () => {
+    it('coerces non-string bindings and reads them back typed', () => {
+        Envapter.useSource(new ManualEnvSource({ PORT: 8080, ENABLED: true, CFG: { a: 1 } }));
+        expect(Envapter.getNumber('PORT')).toBe(8080);
+        expect(Envapter.getBoolean('ENABLED')).toBe(true);
+        expect(Envapter.getUsing('CFG', Converters.Json)).toEqual({ a: 1 });
+    });
+
+    it('applies url, regexp, date, and time converters', () => {
+        Envapter.useSource(
+            new ManualEnvSource({
+                URL: 'https://x.test/p',
+                RE: '^a.c$',
+                WHEN: '2020-01-02T03:04:05.000Z',
+                TTL: '1.5h'
+            })
+        );
+        expect(Envapter.getUsing('URL', Converters.Url)?.host).toBe('x.test');
+        expect(Envapter.getUsing('RE', Converters.Regexp)?.test('abc')).toBe(true);
+        expect(Envapter.getUsing('WHEN', Converters.Date)?.getUTCFullYear()).toBe(2020);
+        expect(Envapter.getUsing('TTL', Converters.Time)).toBe(5_400_000);
+    });
+
+    it('reads a delimited array binding', () => {
+        Envapter.useSource(new ManualEnvSource({ HOSTS: 'a.test;b.test' }));
+        const hosts = Envapter.getUsing('HOSTS', Converters.array({ of: Converters.String, delimiter: ';' }));
+        expect(hosts).toEqual(['a.test', 'b.test']);
+    });
+});
+
+describe('strict mode and require on workerd', () => {
+    it('throws MissingEnvValue (305) for a missing strict template read', () => {
+        Envapter.useSource(new ManualEnvSource({ PRESENT: 'yes' }));
+        Envapter.strict = true;
+        try {
+            Envapter.resolve`${'ABSENT'}`;
+            expect.unreachable('strict resolve of a missing var should throw');
+        } catch (err) {
+            expect(err).toBeInstanceOf(EnvaptError);
+            expect((err as EnvaptError).code).toBe(EnvaptErrorCodes.MissingEnvValue);
+        }
+    });
+
+    it('require() throws when a key is missing', () => {
+        Envapter.useSource(new ManualEnvSource({ A: '1' }));
+        try {
+            Envapter.require('A', 'B');
+            expect.unreachable('require should throw when B is missing');
+        } catch (err) {
+            expect(err).toBeInstanceOf(EnvaptError);
+            expect((err as EnvaptError).code).toBe(EnvaptErrorCodes.MissingEnvValue);
+        }
+    });
+});

--- a/packages/envapt/tests/workers/tsconfig.json
+++ b/packages/envapt/tests/workers/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "rootDir": "../..",
+        "types": ["@cloudflare/workers-types"]
+    },
+    "include": ["**/*.ts", "../../dist/workerd/index.d.mts"],
+    "exclude": []
+}

--- a/packages/envapt/tsconfig.json
+++ b/packages/envapt/tsconfig.json
@@ -5,6 +5,20 @@
         "lib": ["ESNext", "Decorators.Legacy"],
         "rootDir": "."
     },
-    "include": ["src/**/*", "tests/**/*", "scripts/**/*", "tsdown.config.ts"],
-    "exclude": ["node_modules", "dist", "tests/type-error-fixtures/**"]
+    "include": [
+        "src/**/*",
+        "tests/**/*",
+        "scripts/**/*",
+        "tsdown.config.ts",
+        "vitest.workers.config.ts",
+        "vitest.browser.config.ts"
+    ],
+    "exclude": [
+        "node_modules",
+        "dist",
+        "tests/type-error-fixtures/**",
+        "tests/workers/**",
+        "tests/browser/**",
+        "tests/consumer-build/**"
+    ]
 }

--- a/packages/envapt/vitest.browser.config.ts
+++ b/packages/envapt/vitest.browser.config.ts
@@ -1,0 +1,15 @@
+import { playwright } from '@vitest/browser-playwright';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        include: ['tests/browser/**/*.test.ts'],
+        coverage: { enabled: false },
+        browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [{ browser: 'chromium' }]
+        }
+    }
+});

--- a/packages/envapt/vitest.workers.config.ts
+++ b/packages/envapt/vitest.workers.config.ts
@@ -1,0 +1,27 @@
+import { cloudflareTest } from '@cloudflare/vitest-pool-workers';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    plugins: [
+        cloudflareTest({
+            miniflare: {
+                compatibilityDate: '2024-09-23',
+                compatibilityFlags: [],
+                bindings: {
+                    APP_NAME: 'envapt',
+                    PORT: '8787',
+                    DEBUG: 'true',
+                    API_URL: 'https://api.example.com/v1',
+                    FEATURES: '{"beta":true}',
+                    GREETING: 'Hello ${APP_NAME}',
+                    TAGS: 'a,b,c',
+                    TIMEOUT: '1.5h'
+                }
+            }
+        })
+    ],
+    test: {
+        include: ['tests/workers/**/*.test.ts'],
+        coverage: { enabled: false }
+    }
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,7 +60,7 @@ importers:
         version: 25.9.1
       '@vitest/coverage-v8':
         specifier: ^4.1.7
-        version: 4.1.7(vitest@4.1.7)
+        version: 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
       eslint:
         specifier: catalog:dev
         version: 9.39.2(jiti@2.7.0)
@@ -99,7 +99,7 @@ importers:
         version: 8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
   apps/guide:
     dependencies:
@@ -199,16 +199,34 @@ importers:
         version: 6.0.3
       wrangler:
         specifier: ^4.95.0
-        version: 4.95.0
+        version: 4.95.0(@cloudflare/workers-types@4.20260609.1)
       zod:
         specifier: catalog:dev
         version: 4.4.3
 
   packages/envapt:
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: 0.16.14
+        version: 0.16.14(@cloudflare/workers-types@4.20260609.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7)
+      '@cloudflare/workers-types':
+        specifier: ^4.20260609.1
+        version: 4.20260609.1
+      '@vitest/browser':
+        specifier: 4.1.7
+        version: 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/browser-playwright':
+        specifier: 4.1.7
+        version: 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
       arktype:
         specifier: ^2.2.0
         version: 2.2.0
+      esbuild:
+        specifier: ^0.28.0
+        version: 0.28.0
+      playwright:
+        specifier: 1.60.0
+        version: 1.60.0
       valibot:
         specifier: ^1.4.1
         version: 1.4.1(typescript@6.0.3)
@@ -376,6 +394,9 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@blazediff/core@1.9.1':
+    resolution: {integrity: sha512-ehg3jIkYKulZh+8om/O25vkvSsXXwC+skXmyA87FFx6A/45eqOkZsBltMw/TVteb0mloiGT8oGRTcjRAz66zaA==}
+
   '@changesets/apply-release-plan@7.1.1':
     resolution: {integrity: sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA==}
 
@@ -444,8 +465,21 @@ packages:
       workerd:
         optional: true
 
+  '@cloudflare/vitest-pool-workers@0.16.14':
+    resolution: {integrity: sha512-QEoC+S0qhT/60Yy/9H96hmVDOSEc0lEV2HiBTCVB0xepXc96ig6bWxPyeDXmafOYv/cNiyarS8eP+CK8WjT46A==}
+    peerDependencies:
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: ^4.1.0
+
   '@cloudflare/workerd-darwin-64@1.20260526.1':
     resolution: {integrity: sha512-/pR3GH3gfv0PUp7DjI8v0aAIDOqFwibq4bg5xT7TZgcVdBV/cJQWckdXCMqiRtHiawLwogUX00EIOINkYJ1Zqg==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-64@1.20260609.1':
+    resolution: {integrity: sha512-AK8tYLQm+8BqQMzjZ55ZfuhfIm1eCkj+Ykxz6kWXojdACwjjU03MrwdM9fBDdgzU3upXOs4e1scOFHySlfVQjA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -456,8 +490,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-arm64@1.20260609.1':
+    resolution: {integrity: sha512-4kKXfr7ZHU6xQ/R9ShdSuj1A1bEouoRcHzUWdjnuMPBlRsAAVanlxAVYISotFUulLEinayOpRFbhpsfwzrpSSw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@cloudflare/workerd-linux-64@1.20260526.1':
     resolution: {integrity: sha512-5EZAEnlLwa9oGJRo8Nd3iY5Wcd9ROGNNG90xNIGp8MEjj8v2jTn42NC47fCZKFdnLj3+S+vWEhu1x0GVJnALjA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-64@1.20260609.1':
+    resolution: {integrity: sha512-T2Ebir2OPHAvvZ0HUh5mi1lN8q30sVi4lf7LIpc28AHoWtoOmJ0jA5AJK4IYJm1MKEbBldq+QsckaHOCQFmRpQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -468,11 +514,26 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260609.1':
+    resolution: {integrity: sha512-INfcYoSsKqEIvPL69/3RkqYoP8WUR0VEN6loWN/3tekXLoJrVOj3E5NjIetsdS8MJN6zc3st/ae4bMuWRRzoDg==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260526.1':
     resolution: {integrity: sha512-R+tqpFFdcfZIljx8fIW9rj9fRTtDgfoA2yonsfAGa6e8snrmr+38mdFHtkRC0D3UyZpn/hOtmXiUBfdX2gMR7Q==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260609.1':
+    resolution: {integrity: sha512-EWhfxKI1aqUr7S8xuGxgmRCumEzB8iSsCIz6oEqJN+3pZuW3EWiKDGFW4EY1BmwNINLW1eO5VMGYb8Fj6FVYxA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workers-types@4.20260609.1':
+    resolution: {integrity: sha512-krGHtwSApCFBjTe1NTx/TFQ0P5i/bHGQOqCPnCLssb8rOKaAG4JkPFJZsossr0z/ZTMnpP2Tid5jWju+/i0hCA==}
 
   '@commitlint/cli@21.0.1':
     resolution: {integrity: sha512-8vq10krmbJwBkvzXKhbs4o4JQEVscd3pqOlWuDUaDBwbeL694/P33UC29tZQFTAgPU9fVJ2+f2m3zw16yKWxHg==}
@@ -1811,6 +1872,9 @@ packages:
     resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
+  '@polka/url@1.0.0-next.29':
+    resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
   '@poppinss/colors@4.1.6':
     resolution: {integrity: sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==}
 
@@ -2849,6 +2913,17 @@ packages:
     peerDependencies:
       valibot: ^1.4.0
 
+  '@vitest/browser-playwright@4.1.7':
+    resolution: {integrity: sha512-OlTlJej7YN6VwV7zJJoNeaCsctF+JXpzpZ4oBHUbrQFfIq+0KW2f07rprCLh9N/zRIZ0v4Mchn1QDDmWMUhPKw==}
+    peerDependencies:
+      playwright: '*'
+      vitest: 4.1.7
+
+  '@vitest/browser@4.1.7':
+    resolution: {integrity: sha512-N2JFGfXoEGVAut+kHeru9dD4BUMq/q5xDvBARNl0tUsly3m5KglLOu8VO/6MkDfOlgxXTycojkt6gBKsuyR+IQ==}
+    peerDependencies:
+      vitest: 4.1.7
+
   '@vitest/coverage-v8@4.1.7':
     resolution: {integrity: sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==}
     peerDependencies:
@@ -3153,6 +3228,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -3848,6 +3926,11 @@ packages:
   fs-extra@8.1.0:
     resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
     engines: {node: '>=6 <7 || >=8'}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -4872,6 +4955,11 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  miniflare@4.20260609.0:
+    resolution: {integrity: sha512-4ZfNh9ACDa/mKKQvTSO2vigyQS2MB7dEU02KRPle4FqL7S6nek+2Fq6WGzazZbt1OORYgb4OGVLnOCx+My2NNA==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -4913,6 +5001,10 @@ packages:
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
     engines: {node: '>=4'}
+
+  mrmime@2.0.1:
+    resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
+    engines: {node: '>=10'}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -5175,6 +5267,20 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  pngjs@7.0.0:
+    resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
+    engines: {node: '>=14.19.0'}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5612,6 +5718,10 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
+    engines: {node: '>=18'}
+
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
@@ -5864,6 +5974,10 @@ packages:
   toml@4.1.1:
     resolution: {integrity: sha512-EBJnVBr3dTXdA89WVFoAIPUqkBjxPMwRqsfuo1r240tKFHXv3zgca4+NJib/h6TyvGF7vOawz0jGuryJCdNHrw==}
     engines: {node: '>=20'}
+
+  totalist@3.0.1:
+    resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
+    engines: {node: '>=6'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -6285,12 +6399,27 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260609.1:
+    resolution: {integrity: sha512-KF/Y/8f4VoXCk87NuU6RqmO0X5fdzcrxU3XzAgoPUpnH9t1ZyzRgX1O/9sJvjItxroCBTEBzKssda02Dz9i6BA==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   wrangler@4.95.0:
     resolution: {integrity: sha512-vgXzFVSCdUbeCadgVXvu8fK5tzNm8T9W+7lriyGWZMx0B1+CAdr4d8JTlZszHfgjypRAHmAxb49etZGIRD9pgg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
       '@cloudflare/workers-types': ^4.20260526.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
+  wrangler@4.99.0:
+    resolution: {integrity: sha512-i7GA2mZETTyq3ljWdEzM908FjLaMWZ1AaAHKaOJ8pFA/tonf2VqIWDyBGzKleIVBbNQxOTIY2wnbv0iaK3rC6g==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260609.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -6588,6 +6717,8 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@blazediff/core@1.9.1': {}
+
   '@changesets/apply-release-plan@7.1.1':
     dependencies:
       '@changesets/config': 3.1.4
@@ -6739,20 +6870,58 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260526.1
 
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260609.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260609.1
+
+  '@cloudflare/vitest-pool-workers@0.16.14(@cloudflare/workers-types@4.20260609.1)(@vitest/runner@4.1.7)(@vitest/snapshot@4.1.7)(vitest@4.1.7)':
+    dependencies:
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      cjs-module-lexer: 1.2.3
+      esbuild: 0.27.3
+      miniflare: 4.20260609.0
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      wrangler: 4.99.0(@cloudflare/workers-types@4.20260609.1)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
   '@cloudflare/workerd-darwin-64@1.20260526.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260609.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260526.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-arm64@1.20260609.1':
+    optional: true
+
   '@cloudflare/workerd-linux-64@1.20260526.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260609.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260526.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260609.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260526.1':
     optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260609.1':
+    optional: true
+
+  '@cloudflare/workers-types@4.20260609.1': {}
 
   '@commitlint/cli@21.0.1(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
@@ -7719,6 +7888,8 @@ snapshots:
 
   '@pkgr/core@0.2.9': {}
 
+  '@polka/url@1.0.0-next.29': {}
+
   '@poppinss/colors@4.1.6':
     dependencies:
       kleur: 4.1.5
@@ -8151,9 +8322,9 @@ snapshots:
       '@typescript-eslint/parser': 8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.7.0)
       eslint-config-prettier: 10.1.8(eslint@9.39.2(jiti@2.7.0))
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-better-tailwindcss: 4.5.0(eslint@9.39.2(jiti@2.7.0))(oxlint@1.67.0)(tailwindcss@4.3.0)(typescript@6.0.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-mdx: 3.7.1(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-prettier: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))(prettier@3.8.3)
       eslint-plugin-security: 4.0.0
@@ -8727,7 +8898,37 @@ snapshots:
     dependencies:
       valibot: 1.4.1(typescript@6.0.3)
 
-  '@vitest/coverage-v8@4.1.7(vitest@4.1.7)':
+  '@vitest/browser-playwright@4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      playwright: 1.60.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/browser@4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)':
+    dependencies:
+      '@blazediff/core': 1.9.1
+      '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/utils': 4.1.7
+      magic-string: 0.30.21
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      tinyrainbow: 3.1.0
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+
+  '@vitest/coverage-v8@4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.7
@@ -8739,7 +8940,9 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+    optionalDependencies:
+      '@vitest/browser': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
 
   '@vitest/expect@4.1.7':
     dependencies:
@@ -9065,6 +9268,8 @@ snapshots:
       readdirp: 5.0.0
 
   ci-info@4.4.0: {}
+
+  cjs-module-lexer@1.2.3: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -9618,7 +9823,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.7.0)
@@ -9629,7 +9834,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9663,14 +9868,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -9721,7 +9926,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9732,7 +9937,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.60.1(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.3
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10088,6 +10293,9 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 4.0.0
       universalify: 0.1.2
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -11459,6 +11667,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@4.20260609.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260609.1
+      ws: 8.20.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -11490,6 +11710,8 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
 
   mri@1.2.0: {}
+
+  mrmime@2.0.1: {}
 
   ms@2.1.3: {}
 
@@ -11848,6 +12070,16 @@ snapshots:
   picomatch@4.0.4: {}
 
   pify@4.0.1: {}
+
+  playwright-core@1.60.0: {}
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  pngjs@7.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
 
@@ -12349,6 +12581,12 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  sirv@3.0.2:
+    dependencies:
+      '@polka/url': 1.0.0-next.29
+      mrmime: 2.0.1
+      totalist: 3.0.1
+
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
@@ -12591,6 +12829,8 @@ snapshots:
       is-number: 7.0.0
 
   toml@4.1.1: {}
+
+  totalist@3.0.1: {}
 
   tree-kill@1.2.2: {}
 
@@ -12970,7 +13210,7 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(@vitest/coverage-v8@4.1.7)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.7
       '@vitest/mocker': 4.1.7(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -12994,7 +13234,8 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
-      '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
+      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/coverage-v8': 4.1.7(@vitest/browser@4.1.7)(vitest@4.1.7)
     transitivePeerDependencies:
       - msw
 
@@ -13070,7 +13311,15 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260526.1
       '@cloudflare/workerd-windows-64': 1.20260526.1
 
-  wrangler@4.95.0:
+  workerd@1.20260609.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260609.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260609.1
+      '@cloudflare/workerd-linux-64': 1.20260609.1
+      '@cloudflare/workerd-linux-arm64': 1.20260609.1
+      '@cloudflare/workerd-windows-64': 1.20260609.1
+
+  wrangler@4.95.0(@cloudflare/workers-types@4.20260609.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260526.1)
@@ -13082,6 +13331,24 @@ snapshots:
       unenv: 2.0.0-rc.24
       workerd: 1.20260526.1
     optionalDependencies:
+      '@cloudflare/workers-types': 4.20260609.1
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  wrangler@4.99.0(@cloudflare/workers-types@4.20260609.1):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260609.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260609.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260609.1
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260609.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,7 +10,7 @@ allowBuilds:
     msgpackr-extract: true
     sharp: false
     unrs-resolver: true
-    workerd: false
+    workerd: true
 
 catalogs:
     dev:

--- a/scripts/release-preflight.ts
+++ b/scripts/release-preflight.ts
@@ -6,12 +6,16 @@ import process from 'node:process';
 
 const repoRoot = resolve(import.meta.dirname, '..');
 
-const readPreMode = (): string => {
+const readPre = (): { mode: string; tag: string | undefined } => {
     const preJsonPath = resolve(repoRoot, '.changeset/pre.json');
-    if (!fs.existsSync(preJsonPath)) return 'exit';
+    if (!fs.existsSync(preJsonPath)) return { mode: 'exit', tag: undefined };
     const preJson = JSON.parse(fs.readFileSync(preJsonPath, 'utf-8')) as Record<string, unknown>;
-    return typeof preJson.mode === 'string' ? preJson.mode : 'exit';
+    const mode = typeof preJson.mode === 'string' ? preJson.mode : 'exit';
+    const tag = typeof preJson.tag === 'string' ? preJson.tag : undefined;
+    return { mode, tag };
 };
+
+const isPrerelease = (version: string): boolean => /^\d+\.\d+\.\d+-/.test(version);
 
 const hasPendingChangesets = (): boolean => {
     const changesetDir = resolve(repoRoot, '.changeset');
@@ -24,7 +28,7 @@ const isVersionPublished = (name: string, version: string): boolean => {
         execFileSync('npm', ['view', `${name}@${version}`, 'version'], { stdio: 'ignore' });
         return true;
     } catch {
-        // 404 or an unreachable registry both
+        // a 404 and an unreachable registry both count as not-confirmed-published
         return false;
     }
 };
@@ -39,34 +43,74 @@ const readEnvaptPackage = (): { name: string; version: string } => {
     return { name, version };
 };
 
+const readDenoConfig = (): { name: string; version: string } => {
+    const denoPath = resolve(repoRoot, 'packages/envapt/deno.json');
+    const deno = JSON.parse(fs.readFileSync(denoPath, 'utf-8')) as Record<string, unknown>;
+    const { name, version } = deno;
+    if (typeof name !== 'string' || typeof version !== 'string') {
+        throw new Error('packages/envapt/deno.json is missing a string name or version');
+    }
+    return { name, version };
+};
+
+const isVersionOnJsr = (name: string, version: string): boolean => {
+    try {
+        const meta = execFileSync('curl', ['-fsSL', `https://jsr.io/${name}/meta.json`], { encoding: 'utf-8' });
+        const parsed = JSON.parse(meta) as { versions?: Record<string, unknown> };
+        return parsed.versions !== undefined && version in parsed.versions;
+    } catch {
+        return false;
+    }
+};
+
 const setOutput = (key: string, value: string): void => {
     const outputPath = process.env.GITHUB_OUTPUT;
     if (outputPath) fs.appendFileSync(outputPath, `${key}=${value}\n`);
 };
 
 const branch = process.env.GITHUB_REF_NAME ?? '';
-const mode = readPreMode();
-console.log(`branch=${branch} pre-mode=${mode}`);
-
-// `next` publishes -next.N to the `next` dist-tag and must be in changeset pre-mode.
-// `main` publishes `latest` and must not be.
-// so a pre.json can never ship a prerelease to `latest`.
-if (branch === 'next' && mode !== 'pre') {
-    console.error(
-        `::error::next must be in changeset pre-mode (pre.json mode=pre); got '${mode}'. Refusing to publish.`
-    );
-    process.exit(1);
-}
-if (branch === 'main' && mode === 'pre') {
-    console.error('::error::main must not be in pre-mode. Refusing to publish a prerelease to the latest tag.');
-    process.exit(1);
-}
-
-// only invoke changesets/action when there is real work
+const { mode, tag } = readPre();
 const { name, version } = readEnvaptPackage();
+console.log(`branch=${branch} pre-mode=${mode} tag=${tag ?? '(none)'} version=${version}`);
+
+// both the tag and the version are asserted so neither a stray pre tag nor a forgotten `pre exit`
+// can ship a prerelease to the `latest` channel
+if (branch === 'next') {
+    if (mode !== 'pre') {
+        console.error(
+            `::error::next must be in changeset pre-mode (pre.json mode=pre); got '${mode}'. Refusing to publish.`
+        );
+        process.exit(1);
+    }
+    if (!tag || tag === 'latest') {
+        console.error(
+            `::error::next pre-mode tag must be a dedicated prerelease channel, never 'latest'; got '${tag ?? '(none)'}'. Refusing to publish.`
+        );
+        process.exit(1);
+    }
+}
+if (branch === 'main') {
+    if (mode === 'pre') {
+        console.error('::error::main must not be in pre-mode. Refusing to publish a prerelease to the latest tag.');
+        process.exit(1);
+    }
+    if (isPrerelease(version)) {
+        console.error(
+            `::error::main version '${version}' is a prerelease. Run \`changeset pre exit\` before merging to main. Refusing to publish a prerelease to the latest tag.`
+        );
+        process.exit(1);
+    }
+}
+
 const pendingChangesets = hasPendingChangesets();
 const needsPublish = !isVersionPublished(name, version);
 const run = pendingChangesets || needsPublish;
 
 console.log(`pendingChangesets=${pendingChangesets} needsPublish=${needsPublish} (${name}@${version}) run=${run}`);
 setOutput('run', String(run));
+
+// jsr has no version-PR phase, so gate on consumed changesets, otherwise `deno publish` republishes a live version and fails
+const { name: jsrName, version: jsrVersion } = readDenoConfig();
+const publishJsr = !pendingChangesets && !isVersionOnJsr(jsrName, jsrVersion);
+console.log(`jsr ${jsrName}@${jsrVersion} publish_jsr=${publishJsr}`);
+setOutput('publish_jsr', String(publishJsr));

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -1,0 +1,52 @@
+import { execFile, execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+const pexec = promisify(execFile);
+
+// eslint-disable-next-line no-magic-numbers -- 64 MiB cap so a verbose suite's captured output is not truncated
+const captureBytes = 64 * 1024 * 1024;
+
+// build first because every slice below reads the built dist
+process.stdout.write('── build ──\n');
+execFileSync('pnpm', ['--filter', 'envapt', 'build'], { stdio: 'inherit' });
+
+const playwrightCache = [join(homedir(), '.cache/ms-playwright'), join(homedir(), 'Library/Caches/ms-playwright')];
+const hasChromium = playwrightCache.some(existsSync);
+
+const slices = [
+    ['unit', ['--filter', 'envapt', 'test']],
+    ['integration', ['--filter', 'envapt', 'test:integration']],
+    ['workerd', ['--filter', 'envapt', 'test:workers']],
+    ['consumer-build', ['--filter', 'envapt', 'test:consumer-build']]
+];
+if (hasChromium) slices.push(['browser', ['--filter', 'envapt', 'test:browser']]);
+
+// each slice is its own process with no shared state, so they can run in parallel
+const results = await Promise.all(
+    slices.map(async ([label, args]) => {
+        try {
+            const { stdout, stderr } = await pexec('pnpm', args, { maxBuffer: captureBytes });
+            return { label, ok: true, output: stdout + stderr };
+        } catch (err) {
+            return { label, ok: false, output: String(err.stdout ?? '') + String(err.stderr ?? '') };
+        }
+    })
+);
+
+let failed = 0;
+for (const result of results) {
+    process.stdout.write(`\n══ ${result.label} ${result.ok ? 'PASS' : 'FAIL'} ══\n`);
+    process.stdout.write(result.output);
+    if (!result.ok) failed += 1;
+}
+
+if (!hasChromium) {
+    process.stdout.write('\n══ browser SKIPPED ══\n');
+    process.stdout.write('run `pnpm --filter envapt exec playwright install chromium` to enable it\n');
+}
+
+process.stdout.write(`\ntest:all: ${results.length - failed}/${results.length} suites passed\n`);
+if (failed > 0) process.exit(1);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,14 +1,16 @@
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-import { defineConfig } from 'vitest/config';
+import { configDefaults, defineConfig } from 'vitest/config';
 
 const configDir = dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
     test: {
         testTimeout: 500,
-        // Absolute so it resolves whether vitest's root is the package dir (CLI) or the repo root (IDE test runner).
+        // workers, browser, and consumer-build run on their own runtimes via dedicated configs, never the node pool
+        exclude: [...configDefaults.exclude, '**/tests/{workers,browser,consumer-build}/**'],
+        // absolute so it resolves whether vitest's root is the package dir (CLI) or the repo root (IDE runner)
         setupFiles: [resolve(configDir, 'packages/envapt/tests/setup.ts')],
         coverage: {
             enabled: true,


### PR DESCRIPTION
Adds real-runtime test coverage for the Workers and browser builds, and publishes JSR prereleases alongside npm.

## Test suites

These run against the built `dist`, stay out of the default `test`, and run as separate `cross-runtime` CI jobs.

- **workerd**, real workerd via `@cloudflare/vitest-pool-workers`. Covers `WorkerEnvSource` from the `env` binding, converters, template resolution, strict mode, and the `EnvaptError` 306 file-API guard.
- **browser**, headless Chromium via Playwright. A missing required read throws `EnvaptError` rather than a `process` ReferenceError, debug output goes to `console`, and `ManualEnvSource` reads from `import.meta.env` and `window.__ENV__`.
- **consumer-build**, esbuild bundles `envapt` for the browser and workerd conditions and asserts no `node:` builtin reaches the output.

## Release pipeline

`npm-publish` and `jsr-publish` are independent jobs, each gated on `dry-run-npm` and `dry-run-jsr`. A shared `preflight` job emits `publish_jsr`, true when no changesets are pending and the version is not already on JSR, so `5.2.0-next.N` prereleases reach JSR alongside npm. `release-preflight` also refuses a `latest` pre-tag on `next` and a prerelease version on `main`.
