### PR TITLE
fix: cjs output esm banner

### DIFF
--- a/.changeset/cjs-esm-banner-fix.md
+++ b/.changeset/cjs-esm-banner-fix.md
@@ -1,0 +1,5 @@
+---
+'envapt': patch
+---
+
+fix malformed CJS output (tsdown shim banner leaked ESM syntax into every .cjs)

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,5 +5,7 @@
     "@envapt/guide": "1.0.0",
     "envapt": "7.0.1"
   },
-  "changesets": []
+  "changesets": [
+    "cjs-esm-banner-fix"
+  ]
 }

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to Envapt
+# Contributing to envapt
 
-Thanks for your interest in making Envapt better! I appreciate any help, whether it's fixing bugs, adding features, or improving documentation.
+I appreciate any help, whether it's fixing bugs, adding features, or improving documentation.
 
 ## Getting Started
 
@@ -84,6 +84,14 @@ I use a very strict ESLint config accompanied by Prettier to keep code consisten
 - Add comments for complex logic
 - Keep functions small and focused
 
+## AI-generated code
+
+AI tools are fine, I use them too. The bar is just the same as any other code. You have to actually understand what you're submitting and review it properly before it goes up. Don't send a PR with code you couldn't explain or debug yourself, and if a someone (most prolly me) asks why something works, "the AI wrote it" isn't an answer.
+
+Same for anything you write in the repo. Issues, PR descriptions, and review replies/comments should come from **you**, the person who read and understood the change. I want to talk through it with the human doing the work.
+
+AI code also has a habit of looking correct while missing edge cases, so the test and coverage rules above matter even more here. Preferrably use test-driven development when using AI.
+
 ## CI and checks
 
 All pull requests must have
@@ -125,4 +133,4 @@ If you have questions or need help:
 
 ---
 
-Thank you for helping improve Envapt!
+Thank you for helping improve envapt!

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -86,11 +86,11 @@ I use a very strict ESLint config accompanied by Prettier to keep code consisten
 
 ## AI-generated code
 
-AI tools are fine, I use them too. The bar is just the same as any other code. You have to actually understand what you're submitting and review it properly before it goes up. Don't send a PR with code you couldn't explain or debug yourself, and if a someone (most prolly me) asks why something works, "the AI wrote it" isn't an answer.
+AI tools are fine, I use them too. The bar is just the same as any other code. You have to actually understand what you're submitting and review it properly before it goes up. Don't send a PR with code you couldn't explain or debug yourself, and if someone (most probably me) asks why something is the way it is, "the AI wrote it" isn't an answer.
 
 Same for anything you write in the repo. Issues, PR descriptions, and review replies/comments should come from **you**, the person who read and understood the change. I want to talk through it with the human doing the work.
 
-AI code also has a habit of looking correct while missing edge cases, so the test and coverage rules above matter even more here. Preferrably use test-driven development when using AI.
+AI code also has a habit of looking correct while missing edge cases, so the test and coverage rules above matter even more here. Preferably use test-driven development when using AI.
 
 ## CI and checks
 

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -58,6 +58,8 @@ jobs:
               run: pnpm test
             - name: Run exports-dedup guard
               run: pnpm --filter envapt test:exports-dedup
+            - name: Run cjs-validity guard
+              run: pnpm --filter envapt test:cjs-validity
             - name: Run tsc-emit decorator guard
               run: pnpm --filter envapt test:tsc-emit
             - name: Run stage3-emit decorator guard

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ export const apiToken = Envapter.get('API_TOKEN');
 Bind a value to a class field with a TC39 accessor decorator. No `experimentalDecorators` flag, and it runs on Bun and Deno from `.ts` directly.
 
 ```ts
-import { EnvNum, Converters } from 'envapt';
+import { EnvNum } from 'envapt';
 
 class Config {
     @EnvNum('PORT', 3000)

--- a/packages/envapt/CHANGELOG.md
+++ b/packages/envapt/CHANGELOG.md
@@ -1,5 +1,11 @@
 # envapt
 
+## 7.0.2-next.0
+
+### Patch Changes
+
+- 5719aa6: fix malformed CJS output (tsdown shim banner leaked ESM syntax into every .cjs)
+
 ## 7.0.1
 
 ### Patch Changes

--- a/packages/envapt/README.md
+++ b/packages/envapt/README.md
@@ -92,7 +92,7 @@ export const apiToken = Envapter.get('API_TOKEN');
 Bind a value to a class field with a TC39 accessor decorator. No `experimentalDecorators` flag, and it runs on Bun and Deno from `.ts` directly.
 
 ```ts
-import { EnvNum, Converters } from 'envapt';
+import { EnvNum } from 'envapt';
 
 class Config {
     @EnvNum('PORT', 3000)

--- a/packages/envapt/deno.json
+++ b/packages/envapt/deno.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://raw.githubusercontent.com/denoland/deno/main/cli/schemas/config-file.v1.json",
     "name": "@materwelon/envapt",
-    "version": "7.0.1",
+    "version": "7.0.2-next.0",
     "exports": {
         ".": "./src/index.ts",
         "./legacy": "./src/legacy.ts"

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -1,7 +1,7 @@
 {
     "name": "envapt",
     "type": "module",
-    "version": "7.0.1",
+    "version": "7.0.2-next.0",
     "description": "Type-safe config for TypeScript. Read typed values from any source, process.env, .env files, Cloudflare Workers bindings, browser bundles, or any object you supply. Zero runtime dependencies, one API across Node, Bun, Deno, Workers, and the browser. TC39 accessor decorators (legacy decorators at envapt/legacy), converters, and Standard Schema (zod/valibot/arktype) validation.",
     "types": "./dist/types/index.d.mts",
     "exports": {

--- a/packages/envapt/package.json
+++ b/packages/envapt/package.json
@@ -123,6 +123,7 @@
         "test:consumer-build": "node tests/consumer-build/run.mjs",
         "test:tree-shaking": "node tests/tree-shaking/run.mjs",
         "test:exports-dedup": "node tests/exports-dedup/run.mjs",
+        "test:cjs-validity": "node tests/cjs-validity/run.mjs",
         "test:tsc-emit": "node tests/tsc-emit/run.mjs",
         "test:stage3-emit": "node tests/stage3-emit/run.mjs",
         "test:all": "node ../../scripts/test-all.mjs",

--- a/packages/envapt/tests/cjs-validity/run.mjs
+++ b/packages/envapt/tests/cjs-validity/run.mjs
@@ -1,0 +1,58 @@
+// Build gate. Every emitted `.cjs` must parse and `require()` as CommonJS. ESM syntax leaking into a
+// `.cjs` (a `shims`/banner regression) still loads as ESM, so the runtime builds pass while every
+// `require('envapt')` consumer breaks.
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { dirname, join, resolve } from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const nodeDist = resolve(here, '..', '..', 'dist', 'node');
+const require = createRequire(import.meta.url);
+
+const cjsFiles = readdirSync(nodeDist, { recursive: true }).filter((name) => name.endsWith('.cjs'));
+assert.ok(cjsFiles.length > 0, `no .cjs files under ${nodeDist} (build first?)`);
+
+let failures = 0;
+
+// `.cjs` forces Node's CommonJS parser, so a top-level `import`/`import.meta` is a SyntaxError here.
+for (const name of cjsFiles) {
+    const file = join(nodeDist, name);
+    try {
+        execFileSync('node', ['--check', file], { stdio: 'pipe' });
+    } catch (err) {
+        failures += 1;
+        process.stderr.write(`cjs-validity: ${name} is not valid CommonJS\n`);
+        process.stderr.write(`${err instanceof Error && err.stderr ? err.stderr.toString() : String(err)}\n`);
+    }
+}
+
+// --check is syntax-only, so also load each entry the way a consumer does to prove the graph resolves
+const entries = [
+    { file: 'index.cjs', expect: ['Envapter', 'Envapt', 'Converters', 'EnvaptError'] },
+    { file: 'legacy.cjs', expect: ['Envapt', 'EnvNum'] },
+    { file: 'config.cjs', expect: [] }
+];
+for (const { file, expect } of entries) {
+    try {
+        // eslint-disable-next-line security/detect-non-literal-require -- loading built CJS entries by path is this gate's job
+        const loaded = require(join(nodeDist, file));
+        for (const name of expect) {
+            assert.ok(name in loaded, `${file}: missing export "${name}"`);
+        }
+        process.stdout.write(`cjs-validity: require('${file}') OK\n`);
+    } catch (err) {
+        failures += 1;
+        process.stderr.write(`cjs-validity: require('${file}') threw\n`);
+        process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    }
+}
+
+if (failures > 0) {
+    process.stderr.write(`cjs-validity: ${failures} check(s) failed\n`);
+    process.exit(1);
+}
+process.stdout.write(`cjs-validity: ${cjsFiles.length} .cjs files valid, all CJS entries require cleanly\n`);

--- a/packages/envapt/tsdown.config.ts
+++ b/packages/envapt/tsdown.config.ts
@@ -17,13 +17,11 @@ const shared = {
 // Each runtime build emits its own sibling dts so the deep-import tests resolve against the exact built
 // JS. package.json points every `types` at the single dist/types tree below, not at these.
 export default defineConfig([
-    // shims injects __dirname/process for the node:* sources.
     {
         ...shared,
         entry: { index: 'src/index.ts', config: 'src/config.ts', legacy: 'src/legacy.ts' },
         format: ['esm', 'cjs'],
         platform: 'node',
-        shims: true,
         outDir: 'dist/node'
     },
     // fixedExtension forces .mjs (it only defaults on for platform:node).

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -28,6 +28,7 @@ const slices = [
     ['consumer-build', ['--filter', 'envapt', 'test:consumer-build']],
     ['tree-shaking', ['--filter', 'envapt', 'test:tree-shaking']],
     ['exports-dedup', ['--filter', 'envapt', 'test:exports-dedup']],
+    ['cjs-validity', ['--filter', 'envapt', 'test:cjs-validity']],
     ['tsc-emit', ['--filter', 'envapt', 'test:tsc-emit']],
     ['stage3-emit', ['--filter', 'envapt', 'test:stage3-emit']]
 ];


### PR DESCRIPTION
## What and why

The published CJS build was broken. With `shims` and `unbundle` on, tsdown wrote an ESM banner into the `.cjs`, so `require('envapt')` threw `Cannot use import statement outside a module`. envapt uses none of the shimmed globals, so I dropped `shims` from the node build. The `.cjs` is valid again, the `.mjs` only loses dead code, and ESM behavior is unchanged.

A new `cjs-validity` gate runs in CI to guard against this coming back. It runs `node --check` on every emitted `.cjs` and `require()`s each entry.

Also bundles two small docs changes, a stray `Converters` import removed from the README decorator example, and a short AI-generated code section in CONTRIBUTING.

## Checklist

- [x] New or regression tests cover the change
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where ESM syntax could leak into generated `.cjs` files, causing malformed CommonJS output.
* **Tests**
  * Added a CommonJS validity check to ensure built `.cjs` artifacts pass syntax validation and load correctly.
  * Included the new validity check in the main CI/test run.
* **Documentation**
  * Updated the README decorator example to simplify the import.
  * Refreshed contributor guidance with an “AI-generated code” section.
* **Chores**
  * Bumped the `envapt` package version to `7.0.2-next.0` and updated changelog entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->