### PR TITLE
docs: position envapt as typed config from any source

### DIFF
--- a/.changeset/any-source-positioning.md
+++ b/.changeset/any-source-positioning.md
@@ -1,0 +1,5 @@
+---
+'envapt': patch
+---
+
+Reword the package description to lead with typed config from any source rather than .env loading, because that's what envapt is about and the .env cascade is just one feature of the default Node source.

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,9 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "@envapt/guide": "1.0.0",
+    "envapt": "6.0.0"
+  },
+  "changesets": []
+}

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "next",
   "initialVersions": {
     "@envapt/guide": "1.0.0",

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 <h3>envapt</h3>
 
 <p>
-  <strong>The apt way to handle environment variables.</strong><br/>
-  Read them as typed values, with zero runtime dependencies.
+  <strong>The apt way to read typed config.</strong><br/>
+  Read config from any source as real typed values, with zero runtime dependencies.
 </p>
 
 <p>
@@ -17,9 +17,10 @@
 
 <br clear="left"/>
 
-`process.env` always hands you a `string | undefined`. envapt returns the type you asked for, with a
-fallback that removes `undefined` from the return type. On Node, Bun, and Deno it reads `process.env`
-and your `.env` files; on Cloudflare Workers and in the browser you bind the source with
+envapt returns config as the type you asked for instead of the `string | undefined` you get raw, with
+a fallback that removes `undefined` from the return type. It reads from whatever source you bind. On
+Node, Bun, and Deno that is `process.env` and your `.env` files, bound on import. On Cloudflare
+Workers, in the browser, or for a secrets object you fetched at boot, you bind the source with
 `Envapter.useSource(...)`.
 
 ```ts
@@ -35,14 +36,17 @@ const port = Envapter.getNumber('PORT', 3000); // number, not string | undefined
 - **Typed values.** A fallback removes `undefined` from the return type. Built-in converters cover
   numbers, booleans, bigint, JSON, URLs, regular expressions, dates, durations, and arrays, or pass
   your own function or a Standard Schema validator (zod, valibot, arktype).
-- **Zero runtime dependencies.** envapt ships its own `.env` parser, so nothing is added to your
-  dependency tree.
+- **Any source.** A source is any object with a `readVars()` method, so you can bind `process.env`, a
+  Cloudflare Workers binding, a browser bundle, or a secrets payload you fetched from a store at boot.
+  On Node, Bun, and Deno one binds on import.
+- **Zero runtime dependencies.** The reader, converters, and built-in `.env` parser are self-contained,
+  so nothing is added to your dependency tree.
 - **Runs on Node, Bun, Deno, Cloudflare Workers, and the browser.** Node `>=20`, Bun `>=1.3`, Deno
-  `>=2.5` (ESM and CJS); the Workers and browser builds resolve through the package `exports`
+  `>=2.5` (ESM and CJS). The Workers and browser builds resolve through the package `exports`
   conditions.
-- **`.env` loading on Node, Bun, and Deno.** A per-environment file cascade, `${VAR}` templates, and
-  strict / required checks. Off Node there is no filesystem, so you bind a source with
-  `Envapter.useSource(...)` and read with the same typed API.
+- **`.env` loading built in on Node.** The default Node source adds a per-environment file cascade,
+  `${VAR}` templates, and strict / required checks. Off Node there is no filesystem, so you bind
+  another source with `Envapter.useSource(...)` and read with the same typed API.
 
 ## Install
 
@@ -62,7 +66,7 @@ Both share the same parsing, converters, and cache.
 ### Functional
 
 Read a value from any call site, in JavaScript or TypeScript. No build step. On Node the source is
-bound for you; on Workers and in the browser, call `Envapter.useSource(...)` first.
+bound for you. On Workers and in the browser, call `Envapter.useSource(...)` first.
 
 ```ts
 import { Envapter, Converters } from 'envapt';

--- a/apps/guide/app/(home)/page.tsx
+++ b/apps/guide/app/(home)/page.tsx
@@ -28,10 +28,10 @@ export default function HomePage(): ReactNode {
     return (
         <main className="flex flex-1 flex-col">
             <Hero />
+            <AnyRuntime />
             <TwoWays />
             <ConverterShowcase />
             <EnvLoading />
-            <AnyRuntime />
             <ClosingCta />
         </main>
     );

--- a/apps/guide/components/AnyRuntime.tsx
+++ b/apps/guide/components/AnyRuntime.tsx
@@ -23,9 +23,9 @@ const beta = Envapter.getBoolean('VITE_BETA', false);`;
 export function AnyRuntime(): ReactNode {
     return (
         <Section
-            eyebrow="// any runtime"
+            eyebrow="// any source"
             title="Bind a source, read it typed."
-            lead="On Node, Bun, and Deno the source binds itself on import. On Cloudflare Workers and in the browser you bind it in one line, then read with the same typed API."
+            lead="A source is any object with a readVars() method. On Node, Bun, and Deno one binds itself on import, reading process.env and your .env files. On Cloudflare Workers, in the browser, or for secrets you fetch from a store at boot, you bind it in one line and read with the same typed API."
         >
             <div className="grid grid-cols-1 gap-5 md:grid-cols-2">
                 <CodeCard fileName="worker.ts">
@@ -53,9 +53,21 @@ export function AnyRuntime(): ReactNode {
                         <Link href="/docs/sources" className="text-(--ev-link) hover:underline">
                             Sources
                         </Link>
+                        <span className="text-(--ev-gutter)"> · </span>
+                        <Link href="/docs/secret-stores" className="text-(--ev-link) hover:underline">
+                            Secret stores
+                        </Link>
                     </p>
                 </div>
                 <p className="mt-3 border-t border-fd-border pt-3 font-mono text-[12.5px] text-fd-muted-foreground">
+                    Fetch secrets from 1Password, Vault, Doppler, or any store at boot, then bind the resolved object as
+                    a source. envapt reads them typed, it does not fetch them.{' '}
+                    <Link href="/docs/secret-stores" className="text-(--ev-link) hover:underline">
+                        Using secret stores
+                    </Link>
+                    .
+                </p>
+                <p className="mt-3 font-mono text-[12.5px] text-fd-muted-foreground">
                     Browser values are inlined into your bundle, so seed public configuration only, never a secret.
                 </p>
             </div>

--- a/apps/guide/components/ClosingCta.tsx
+++ b/apps/guide/components/ClosingCta.tsx
@@ -8,7 +8,7 @@ export function ClosingCta(): ReactNode {
             <div className="ev-hero-grid pointer-events-none absolute inset-0" aria-hidden="true" />
             <div className="relative mx-auto max-w-295 px-6 text-center">
                 <h2 className="mb-3 text-2xl font-semibold tracking-tight text-balance md:text-[2rem]">
-                    Read environment variables as real types.
+                    Read config from any source, fully typed.
                 </h2>
                 <p className="mb-7 text-lg text-fd-muted-foreground">
                     Zero runtime dependencies. Zod/Valibot/Arktype validation.

--- a/apps/guide/components/EnvLoading.tsx
+++ b/apps/guide/components/EnvLoading.tsx
@@ -9,13 +9,13 @@ const RESOLVED = `Envapter.get('DATABASE_URL');
 export function EnvLoading(): ReactNode {
     return (
         <Section
-            eyebrow="// .env, loaded"
+            eyebrow="// node source"
             title={
                 <>
-                    Loads your .env, not just <span className="text-(--ev-link)">process.env</span>.
+                    The default Node source loads <span className="text-(--ev-link)">.env</span>.
                 </>
             }
-            lead="In production, envapt reads .env.production.local, then .env.production, then .env.local, then .env. Values from higher files win; missing files are skipped."
+            lead="When the Node source is active, envapt reads .env.production.local, then .env.production, then .env.local, then .env in production. Values from higher files win, missing files are skipped. Bind another source and the cascade steps aside."
         >
             <div className="flex flex-col gap-6 lg:flex-row lg:items-center">
                 <div className="min-w-0 lg:w-3/5">
@@ -49,7 +49,7 @@ export function EnvLoading(): ReactNode {
                     · zero dependencies
                 </p>
                 <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-                    <span className="shrink-0 text-[14px] text-fd-muted-foreground">Coming from dotenv?</span>
+                    <span className="shrink-0 text-[14px] text-fd-muted-foreground">Need values on process.env?</span>
                     <div className="overflow-hidden rounded-md border border-fd-border">
                         <Code code="import 'envapt/config';" lang="ts" dense />
                     </div>

--- a/apps/guide/components/Hero.tsx
+++ b/apps/guide/components/Hero.tsx
@@ -24,16 +24,17 @@ export function Hero(): ReactNode {
             <div className="relative mx-auto grid max-w-295 grid-cols-1 items-center gap-12 px-6 md:grid-cols-[1.05fr_1fr]">
                 <div className="min-w-0">
                     <p className="mb-4 font-mono text-[13px] tracking-wide text-(--ev-eyebrow)">
-                        {'// the apt way to handle env'}
+                        {'// the apt way to read config'}
                     </p>
                     <h1 className="mb-5 text-4xl leading-[1.04] font-semibold tracking-tight text-balance md:text-5xl">
                         Typed config,
                         <br />
-                        straight from <span className="text-(--ev-link)">.env</span>.
+                        from <span className="text-(--ev-link)">any source</span>.
                     </h1>
                     <p className="mb-7 max-w-110 text-lg/relaxed text-fd-muted-foreground">
-                        Read environment variables as real types. Zero runtime dependencies. Zod/Valibot/Arktype
-                        validation.
+                        Read config as real types from <code className="font-mono text-[0.92em]">process.env</code>, a
+                        Workers binding, a browser bundle, or any object you bind. Zero runtime dependencies.
+                        Zod/Valibot/Arktype validation.
                     </p>
                     <div className="flex flex-wrap gap-3">
                         <BaseButton href="/docs/quick-start" variant="solid">

--- a/apps/guide/content/blog/reading-typed-env.mdx
+++ b/apps/guide/content/blog/reading-typed-env.mdx
@@ -1,6 +1,6 @@
 ---
-title: Reading typed config from .env in TypeScript
-description: Read env vars as numbers, URLs, durations, and schema-validated values in TypeScript, with fallbacks that narrow the type and any Standard Schema validator you already use.
+title: Reading typed config in TypeScript
+description: Read config from any source as numbers, URLs, durations, and schema-validated values in TypeScript, with fallbacks that narrow the type and any Standard Schema validator you already use.
 author: Dhruv
 date: '2026-06-01'
 ---
@@ -11,7 +11,7 @@ That line shows up in a lot of config files, and it has two bugs hiding in it.
 
 Misspell `PORT` in your `.env` and you don't get an error, you get `3000`, and you find out in production. Want to set `PORT=0` on purpose? You can't: `Number('0') || 3000` is `3000` too. The `|| fallback` can't tell "missing" from "zero," and `process.env` hands you `string | undefined` regardless, so every read sits one coercion away from a quiet bug.
 
-I got tired of writing that coercion by hand and keeping it correct, so I built envapt. On Node, Bun, and Deno it reads `process.env` and your `.env` files; off Node the source is pluggable, so the same reads work on Cloudflare Workers and in the browser.
+I got tired of writing that coercion by hand and keeping it correct, so I built envapt. It reads from whatever source you bind. On Node, Bun, and Deno that is `process.env` and your `.env` files, bound on import. Off Node the source is pluggable, so the same reads work on Cloudflare Workers, in the browser, or over a secrets object you fetched at boot.
 
 ## The typed read
 
@@ -54,7 +54,7 @@ const ttl = Envapter.getUsing('CACHE_TTL', Converters.Time, '5m'); // "5m" -> 30
 //    ^?
 ```
 
-`Converters.Url` runs the value through `new URL`, so a non-absolute URL takes the fallback instead of slipping through as a string. `Converters.array({ of: Converters.Url })` splits on the delimiter and converts each element, so the type is `URL[]`, not the `string[]` you'd `.split(',')` your way to. `Converters.Time` reads `5m` and returns `300000`, which means a timeout in your `.env` reads the way you'd write it in code rather than as a pile of zeroes you have to count.
+`Converters.Url` runs the value through `new URL`, so a non-absolute URL takes the fallback instead of slipping through as a string. `Converters.array({ of: Converters.Url })` splits on the delimiter and converts each element, so the type is `URL[]`, not the `string[]` you'd `.split(',')` your way to. `Converters.Time` reads `5m` and returns `300000`, which means a timeout in config reads the way you'd write it in code rather than as a pile of zeroes you have to count.
 
 The built-in tokens cover number, integer, float, boolean, bigint, symbol, JSON, URL, RegExp, Date, duration, and arrays. When none of them fit, `getWith` takes a plain `(raw, fallback) => T`:
 
@@ -152,15 +152,15 @@ t3-env centralizes: you declare every variable up front in one `createEnv` call,
 
 On Node, Bun, and Deno, envapt reads `process.env` and the `.env` cascade with no setup. On Cloudflare Workers and in the browser there is no filesystem, so you bind the source yourself: a `WorkerEnvSource` over the `env` binding in a Worker, a `ManualEnvSource` over the config your bundler injects in the browser. The typed reads, converters, and validators are identical across all of them; the `.env` cascade and the file-only config APIs are the part that stays on Node.
 
-## Loading the .env file
+## Loading a .env file on Node
 
-For local development you still want a `.env` file. On Node that's usually `dotenv`. envapt parses `.env` itself, so it loads the file without adding a dependency:
+For local development on Node you likely still want a `.env` file. envapt parses it itself, so it loads the file without adding a `dotenv` dependency:
 
 ```ts twoslash
 import 'envapt/config';
 ```
 
-That import is a drop-in for `dotenv/config`. It reads the cascade and mirrors the result into `process.env`. The cascade is per-environment and the most-specific file wins:
+That import reads the cascade and mirrors the result into `process.env`, the same way `dotenv/config` does. The cascade is per-environment and the most-specific file wins:
 
 ```dotenv
 .env.production.local
@@ -173,4 +173,4 @@ That import is a drop-in for `dotenv/config`. It reads the cascade and mirrors t
 
 ## So, finally
 
-What envapt gives you is the combination: a fallback that narrows the type and tells missing from zero, converters for the shapes that aren't strings, and validation through the schema you already wrote rather than the one a helper chose for you. If that's the shape of your config problem, the docs and the v4-to-v5 migration are at [envapt.materwelon.dev](https://envapt.materwelon.dev), it's on [npm](https://www.npmjs.com/package/envapt) and [JSR](https://jsr.io/@materwelon/envapt), and the source is on [GitHub](https://github.com/materwelonDhruv/envapt). Please feel free to ask questions, report bugs, or suggest features in the repo! I'm always open to feedback and contributions.
+What envapt gives you is typed reads from any source (`process.env`, a Worker binding, a browser bundle, or a secrets object you supply), a fallback that narrows the type and tells missing from zero, converters for the shapes that aren't strings, and validation through the schema you already wrote rather than the one a helper chose for you. If that's the shape of your problem, it's on [npm](https://www.npmjs.com/package/envapt) and [JSR](https://jsr.io/@materwelon/envapt), and the source is on [GitHub](https://github.com/materwelonDhruv/envapt). Please feel free to ask questions, report bugs, or suggest features in the repo! I'm always open to feedback and contributions.

--- a/apps/guide/content/docs/compatibility.mdx
+++ b/apps/guide/content/docs/compatibility.mdx
@@ -3,7 +3,7 @@ title: Compatibility
 description: Runtime support, engine versions, module formats, per-runtime builds, and how decorators behave across runtimes.
 ---
 
-envapt runs on Node, Bun, and Deno with the same API and zero runtime dependencies. It also runs on Cloudflare Workers (workerd) and in the browser, where you bind an environment source yourself and there is no `.env` cascade. The functional reader API works on every runtime with no build step. The `@Envapt` decorator is TypeScript-only and has per-runtime requirements, covered below.
+envapt runs on Node, Bun, and Deno with the same API and zero runtime dependencies. It also runs on Cloudflare Workers (workerd) and in the browser, where you bind the source yourself (`WorkerEnvSource` or `ManualEnvSource`) and read with the same typed API. The functional reader API works on every runtime with no build step. The `@Envapt` decorator is TypeScript-only and has per-runtime requirements, covered below.
 
 ## Engine versions
 

--- a/apps/guide/content/docs/configuration.mdx
+++ b/apps/guide/content/docs/configuration.mdx
@@ -1,9 +1,9 @@
 ---
 title: Configuration
-description: Choose which .env files load, mirror values back to process.env, and turn on debug logging.
+description: Control which files load on Node, mirror values back to process.env, and turn on debug logging.
 ---
 
-envapt reads from `process.env` plus the `.env` files it loads. Static settings on `Envapter` control which files load, whether loaded values reach `process.env`, and how much envapt logs.
+On Node, Bun, and Deno the default source reads `process.env` plus the `.env` files it loads. Static settings on `Envapter` control which files load, whether loaded values reach `process.env`, and how much envapt logs. They apply only while a Node source is active, on Workers and in the browser you bind a [source](/docs/sources) instead.
 
 ```ts twoslash
 import { Envapter } from 'envapt';

--- a/apps/guide/content/docs/envapter.mdx
+++ b/apps/guide/content/docs/envapter.mdx
@@ -157,4 +157,4 @@ Static and instance reads hit the same cache.
 
 ## Environment detection
 
-`Envapter` also detects the current runtime environment and auto-loads the matching `.env` files for it. The `isProduction` / `isStaging` / `isDevelopment` / `isTest` helpers, the `Environment` enum, and per-environment file selection all live on [Environment](/docs/environment).
+`Envapter` also detects the current runtime environment and exposes it through the `isProduction` / `isStaging` / `isDevelopment` / `isTest` helpers. On Node, Bun, and Deno it auto-loads the matching `.env` files for that environment. The helpers, the `Environment` enum, and per-environment file selection all live on [Environment](/docs/environment).

--- a/apps/guide/content/docs/environment.mdx
+++ b/apps/guide/content/docs/environment.mdx
@@ -1,9 +1,9 @@
 ---
 title: Environment
-description: Detect the current runtime environment and auto-load the matching .env files for it.
+description: Detect the current runtime environment and branch on it, and auto-load the matching .env files on Node.
 ---
 
-envapt detects which environment it's running in and loads the matching `.env` files for it. The `isProduction` / `isStaging` / `isDevelopment` / `isTest` helpers read that same value.
+envapt detects which environment it's running in and exposes it through the `isProduction` / `isStaging` / `isDevelopment` / `isTest` helpers, which work on every runtime. On Node, Bun, and Deno it also loads the matching `.env` files for that environment.
 
 ## Detecting the environment
 

--- a/apps/guide/content/docs/index.mdx
+++ b/apps/guide/content/docs/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Introduction
-description: Read environment variables as typed values, with zero runtime dependencies, plus zod/valibot/arktype validation, and much more.
+description: Read config as typed values from any source, with zero runtime dependencies and zod/valibot/arktype validation.
 ---
 
-envapt reads environment variables as typed values. You give it a key and a fallback; it returns a `number`, `boolean`, `URL`, `Date`, an array, or any type you define, instead of the `string | undefined` you get from `process.env`.
+envapt reads config as typed values from any source you bind, `process.env`, a Cloudflare Workers binding, a browser bundle, a secret store, or any object. You give it a key and a fallback, and it returns a `number`, `boolean`, `URL`, `Date`, an array, or any type you define, instead of the `string | undefined` you get raw.
 
 ```ts twoslash
 import { Envapter, Converters } from 'envapt';
@@ -28,9 +28,10 @@ class Config {
 ## What you get
 
 - **Typed values.** A fallback removes `undefined` from the return type. [Converters](/docs/converters) convert numbers, booleans, bigint, JSON, URLs, dates, durations, and arrays, or pass your own function or a [Standard Schema](/docs/standard-schema) validator (zod, valibot, arktype).
-- **Zero runtime dependencies.** envapt ships its own `.env` parser (used on Node, Bun, and Deno), so nothing is added to your dependency tree.
-- **The same API on Node, Bun, and Deno, Cloudflare Workers, and the browser.** Off Node you bind an environment source. See [Compatibility](/docs/compatibility) and [Sources](/docs/sources).
-- **`.env` loading built in on Node.** A per-environment file [cascade](/docs/environment), `${VAR}` [templates](/docs/templates), and [strict](/docs/strict-mode) / required checks. The cascade needs a filesystem; off Node you pass values through the source.
+- **Any source.** A [source](/docs/sources) is any object with a `readVars()` method. Bind `process.env`, a Cloudflare Workers binding, a browser bundle, or a [secret store](/docs/secret-stores) payload you fetched at boot. On Node, Bun, and Deno one binds on import.
+- **Zero runtime dependencies.** The reader, converters, and the built-in `.env` parser are self-contained, so nothing is added to your dependency tree.
+- **`.env` loading built in on Node.** The default Node source adds a per-environment file [cascade](/docs/environment), `${VAR}` [templates](/docs/templates), and [strict](/docs/strict-mode) / required checks. It needs a filesystem, so off Node you pass values through another source.
+- **The same API on Node, Bun, Deno, Cloudflare Workers, and the browser.** See [Compatibility](/docs/compatibility).
 
 ## Next
 

--- a/apps/guide/content/docs/meta.json
+++ b/apps/guide/content/docs/meta.json
@@ -14,6 +14,7 @@
         "---Configuration---",
         "configuration",
         "sources",
+        "secret-stores",
         "workers",
         "browser",
         "env-file-syntax",

--- a/apps/guide/content/docs/migration-v5-to-v6.mdx
+++ b/apps/guide/content/docs/migration-v5-to-v6.mdx
@@ -25,7 +25,7 @@ The sugar decorators `@EnvNum`, `@EnvStr`, `@EnvBool`, `@EnvUrl`, and `@EnvTime`
 ## Behavior changes to watch
 
 <Callout type="danger">
-    This change compiles without edits but runs differently than v5.1. Check it before upgrading.
+    This change compiles without edits but runs differently than v5. Check it before upgrading.
 </Callout>
 
 - **`NODE_ENV=test` resolves to `Environment.Test`.** `Envapter.isTest` returns true under a test runner, and `isDevelopment` returns false where it returned true on v5.1 and earlier. Vite's `MODE=test` maps the same way. This first shipped by mistake in the 5.2.0 minor, which is deprecated on npm. If you branch on `isDevelopment` inside tests, switch to `isTest` or set the environment explicitly. See [Environment](/docs/environment).

--- a/apps/guide/content/docs/quick-start.mdx
+++ b/apps/guide/content/docs/quick-start.mdx
@@ -57,9 +57,9 @@ Decorators need `experimentalDecorators` enabled, and the property declared with
     [Decorators](/docs/decorators#declare-the-property-never-initialize-it).
 </Callout>
 
-## Drop-in for dotenv
+## Mirror loaded values to process.env
 
-For the `dotenv/config` workflow, import `envapt/config`. It loads the `.env` cascade and mirrors every loaded key into `process.env` in one step, so `process.env.PORT` works without touching `Envapter`.
+Import `envapt/config` to load the `.env` cascade and mirror every loaded key into `process.env` in one step, so `process.env.PORT` works without touching `Envapter`. This is the same pattern as the `dotenv/config` import, so code that reads `process.env` directly still sees the values.
 
 ```ts twoslash
 import 'envapt/config';
@@ -80,4 +80,4 @@ For typed reads on top, keep using [`Envapter`](/docs/envapter).
 
 ## Requirements
 
-envapt runs on Node `>=20`, Bun `>=1.3`, and Deno `>=2.5`, Cloudflare Workers, and the browser, where you bind an environment source yourself. The functional API needs no build step on any runtime; the decorator API is TypeScript and needs compilation, with one caveat on Bun. See [Compatibility](/docs/compatibility).
+envapt runs on Node `>=20`, Bun `>=1.3`, Deno `>=2.5`, Cloudflare Workers, and the browser. On Node, Bun, and Deno a source binds on import, on Workers and in the browser you bind one yourself. The functional API needs no build step on any runtime. The decorator API is TypeScript and needs compilation, with one caveat on Bun. See [Compatibility](/docs/compatibility).

--- a/apps/guide/content/docs/secret-stores.mdx
+++ b/apps/guide/content/docs/secret-stores.mdx
@@ -1,0 +1,221 @@
+---
+title: Using secret stores
+description: Fetch secrets from 1Password, Vault, Doppler, AWS Secrets Manager, and others, then read them typed. envapt does not fetch secrets, it reads what you bind.
+---
+
+envapt does not fetch secrets, contact any remote API, or manage credentials. It reads typed values on top of whatever object is bound as the active [source](/docs/sources). To use a secret store, get your secrets into envapt one of two ways.
+
+- **Wrapper CLIs** (`op run`, `doppler run`, `infisical run`, `bws run`) inject secrets as real environment variables before your process starts. On Node, envapt reads them from `process.env` with no extra code.
+- **SDKs and HTTP APIs** hand you the secrets in your own code. You fetch them at boot, build a plain object, then bind it as a source.
+
+<Callout type="warn">
+    A source's `readVars()` is synchronous, so finish the async fetch before you call `useSource`. Await the SDK call,
+    reduce the result to a `Record<string, string>`, then bind that object.
+</Callout>
+
+## Wrapper CLIs, zero code on Node
+
+A wrapper CLI resolves your secrets and execs your process with them already set as environment variables. The default Node source reads them like any other variable, so the app code is unchanged.
+
+```dotenv title="secrets.env"
+# references, not the secrets themselves
+DB_PASSWORD=op://prod/db/password
+API_BASE_URL=op://prod/api/base-url
+```
+
+```bash
+op run --env-file=secrets.env -- node dist/server.js
+```
+
+```ts twoslash
+import { Envapter, Converters } from 'envapt';
+// ---cut---
+// op set these in process.env before the process started
+const dbPassword = Envapter.get('DB_PASSWORD');
+const apiBase = Envapter.getUsing('API_BASE_URL', Converters.Url);
+```
+
+The same shape works with `doppler run -- node dist/server.js`, `infisical run -- ...`, and `bws run -- ...`. Nothing binds a source, because the secrets are already in `process.env`.
+
+## Fetch at boot, then bind
+
+When you fetch with an SDK or HTTP call, await it, reduce the result to a flat object, then bind it. Reads after that are the normal typed API.
+
+```ts twoslash
+import { Envapter, Converters } from 'envapt';
+// ---cut---
+declare const secrets: Record<string, string>; // already fetched and awaited
+Envapter.useSource({ readVars: () => secrets });
+
+const dbUrl = Envapter.getUsing('DATABASE_URL', Converters.Url);
+const poolSize = Envapter.getNumber('DB_POOL_SIZE', 10);
+```
+
+<Callout type="warn">
+    On Node, `useSource` replaces the default Node source, so the `.env` cascade and the file-only config APIs
+    (`envPaths`, `baseDir`, `configureProfiles`) stop working after the swap. Bind a store source only if you do not
+    also need those. To keep both, see the bridge pattern below.
+</Callout>
+
+### Inline object or ManualEnvSource
+
+`ManualEnvSource` runs `coerceToStringRecord` at construction, so non-string values (numbers, booleans, objects) are JSON-stringified before they reach envapt's cache. The bare `{ readVars: () => secrets }` form skips that step, so any non-string in the payload reaches the converters unparsed. Prefer `ManualEnvSource` unless you know the payload is already all strings.
+
+```ts twoslash
+import { Envapter, ManualEnvSource } from 'envapt';
+// ---cut---
+declare const secrets: Record<string, string>;
+Envapter.useSource(new ManualEnvSource(secrets));
+```
+
+## Per-store examples
+
+Each example fetches a flat `Record<string, string>` and binds it. Pin and verify each SDK against its own docs before shipping, the snippets reflect the API at the time of writing.
+
+Each example reads one or two bootstrap credentials from `process.env` to initialize the SDK. These have to exist before envapt's source is bound, so they are the narrow exception to routing all config through envapt.
+
+### AWS Secrets Manager
+
+```ts
+import { SecretsManagerClient, GetSecretValueCommand } from '@aws-sdk/client-secrets-manager';
+import { Envapter, ManualEnvSource, Converters } from 'envapt';
+
+// This should be done early in your app, before any envapt read
+const client = new SecretsManagerClient();
+const { SecretString } = await client.send(new GetSecretValueCommand({ SecretId: 'prod/myapp' }));
+if (!SecretString) throw new Error('secret is binary, not a string');
+const secrets = JSON.parse(SecretString) as Record<string, string>;
+
+Envapter.useSource(new ManualEnvSource(secrets));
+
+// Now use envapt anywhere in your project
+const dbUrl = Envapter.getUsing('DATABASE_URL', Converters.Url);
+```
+
+Store the secret as one flat JSON object so `JSON.parse` returns a `Record`. The client reads credentials and region from the standard AWS credential chain.
+
+### HashiCorp Vault
+
+```ts
+import vault from 'node-vault';
+import { Envapter, ManualEnvSource, Converters } from 'envapt';
+
+const vc = vault({ endpoint: process.env.VAULT_ADDR });
+const { auth } = await vc.approleLogin({
+    role_id: process.env.VAULT_ROLE_ID,
+    secret_id: process.env.VAULT_SECRET_ID
+});
+vc.token = auth.client_token;
+
+const { data } = await vc.read('secret/data/myapp');
+const secrets = data.data as Record<string, string>;
+
+Envapter.useSource(new ManualEnvSource(secrets));
+const gcpServiceAccount = Envapter.getUsing('GCP_SA_JSON', Converters.Json);
+```
+
+HashiCorp ships no official Node client, `node-vault` is community-maintained. For KV v2 the payload sits at `data.data`, two levels deep.
+
+### 1Password
+
+Use `op run` (above) to avoid an SDK dependency, or fetch with the SDK and a service-account token.
+
+```ts
+import sdk from '@1password/sdk';
+import { Envapter, ManualEnvSource } from 'envapt';
+
+const op = await sdk.createClient({
+    auth: process.env.OP_SERVICE_ACCOUNT_TOKEN,
+    integrationName: 'my-app',
+    integrationVersion: 'v1.0.0'
+});
+
+const refs = {
+    DB_PASSWORD: 'op://prod/db/password',
+    API_KEY: 'op://prod/api/key'
+};
+const secrets: Record<string, string> = {};
+for (const [key, ref] of Object.entries(refs)) {
+    secrets[key] = await op.secrets.resolve(ref);
+}
+
+Envapter.useSource(new ManualEnvSource(secrets));
+const dbPassword = Envapter.get('DB_PASSWORD');
+```
+
+`@1password/sdk` is pre-1.0, pin the version. It needs a service-account token in `OP_SERVICE_ACCOUNT_TOKEN`.
+
+### Doppler
+
+Use `doppler run -- node dist/server.js` for the zero-code path, or download the secrets over HTTP.
+
+```ts
+import { Envapter, ManualEnvSource, Converters } from 'envapt';
+
+const url = `https://api.doppler.com/v3/configs/config/secrets/download?project=${project}&config=${config}&format=json`;
+const res = await fetch(url, { headers: { Authorization: `Bearer ${process.env.DOPPLER_TOKEN}` } });
+const secrets = (await res.json()) as Record<string, string>;
+
+Envapter.useSource(new ManualEnvSource(secrets));
+const corsOrigins = Envapter.getUsing('ALLOWED_ORIGINS', Converters.array({ of: Converters.Url }));
+```
+
+Confirm the auth scheme against Doppler's API reference. Older docs used HTTP Basic with the token as the username and an empty password.
+
+### Infisical
+
+```ts
+import { InfisicalSDK } from '@infisical/sdk';
+import { Envapter, ManualEnvSource, Converters } from 'envapt';
+
+const client = new InfisicalSDK();
+await client.auth().universalAuth.login({
+    clientId: process.env.INFISICAL_CLIENT_ID!,
+    clientSecret: process.env.INFISICAL_CLIENT_SECRET!
+});
+
+const { secrets } = await client.secrets().listSecrets({ projectId: 'YOUR_PROJECT_ID', environment: 'prod' });
+const vars = Object.fromEntries(secrets.map((s) => [s.secretKey, s.secretValue]));
+
+Envapter.useSource(new ManualEnvSource(vars));
+const cacheTtl = Envapter.getUsing('CACHE_TTL', Converters.Time, '15m');
+```
+
+The secret shape uses `secretKey` and `secretValue`. Use `@infisical/sdk` (v5+), not the unmaintained `infisical-node`.
+
+### Bitwarden Secrets Manager
+
+```ts
+import { BitwardenClient, DeviceType, LogLevel } from '@bitwarden/sdk-napi';
+import { Envapter, ManualEnvSource } from 'envapt';
+
+const client = new BitwardenClient(
+    { apiUrl: 'https://api.bitwarden.com', identityUrl: 'https://identity.bitwarden.com', deviceType: DeviceType.SDK },
+    LogLevel.Info
+);
+await client.auth().loginAccessToken(process.env.BW_ACCESS_TOKEN!);
+
+const { data } = await client.secrets().list(process.env.BW_ORG_ID!);
+const full = await client.secrets().getByIds(data.map((s) => s.id));
+const vars = Object.fromEntries(full.data.map((s) => [s.key, s.value]));
+
+Envapter.useSource(new ManualEnvSource(vars));
+const smtpPort = Envapter.getNumber('SMTP_PORT', 587);
+```
+
+`list()` returns identifiers only, fetch the values with `getByIds`. The package ships native binaries, so it runs on Node only, and it is in beta.
+
+## Bridge through process.env on Node
+
+To keep the default Node source and the `.env` cascade, write the fetched secrets onto `process.env` instead of calling `useSource`. This only works if the `Object.assign` runs before the first envapt read, before `Envapter.load()`, and before importing `envapt/config`. The cache builds once on first access and ignores any later writes to `process.env`.
+
+```ts
+import { Envapter, Converters } from 'envapt';
+
+declare const secrets: Record<string, string>; // fetched and awaited
+Object.assign(process.env, secrets);
+
+const dbUrl = Envapter.getUsing('DATABASE_URL', Converters.Url);
+```
+
+If the fetch cannot finish before that first read, write a custom source that implements `FileEnvSource` with `supportsFiles` set to `true`. It keeps the `.env` cascade running alongside your fetched values. See [Sources](/docs/sources).

--- a/apps/guide/content/docs/sources.mdx
+++ b/apps/guide/content/docs/sources.mdx
@@ -3,7 +3,7 @@ title: Sources
 description: Bind an environment source with useSource, and what the Node, Worker, and manual providers read.
 ---
 
-An environment source is the object envapt reads variables from. On Node, Bun, and Deno a source is bound for you on import, reading `process.env` and the `.env` file cascade. On Cloudflare Workers and in the browser there is none of that, so you bind a source yourself with `Envapter.useSource(...)` and read with the same typed API.
+A source is the object envapt reads variables from. On Node, Bun, and Deno one is bound automatically on import, reading `process.env` and the `.env` file cascade. On Cloudflare Workers and in the browser you bind a source yourself with `Envapter.useSource(...)`, then read with the same typed API.
 
 <Callout type="info">
     On Node, Bun, and Deno you never call `useSource`. The Node entry binds a source that reads a clone of `process.env`
@@ -50,6 +50,8 @@ const poolSize = Envapter.getNumber('DB_POOL_SIZE', 10);
 ```
 
 An optional `supportsFiles` flag marks a source as backing the file-only config APIs. Only `NodeEnvSource` sets it, which is why the `.env` cascade and `envPaths` work on Node and nowhere else.
+
+For fetching that secrets object from 1Password, Vault, Doppler, AWS Secrets Manager, and others, see [Using secret stores](/docs/secret-stores).
 
 ## When nothing is bound
 

--- a/apps/guide/content/docs/templates.mdx
+++ b/apps/guide/content/docs/templates.mdx
@@ -3,7 +3,7 @@ title: Templates
 description: Reference one environment variable from inside another, and build strings from keys with the resolve tagged template.
 ---
 
-An environment value can reference another with `${VAR}`. envapt expands those references when you read the value, so you compose values in your `.env` file instead of repeating them.
+A value can reference another with `${VAR}`. envapt expands those references when you read the value, whatever source the values came from, so you compose values instead of repeating them.
 
 ```dotenv
 DB_HOST=localhost

--- a/apps/guide/content/docs/workers.mdx
+++ b/apps/guide/content/docs/workers.mdx
@@ -1,6 +1,6 @@
 ---
 title: Workers
-description: Bind a WorkerEnvSource from the env binding once at module load, with no .env files on workerd.
+description: Bind a WorkerEnvSource from the Cloudflare env object once at module load, then read typed config with the same API as everywhere else.
 ---
 
 On Cloudflare Workers (workerd) there is no filesystem and no ambient `process.env`. Your configuration is the `env` object the runtime exposes. Bind a `WorkerEnvSource` from it once, then read with the same typed API as everywhere else.

--- a/apps/guide/lib/og/cards.tsx
+++ b/apps/guide/lib/og/cards.tsx
@@ -30,7 +30,7 @@ export function defaultCard(): ReactElement {
                 <BrandLockup glyphSize={48} wordmarkHeight={42} gap={16} fill={OG.white} />
                 <div style={{ display: 'flex', flexDirection: 'column', flex: 1, justifyContent: 'center', gap: 22 }}>
                     <div style={{ fontFamily: 'JetBrains Mono', fontSize: 23, color: OG.gold }}>
-                        {'// the apt way to handle env'}
+                        {'// the apt way to read config'}
                     </div>
                     <div
                         style={{
@@ -43,13 +43,13 @@ export function defaultCard(): ReactElement {
                     >
                         <div style={{ display: 'flex' }}>Typed config,</div>
                         <div style={{ display: 'flex' }}>
-                            <span>straight from</span>
-                            <span style={{ color: OG.brand, marginLeft: 14 }}>.env</span>
+                            <span>from</span>
+                            <span style={{ color: OG.brand, marginLeft: 14 }}>any source</span>
                         </div>
                     </div>
                     <div style={{ fontSize: 29, color: OG.muted, lineHeight: 1.42, maxWidth: 880 }}>
-                        Read environment variables as real types. Zero runtime dependencies, plus zod/valibot/arktype
-                        validation, and much more.
+                        Read config as real types from process.env, a Workers binding, a browser bundle, or any object
+                        you bind. Zero runtime dependencies, plus zod/valibot/arktype validation.
                     </div>
                     <div style={{ display: 'flex', gap: 12, fontFamily: 'JetBrains Mono', fontSize: 27 }}>
                         <span style={{ color: OG.teal }}>$</span>

--- a/apps/guide/lib/og/snippets.ts
+++ b/apps/guide/lib/og/snippets.ts
@@ -11,7 +11,7 @@ export const OG_SNIPPETS: Record<string, OgSnippet | undefined> = {
     index: {
         filename: 'config.ts',
         lang: 'ts',
-        code: `// envapt - typed env vars, zero deps
+        code: `// envapt - typed config, zero deps
 import { Envapter, Converters } from 'envapt';
 
 const url = Envapter.getUsing(
@@ -40,7 +40,7 @@ const db = Envapter.get(
     environment: {
         filename: 'env.ts',
         lang: 'ts',
-        code: `// Environment - per-mode .env cascade
+        code: `// Environment - switch mode and branch on it
 Envapter.environment = 'production';
 const level = Envapter.isProduction
   ? 'warn'
@@ -62,7 +62,7 @@ class Config {
         filename: 'cache.ts',
         lang: 'ts',
         code: `// Converters - read a duration as milliseconds
-// CACHE_TTL=15m in .env
+// CACHE_TTL=15m in your config
 const ttl = Envapter.getUsing(
   'CACHE_TTL', Converters.Time
 ); // 900000 (ms)`
@@ -155,6 +155,16 @@ TLS_KEY="line one\\nline two"`
         code: `// Sources - any readVars() object is a source
 const source = { readVars: () => secrets };
 Envapter.useSource(source);
+const db = Envapter.getUsing(
+  'DATABASE_URL', Converters.Url
+);`
+    },
+    'secret-stores': {
+        filename: 'boot.ts',
+        lang: 'ts',
+        code: `// Secret stores - fetch, bind, read typed
+const secrets = await fetchFromStore();
+Envapter.useSource({ readVars: () => secrets });
 const db = Envapter.getUsing(
   'DATABASE_URL', Converters.Url
 );`

--- a/apps/guide/lib/site.ts
+++ b/apps/guide/lib/site.ts
@@ -1,7 +1,7 @@
 export const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://envapt.materwelon.dev';
 export const SITE_NAME = 'envapt';
 export const SITE_DESCRIPTION =
-    'Read environment variables as real types, with zero runtime dependencies and zod/valibot/arktype validation. Runs on Node, Bun, Deno, Cloudflare Workers, and the browser; loads .env files on Node, Bun, and Deno.';
+    'Read config as real typed values from any source, process.env, a Cloudflare Workers binding, a browser bundle, or any object you bind. Zero runtime dependencies and zod/valibot/arktype validation. Runs on Node, Bun, Deno, Cloudflare Workers, and the browser.';
 export const REPO_URL = 'https://github.com/materwelonDhruv/envapt';
 export const DEFAULT_OG_IMAGE = '/og/image.png';
 

--- a/packages/envapt/README.md
+++ b/packages/envapt/README.md
@@ -3,8 +3,8 @@
 <h3>envapt</h3>
 
 <p>
-  <strong>The apt way to handle environment variables.</strong><br/>
-  Read them as typed values, with zero runtime dependencies.
+  <strong>The apt way to read typed config.</strong><br/>
+  Read config from any source as real typed values, with zero runtime dependencies.
 </p>
 
 <p>
@@ -17,9 +17,10 @@
 
 <br clear="left"/>
 
-`process.env` always hands you a `string | undefined`. envapt returns the type you asked for, with a
-fallback that removes `undefined` from the return type. On Node, Bun, and Deno it reads `process.env`
-and your `.env` files; on Cloudflare Workers and in the browser you bind the source with
+envapt returns config as the type you asked for instead of the `string | undefined` you get raw, with
+a fallback that removes `undefined` from the return type. It reads from whatever source you bind. On
+Node, Bun, and Deno that is `process.env` and your `.env` files, bound on import. On Cloudflare
+Workers, in the browser, or for a secrets object you fetched at boot, you bind the source with
 `Envapter.useSource(...)`.
 
 ```ts
@@ -35,14 +36,17 @@ const port = Envapter.getNumber('PORT', 3000); // number, not string | undefined
 - **Typed values.** A fallback removes `undefined` from the return type. Built-in converters cover
   numbers, booleans, bigint, JSON, URLs, regular expressions, dates, durations, and arrays, or pass
   your own function or a Standard Schema validator (zod, valibot, arktype).
-- **Zero runtime dependencies.** envapt ships its own `.env` parser, so nothing is added to your
-  dependency tree.
+- **Any source.** A source is any object with a `readVars()` method, so you can bind `process.env`, a
+  Cloudflare Workers binding, a browser bundle, or a secrets payload you fetched from a store at boot.
+  On Node, Bun, and Deno one binds on import.
+- **Zero runtime dependencies.** The reader, converters, and built-in `.env` parser are self-contained,
+  so nothing is added to your dependency tree.
 - **Runs on Node, Bun, Deno, Cloudflare Workers, and the browser.** Node `>=20`, Bun `>=1.3`, Deno
-  `>=2.5` (ESM and CJS); the Workers and browser builds resolve through the package `exports`
+  `>=2.5` (ESM and CJS). The Workers and browser builds resolve through the package `exports`
   conditions.
-- **`.env` loading on Node, Bun, and Deno.** A per-environment file cascade, `${VAR}` templates, and
-  strict / required checks. Off Node there is no filesystem, so you bind a source with
-  `Envapter.useSource(...)` and read with the same typed API.
+- **`.env` loading built in on Node.** The default Node source adds a per-environment file cascade,
+  `${VAR}` templates, and strict / required checks. Off Node there is no filesystem, so you bind
+  another source with `Envapter.useSource(...)` and read with the same typed API.
 
 ## Install
 
@@ -62,7 +66,7 @@ Both share the same parsing, converters, and cache.
 ### Functional
 
 Read a value from any call site, in JavaScript or TypeScript. No build step. On Node the source is
-bound for you; on Workers and in the browser, call `Envapter.useSource(...)` first.
+bound for you. On Workers and in the browser, call `Envapter.useSource(...)` first.
 
 ```ts
 import { Envapter, Converters } from 'envapt';

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -2,7 +2,7 @@
     "name": "envapt",
     "type": "module",
     "version": "6.0.0",
-    "description": "Type-safe environment variables for TypeScript. Zero-dependency .env loader and parser with one API across Node, Bun, Deno, Cloudflare Workers, and the Browser. Decorators, converters, Standard Schema (zod/valibot/arktype) validation, and much more.",
+    "description": "Type-safe config for TypeScript. Read typed values from any source, process.env, .env files, Cloudflare Workers bindings, browser bundles, or any object you supply. Zero runtime dependencies, one API across Node, Bun, Deno, Workers, and the browser. Decorators, converters, and Standard Schema (zod/valibot/arktype) validation.",
     "types": "./dist/node/index.d.mts",
     "exports": {
         ".": {


### PR DESCRIPTION
## Summary

Stops marketing envapt as a `.env` reader and leads with what it is, a typed config reader over any bound source. The `.env` cascade is reframed as the default Node source, not the headline.

- Home page: hero now "Typed config, from any source", "Bind a source" section moved up to second, `.env` section demoted and retitled, closing CTA reworded. Eyebrows keep the "apt" pun.
- Distribution copy: package description, site meta, OG card, and OG snippets reframed. npm keywords unchanged (kept `.env`/`dotenv` for search). GitHub About updated.
- Docs: index, quick-start, configuration, environment, templates, compatibility, sources, workers, envapter reworded so source-binding is the core and `.env` is one built-in.
- New page `docs/secret-stores.mdx`: bind 1Password, Vault, Doppler, AWS, Infisical, Bitwarden via a fetched source, with the sync `readVars` and cache-timing caveats. Each example shows a distinct typed read.
- README (root + package) and the blog post reframed.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation

## Notes

- No library source changed. The only publishable change is the package `description`, hence a patch changeset.
- Verified the secret-store SDK snippets against current docs. Each carries a caveat (1Password SDK pre-1.0, `node-vault` community-maintained, Bitwarden beta, Doppler auth scheme to confirm).

## Tests

- [x] `pnpm lint:fix`, `pnpm tc`, `pnpm lint:fix:md` clean
- [x] `pnpm test` passes
- [x] Guide `build` passes (all twoslash blocks type-check)

## Docs and changesets

- [x] Docs updated
- [x] Patch changeset added
