### PR TITLE
fix(build): dedupe public type declarations across runtime entry points

### DIFF
--- a/.changeset/dedupe-runtime-type-exports.md
+++ b/.changeset/dedupe-runtime-type-exports.md
@@ -2,4 +2,4 @@
 'envapt': patch
 ---
 
-Editor auto-import now suggests each public name once instead of once per runtime build. The published type declarations are emitted as a single shared tree that the Node, Workers, and browser entry points all re-export, so `Envapt`, `Envapter`, the converters, and the rest resolve to one declaration. The Workers and browser entries still expose the portable `Envapter` without the file-only APIs.
+Editor auto-import now suggests each public name once instead of once per runtime build. The published type declarations are emitted as a single shared tree that the Node, Workers, and browser entry points all re-export, so `Envapt`, `Envapter`, the converters, and the rest resolve to one declaration. The Workers and browser entries still expose the portable `Envapter` without the file-only APIs. The package no longer ships the redundant per-runtime declaration trees, so the install is smaller.

--- a/.changeset/dedupe-runtime-type-exports.md
+++ b/.changeset/dedupe-runtime-type-exports.md
@@ -1,0 +1,5 @@
+---
+'envapt': patch
+---
+
+Editor auto-import now suggests each public name once instead of once per runtime build. The published type declarations are emitted as a single shared tree that the Node, Workers, and browser entry points all re-export, so `Envapt`, `Envapter`, the converters, and the rest resolve to one declaration. The Workers and browser entries still expose the portable `Envapter` without the file-only APIs.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,6 +56,8 @@ jobs:
               run: pnpm lint
             - name: Run tests
               run: pnpm test
+            - name: Run exports-dedup guard
+              run: pnpm --filter envapt test:exports-dedup
             - name: Run tsc-emit decorator guard
               run: pnpm --filter envapt test:tsc-emit
             - name: Run stage3-emit decorator guard

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -91,7 +91,10 @@
         "./dist/workerd/index.mjs"
     ],
     "files": [
-        "dist",
+        "dist/**/*.mjs",
+        "dist/**/*.cjs",
+        "dist/**/*.map",
+        "dist/types",
         "NOTICE.md",
         "LICENSE",
         "README.md",

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -3,82 +3,82 @@
     "type": "module",
     "version": "7.0.0-next.0",
     "description": "Type-safe config for TypeScript. Read typed values from any source, process.env, .env files, Cloudflare Workers bindings, browser bundles, or any object you supply. Zero runtime dependencies, one API across Node, Bun, Deno, Workers, and the browser. TC39 accessor decorators (legacy decorators at envapt/legacy), converters, and Standard Schema (zod/valibot/arktype) validation.",
-    "types": "./dist/node/index.d.mts",
+    "types": "./dist/types/index.d.mts",
     "exports": {
         ".": {
             "workerd": {
-                "types": "./dist/workerd/index.d.mts",
+                "types": "./dist/types/index.portable.d.mts",
                 "default": "./dist/workerd/index.mjs"
             },
             "browser": {
-                "types": "./dist/browser/index.d.mts",
+                "types": "./dist/types/index.portable.d.mts",
                 "default": "./dist/browser/index.mjs"
             },
             "node": {
                 "import": {
-                    "types": "./dist/node/index.d.mts",
+                    "types": "./dist/types/index.d.mts",
                     "default": "./dist/node/index.mjs"
                 },
                 "require": {
-                    "types": "./dist/node/index.d.cts",
+                    "types": "./dist/types/index.d.mts",
                     "default": "./dist/node/index.cjs"
                 }
             },
             "default": {
                 "import": {
-                    "types": "./dist/node/index.d.mts",
+                    "types": "./dist/types/index.d.mts",
                     "default": "./dist/node/index.mjs"
                 },
                 "require": {
-                    "types": "./dist/node/index.d.cts",
+                    "types": "./dist/types/index.d.mts",
                     "default": "./dist/node/index.cjs"
                 }
             }
         },
         "./workerd": {
-            "types": "./dist/workerd/index.d.mts",
+            "types": "./dist/types/index.portable.d.mts",
             "default": "./dist/workerd/index.mjs"
         },
         "./browser": {
-            "types": "./dist/browser/index.d.mts",
+            "types": "./dist/types/index.portable.d.mts",
             "default": "./dist/browser/index.mjs"
         },
         "./config": {
             "import": {
-                "types": "./dist/node/config.d.mts",
+                "types": "./dist/types/config.d.mts",
                 "default": "./dist/node/config.mjs"
             },
             "require": {
-                "types": "./dist/node/config.d.cts",
+                "types": "./dist/types/config.d.mts",
                 "default": "./dist/node/config.cjs"
             }
         },
         "./legacy": {
             "workerd": {
-                "types": "./dist/workerd/legacy.d.mts",
+                "types": "./dist/types/legacy.d.mts",
                 "default": "./dist/workerd/legacy.mjs"
             },
             "browser": {
-                "types": "./dist/browser/legacy.d.mts",
+                "types": "./dist/types/legacy.d.mts",
                 "default": "./dist/browser/legacy.mjs"
             },
             "node": {
                 "import": {
-                    "types": "./dist/node/legacy.d.mts",
+                    "types": "./dist/types/legacy.d.mts",
                     "default": "./dist/node/legacy.mjs"
                 },
                 "require": {
-                    "types": "./dist/node/legacy.d.cts",
+                    "types": "./dist/types/legacy.d.mts",
                     "default": "./dist/node/legacy.cjs"
                 }
             },
             "default": {
                 "import": {
-                    "types": "./dist/node/legacy.d.mts",
+                    "types": "./dist/types/legacy.d.mts",
                     "default": "./dist/node/legacy.mjs"
                 },
                 "require": {
-                    "types": "./dist/node/legacy.d.cts",
+                    "types": "./dist/types/legacy.d.mts",
                     "default": "./dist/node/legacy.cjs"
                 }
             }
@@ -120,6 +120,7 @@
         "test:workers": "tsc --noEmit -p tests/workers/tsconfig.json && vitest run --config vitest.workers.config.ts",
         "test:browser": "tsc --noEmit -p tests/browser/tsconfig.json && vitest run --config vitest.browser.config.ts",
         "test:consumer-build": "node tests/consumer-build/run.mjs",
+        "test:exports-dedup": "node tests/exports-dedup/run.mjs",
         "test:tsc-emit": "node tests/tsc-emit/run.mjs",
         "test:stage3-emit": "node tests/stage3-emit/run.mjs",
         "test:all": "node ../../scripts/test-all.mjs",

--- a/packages/envapt/scripts/verify-no-node.ts
+++ b/packages/envapt/scripts/verify-no-node.ts
@@ -129,7 +129,7 @@ async function stubProof(): Promise<void> {
     process.stdout.write('verify-no-node: workerd + browser file-API stubs throw FileApiUnsupported (306).\n');
 }
 
-// Generated at runtime, not checked in: it imports built artifacts absent at `tc` time. A dts
+// Generated at runtime, not checked in. It imports built artifacts absent at `tc` time. A dts
 // regression that re-adds a file API leaves a fixture suppression unused, so tsc errors.
 function omissionProof(): void {
     const localRequire = createRequire(import.meta.url);
@@ -139,11 +139,11 @@ function omissionProof(): void {
     const omit = (alias: string, api: string): string =>
         `// @ts-expect-error ${api} is omitted from the portable Envapter\nvoid ${alias}.${api};`;
     const body = [
-        `import { Envapter as B } from ${JSON.stringify(join(DIST, 'browser', 'index.mjs'))};`,
-        `import { Envapter as W } from ${JSON.stringify(join(DIST, 'workerd', 'index.mjs'))};`,
-        ...FILE_APIS.map((api) => omit('B', api)),
-        omit('W', 'resetProfiles'),
-        'void B.useSource;'
+        `import { Envapter as P } from ${JSON.stringify(join(DIST, 'types', 'index.portable.mjs'))};`,
+        `import { Envapter as N } from ${JSON.stringify(join(DIST, 'types', 'index.mjs'))};`,
+        ...FILE_APIS.map((api) => omit('P', api)),
+        'void P.useSource;',
+        ...FILE_APIS.map((api) => `void N.${api};`)
     ].join('\n');
     writeFileSync(fixture, `${body}\n`);
     try {
@@ -177,7 +177,28 @@ function omissionProof(): void {
     );
 }
 
+// The public types are all emitted to dist/types, shims-free, so no entry carries a node:* import. A
+// leak here would reach portable consumers without appearing in the workerd/browser grep above.
+function typesNodeFreeProof(): void {
+    const violations: string[] = [];
+    for (const file of walk(join(DIST, 'types'))) {
+        if (!isDeclaration(file)) continue;
+        readFileSync(file, 'utf8')
+            .split('\n')
+            .forEach((line, i) => {
+                if (NODE_SPECIFIER.test(line)) violations.push(`${file}:${i + 1} node: specifier -> ${line.trim()}`);
+            });
+    }
+    if (violations.length > 0) {
+        fail(
+            `verify-no-node: ${violations.length} node coupling(s) in dist/types declarations:\n  ${violations.join('\n  ')}`
+        );
+    }
+    process.stdout.write('verify-no-node: dist/types declarations are node-free.\n');
+}
+
 selfTest();
 grepGate();
+typesNodeFreeProof();
 await stubProof();
 omissionProof();

--- a/packages/envapt/src/browser.ts
+++ b/packages/envapt/src/browser.ts
@@ -1,8 +1,5 @@
-import { Envapter } from './engine/Envapter';
 import { installFileApiStubs } from './engine/installFileApiStubs';
 
-export * from './common';
-export * from './decorators/modern';
-export { Envapter };
+export * from './index.portable';
 
 installFileApiStubs();

--- a/packages/envapt/src/index.portable.ts
+++ b/packages/envapt/src/index.portable.ts
@@ -1,0 +1,3 @@
+export * from './common';
+export * from './decorators/modern';
+export { Envapter } from './engine/Envapter';

--- a/packages/envapt/tests/exports-dedup/run.mjs
+++ b/packages/envapt/tests/exports-dedup/run.mjs
@@ -1,0 +1,90 @@
+// Build gate. A public name must resolve to a single declaration across the runtime entry points, so
+// an editor offers one auto-import per name, not one per runtime build.
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const require = createRequire(import.meta.url);
+const ts = require('typescript');
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgDir = resolve(here, '..', '..');
+const pkg = JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf8'));
+
+// Envapter is the one exception because its Node (NodeEnvapter) and portable surfaces deliberately differ
+const ALLOWED_TO_DIFFER = new Set(['Envapter']);
+
+function collectTypesFiles(entry, out = new Set()) {
+    if (typeof entry === 'string') return out;
+    for (const [key, value] of Object.entries(entry)) {
+        if (key === 'types' && typeof value === 'string') out.add(resolve(pkgDir, value));
+        else if (value && typeof value === 'object') collectTypesFiles(value, out);
+    }
+    return out;
+}
+
+const groups = {
+    index: collectTypesFiles({
+        a: pkg.exports['.'],
+        b: pkg.exports['./workerd'],
+        c: pkg.exports['./browser']
+    }),
+    legacy: collectTypesFiles(pkg.exports['./legacy'])
+};
+
+const allFiles = [...new Set([...groups.index, ...groups.legacy])];
+const program = ts.createProgram(allFiles, {
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    target: ts.ScriptTarget.ESNext,
+    skipLibCheck: true,
+    noEmit: true
+});
+const checker = program.getTypeChecker();
+
+function originFile(symbol) {
+    let resolved = symbol;
+    if (resolved.flags & ts.SymbolFlags.Alias) resolved = checker.getAliasedSymbol(resolved);
+    return resolved.declarations?.[0]?.getSourceFile().fileName;
+}
+
+function exportOrigins(files) {
+    const origins = new Map();
+    for (const file of files) {
+        const source = program.getSourceFile(file);
+        assert.ok(source, `entry types file not found (build first?): ${file}`);
+        const moduleSymbol = checker.getSymbolAtLocation(source);
+        assert.ok(moduleSymbol, `no module symbol for ${file}`);
+        for (const exp of checker.getExportsOfModule(moduleSymbol)) {
+            const origin = originFile(exp);
+            if (!origin) continue;
+            if (!origins.has(exp.name)) origins.set(exp.name, new Set());
+            origins.get(exp.name).add(origin);
+        }
+    }
+    return origins;
+}
+
+const violations = [];
+for (const [group, files] of Object.entries(groups)) {
+    for (const [name, origins] of exportOrigins(files)) {
+        if (origins.size > 1 && !ALLOWED_TO_DIFFER.has(name)) {
+            violations.push(
+                `${group}: "${name}" resolves to ${origins.size} declarations:\n    ${[...origins].map((f) => f.replace(`${pkgDir}/`, '')).join('\n    ')}`
+            );
+        }
+    }
+}
+
+if (violations.length > 0) {
+    process.stderr.write(
+        `exports-dedup: ${violations.length} name(s) duplicate across runtime entry points:\n  ${violations.join('\n  ')}\n`
+    );
+    process.exit(1);
+}
+process.stdout.write(
+    'exports-dedup: every public name resolves to a single declaration across runtime entry points.\n'
+);

--- a/packages/envapt/tsconfig.json
+++ b/packages/envapt/tsconfig.json
@@ -20,6 +20,7 @@
         "tests/workers/**",
         "tests/browser/**",
         "tests/consumer-build/**",
+        "tests/exports-dedup/**",
         "tests/tsc-emit/**",
         "tests/stage3-emit/**",
         "tests/integration/modern-decorator-check.ts"

--- a/packages/envapt/tsdown.config.ts
+++ b/packages/envapt/tsdown.config.ts
@@ -14,6 +14,8 @@ const shared = {
     target: 'es2022'
 } as const satisfies UserConfig;
 
+// Each runtime build emits its own sibling dts so the deep-import tests resolve against the exact built
+// JS. package.json points every `types` at the single dist/types tree below, not at these.
 export default defineConfig([
     // shims injects __dirname/process for the node:* sources.
     {
@@ -42,5 +44,23 @@ export default defineConfig([
         shims: false,
         fixedExtension: true,
         outDir: 'dist/browser'
+    },
+    // The published types, emitted once and shims-free so no entry carries a node:* banner and every
+    // entry shares one declaration (one auto-import per name, not one per runtime build). emitDtsOnly
+    // drops the JS. esm-only avoids a second cjs bundle here.
+    {
+        ...shared,
+        dts: { emitDtsOnly: true },
+        entry: {
+            index: 'src/index.ts',
+            'index.portable': 'src/index.portable.ts',
+            config: 'src/config.ts',
+            legacy: 'src/legacy.ts'
+        },
+        format: ['esm'],
+        platform: 'neutral',
+        shims: false,
+        fixedExtension: true,
+        outDir: 'dist/types'
     }
 ]);

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -26,6 +26,7 @@ const slices = [
     ['integration', ['--filter', 'envapt', 'test:integration']],
     ['workerd', ['--filter', 'envapt', 'test:workers']],
     ['consumer-build', ['--filter', 'envapt', 'test:consumer-build']],
+    ['exports-dedup', ['--filter', 'envapt', 'test:exports-dedup']],
     ['tsc-emit', ['--filter', 'envapt', 'test:tsc-emit']],
     ['stage3-emit', ['--filter', 'envapt', 'test:stage3-emit']]
 ];


### PR DESCRIPTION
## What and why

Type declarations were emitted once per runtime build, so an editor offered each public name up to three times in auto-import. This emits them once into a shared `dist/types` tree that the Node, Workers, and browser entries all re-export, so each name resolves to one declaration (`Envapter` still shows twice, the Node and portable types differ by design). `files` also drops the now-redundant per-build declarations from the published package (131KB to 111KB gzipped).

## Checklist

- [x] New or regression tests cover the change
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed