### PR TITLE
perf(build): make browser and workerd entries tree-shakeable

### DIFF
--- a/.changeset/tree-shake-portable-entries.md
+++ b/.changeset/tree-shake-portable-entries.md
@@ -1,0 +1,5 @@
+---
+'envapt': patch
+---
+
+The `envapt/browser` and `envapt/workerd` builds are now side-effect-free, so a bundler can drop the parts of envapt a consumer never imports. Importing a single export such as `EnvaptError` or `Converters` from the portable builds now ships about 1.3 kB instead of about 22 kB. The filesystem-only APIs (`envPaths`, `baseDir`, `envFileOptions`, `configureProfiles`, `resetProfiles`) still throw `EnvaptError` on the browser and Workers builds, their stubs moved onto the portable `Envapter` class so they install only when that class is used.

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -86,9 +86,7 @@
     },
     "sideEffects": [
         "./dist/node/config.cjs",
-        "./dist/node/config.mjs",
-        "./dist/browser/index.mjs",
-        "./dist/workerd/index.mjs"
+        "./dist/node/config.mjs"
     ],
     "files": [
         "dist/**/*.mjs",
@@ -123,6 +121,7 @@
         "test:workers": "tsc --noEmit -p tests/workers/tsconfig.json && vitest run --config vitest.workers.config.ts",
         "test:browser": "tsc --noEmit -p tests/browser/tsconfig.json && vitest run --config vitest.browser.config.ts",
         "test:consumer-build": "node tests/consumer-build/run.mjs",
+        "test:tree-shaking": "node tests/tree-shaking/run.mjs",
         "test:exports-dedup": "node tests/exports-dedup/run.mjs",
         "test:tsc-emit": "node tests/tsc-emit/run.mjs",
         "test:stage3-emit": "node tests/stage3-emit/run.mjs",

--- a/packages/envapt/src/browser.ts
+++ b/packages/envapt/src/browser.ts
@@ -1,5 +1,1 @@
-import { installFileApiStubs } from './engine/installFileApiStubs';
-
 export * from './index.portable';
-
-installFileApiStubs();

--- a/packages/envapt/src/engine/PortableEnvapter.ts
+++ b/packages/envapt/src/engine/PortableEnvapter.ts
@@ -1,0 +1,18 @@
+import { Envapter } from './Envapter';
+import { installFileApiStubs } from './installFileApiStubs';
+
+/**
+ * The browser/Workers facade. {@link Envapter} with the filesystem-only configuration APIs
+ * (`envPaths`, `baseDir`, `envFileOptions`, `configureProfiles`, `resetProfiles`) stubbed to throw
+ * {@link EnvaptError}. The portable types omit those APIs, so the stubs only guard JS callers that
+ * bypass the types.
+ * @public
+ */
+export class PortableEnvapter extends Envapter {
+    // A static block (not a top-level statement in a separate entry) keeps the stub install intrinsic to
+    // this class, so it tree-shakes out of a leaf import and needs no sideEffects entry. Depends on the
+    // es2022 native static-block emit, lowering the target defeats it.
+    static {
+        installFileApiStubs(PortableEnvapter);
+    }
+}

--- a/packages/envapt/src/engine/installFileApiStubs.ts
+++ b/packages/envapt/src/engine/installFileApiStubs.ts
@@ -1,4 +1,3 @@
-import { Envapter } from './Envapter';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
 const FILE_ONLY_APIS = ['envPaths', 'baseDir', 'envFileOptions', 'configureProfiles', 'resetProfiles'] as const;
@@ -10,11 +9,11 @@ function fileApiUnsupported(api: string): never {
     );
 }
 
-// Call from each entry's own top level, not via `export * from` another entry: the build tree-shakes a
-// re-exported entry's side effect away, which would silently drop these stubs from that entry's output.
-export function installFileApiStubs(): void {
+// Call from a class static block, not an entry top level, or the build drops the stubs from a
+// re-exported entry as a tree-shaken side effect.
+export function installFileApiStubs(target: object): void {
     for (const api of FILE_ONLY_APIS) {
-        Object.defineProperty(Envapter, api, {
+        Object.defineProperty(target, api, {
             configurable: true,
             get: () => fileApiUnsupported(api),
             set: () => fileApiUnsupported(api)

--- a/packages/envapt/src/index.portable.ts
+++ b/packages/envapt/src/index.portable.ts
@@ -1,3 +1,3 @@
 export * from './common';
 export * from './decorators/modern';
-export { Envapter } from './engine/Envapter';
+export { PortableEnvapter as Envapter } from './engine/PortableEnvapter';

--- a/packages/envapt/src/workerd.ts
+++ b/packages/envapt/src/workerd.ts
@@ -1,5 +1,1 @@
-import { installFileApiStubs } from './engine/installFileApiStubs';
-
 export * from './browser';
-
-installFileApiStubs();

--- a/packages/envapt/tests/tree-shaking/run.mjs
+++ b/packages/envapt/tests/tree-shaking/run.mjs
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import * as esbuild from 'esbuild';
+
+const resolveDir = dirname(fileURLToPath(import.meta.url));
+
+// A leaf import that touches none of the reader machinery. If the entry is side-effect-free the bundler
+// drops the whole Envapter graph, leaving only the error type.
+const leafProgram = (specifier) => `import { EnvaptError } from '${specifier}';globalThis.__envapt = EnvaptError;`;
+
+// Markers for code that must NOT survive a leaf import, a converter body and the Standard Schema dispatch.
+const HEAVY_MARKERS = [/new URL\(/, /~standard/, /JSON\.parse/];
+const MAX_LEAF_BYTES = 4000;
+
+const cases = [
+    { name: 'envapt/browser leaf', specifier: 'envapt/browser', platform: 'browser', conditions: [] },
+    { name: 'envapt/workerd leaf', specifier: 'envapt/workerd', platform: 'neutral', conditions: ['workerd'] },
+    { name: 'envapt leaf (browser)', specifier: 'envapt', platform: 'browser', conditions: [] },
+    { name: 'envapt leaf (workerd)', specifier: 'envapt', platform: 'neutral', conditions: ['workerd'] }
+];
+
+let failures = 0;
+for (const testCase of cases) {
+    try {
+        const result = await esbuild.build({
+            stdin: { contents: leafProgram(testCase.specifier), resolveDir, loader: 'js' },
+            bundle: true,
+            write: false,
+            minify: true,
+            format: 'esm',
+            platform: testCase.platform,
+            conditions: testCase.conditions,
+            logLevel: 'silent'
+        });
+        const output = result.outputFiles[0].text;
+        for (const marker of HEAVY_MARKERS) {
+            assert.ok(!marker.test(output), `${testCase.name}: leaf bundle retained ${marker} (graph not tree-shaken)`);
+        }
+        assert.ok(
+            output.length < MAX_LEAF_BYTES,
+            `${testCase.name}: leaf bundle is ${output.length} bytes, expected < ${MAX_LEAF_BYTES}`
+        );
+        process.stdout.write(`tree-shaking ${testCase.name}: OK (${output.length} bytes)\n`);
+    } catch (err) {
+        failures += 1;
+        process.stderr.write(`tree-shaking ${testCase.name}: FAIL\n`);
+        process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    }
+}
+
+if (failures > 0) {
+    process.stderr.write(`tree-shaking: ${failures} portable entry/entries do not tree-shake a leaf import\n`);
+    process.exit(1);
+}
+process.stdout.write('tree-shaking: every portable leaf import tree-shakes the Envapter graph\n');

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -26,6 +26,7 @@ const slices = [
     ['integration', ['--filter', 'envapt', 'test:integration']],
     ['workerd', ['--filter', 'envapt', 'test:workers']],
     ['consumer-build', ['--filter', 'envapt', 'test:consumer-build']],
+    ['tree-shaking', ['--filter', 'envapt', 'test:tree-shaking']],
     ['exports-dedup', ['--filter', 'envapt', 'test:exports-dedup']],
     ['tsc-emit', ['--filter', 'envapt', 'test:tsc-emit']],
     ['stage3-emit', ['--filter', 'envapt', 'test:stage3-emit']]


### PR DESCRIPTION
## What and why

The browser and Workers entries called `installFileApiStubs()` at their top level, a side effect that ran `Object.defineProperty` on the `Envapter` class and pinned the whole class graph. Both entries were also listed in `sideEffects`, so a bundler kept the entire library for any import from `envapt/browser` or `envapt/workerd`, even `import { EnvaptError }`. The stubs now install from a `PortableEnvapter` static block (mirroring how `NodeEnvapter` binds its source), so they tree-shake out of imports that never touch the class, and the two entries leave the `sideEffects` array. A single-export import from the portable builds drops from about 22 kB to about 1.3 kB. The five filesystem-only APIs still throw `EnvaptError` and the portable types still omit them, both proven by `build:verify`. The reader path (`Envapter.get`/`getNumber`) is unchanged.

## Checklist

- [x] New or regression tests cover the change (`tests/tree-shaking/run.mjs`, plus the existing `031-portable-stubs` behavior test)
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed