### PR TITLE
feat(core)!: add `getRequired` and `getRequiredAll`

### DIFF
--- a/.changeset/get-required.md
+++ b/.changeset/get-required.md
@@ -1,0 +1,7 @@
+---
+'envapt': major
+---
+
+Add `getRequired(key, converter)` and `getRequiredAll(spec, casing?)` for typed required reads. `getRequired` takes the converter positionally, returns the non-undefined value, and throws `MissingEnvValue` on a missing or empty key. `getRequiredAll` reads a group in one call and returns a typed record, throwing once listing every missing key. Its spec values can be tokens, `array()` tokens, or custom parser functions, and an optional `casing` (`'camelCase'`, `'PascalCase'`, or `'kebab-case'`) renames the record keys.
+
+Breaking: the `{ required: true }` options-bag form of `getUsing` and `getWith` is removed, use `getRequired` instead. The `@Envapt` decorator's `{ required: true }` option is unchanged.

--- a/.changeset/get-required.md
+++ b/.changeset/get-required.md
@@ -4,4 +4,4 @@
 
 Add `getRequired(key, converter)` and `getRequiredAll(spec, casing?)` for typed required reads. `getRequired` takes the converter positionally, returns the non-undefined value, and throws `MissingEnvValue` on a missing or empty key. `getRequiredAll` reads a group in one call and returns a typed record, throwing once listing every missing key. Its spec values can be tokens, `array()` tokens, or custom parser functions, and an optional `casing` (`'camelCase'`, `'PascalCase'`, or `'kebab-case'`) renames the record keys.
 
-Breaking: the `{ required: true }` options-bag form of `getUsing` and `getWith` is removed, use `getRequired` instead. The `@Envapt` decorator's `{ required: true }` option is unchanged.
+**BREAKING:** the `{ required: true }` options-bag form of `getUsing` and `getWith` is removed, use `getRequired` instead. The `@Envapt` decorator's `{ required: true }` option is unchanged.

--- a/apps/guide/content/docs/converters.mdx
+++ b/apps/guide/content/docs/converters.mdx
@@ -47,8 +47,8 @@ A fallback removes `undefined` from the return type, the same way it does for th
 
 <Callout type="info">
     A failed conversion never throws. `Url`, `Json`, `Date`, `Regexp`, and the number tokens swallow the parse error
-    and return the fallback, or `undefined` when you gave none. Use the `{ required: true }` form to throw on a
-    malformed value instead.
+    and return the fallback, or `undefined` when you gave none. Use `getRequired` to throw on a malformed or missing
+    value instead.
 </Callout>
 
 ## Number, Integer, and Float
@@ -183,7 +183,7 @@ Both readers take an options form that throws on a missing value instead of retu
 ```ts twoslash
 import { Envapter, Converters } from 'envapt';
 // ---cut---
-const dbUrl = Envapter.getUsing('DATABASE_URL', { converter: Converters.Url, required: true });
+const dbUrl = Envapter.getRequired('DATABASE_URL', Converters.Url);
 //    ^?
 ```
 

--- a/apps/guide/content/docs/envapter.mdx
+++ b/apps/guide/content/docs/envapter.mdx
@@ -121,23 +121,44 @@ See [Templates](/docs/templates) for `${VAR}` interpolation and cycle protection
 ```ts twoslash
 import { Envapter } from 'envapt';
 // ---cut---
+// Assuring all three keys are present at the start of the program, for example
 Envapter.require('DATABASE_URL', 'API_KEY', 'SENTRY_DSN');
 ```
 
-For a typed fail-fast that returns the parsed value, use the `{ required: true }` form on `getUsing` or `getWith`:
+For a typed fail-fast that returns the parsed value, use `getRequired`:
 
 ```ts twoslash
 import { Envapter, Converters } from 'envapt';
 // ---cut---
-const url = Envapter.getUsing('DATABASE_URL', { converter: Converters.Url, required: true });
+const url = Envapter.getRequired('DATABASE_URL', Converters.Url);
 //    ^?
 ```
 
-Both throw on a missing value instead of returning a fallback. See [Strict mode](/docs/strict-mode) for the global switch and how `required` relates to it.
+`getRequiredAll` reads a whole group in one call and returns a typed record, throwing once with every missing key. A spec value is a token, an `array()` token, or a custom parser, and an optional casing (`'camelCase'`, `'PascalCase'`, or `'kebab-case'`) renames the keys. Casing splits on underscores, so it expects the conventional `SCREAMING_SNAKE` env-var names:
+
+```ts twoslash
+import { Envapter, Converters } from 'envapt';
+// ---cut---
+const config = Envapter.getRequiredAll(
+    {
+        DATABASE_URL: Converters.Url,
+        PORT: Converters.Number,
+        FEATURE_FLAGS: (raw) => new Set(raw.split(','))
+    },
+    'camelCase'
+);
+
+config;
+// ^?
+```
+
+They throw on a missing value instead of returning a fallback. See [Strict mode](/docs/strict-mode) for the global switch and how required reads relate to it.
 
 <Callout type="danger">
-    `require` and the `{ required: true }` form throw `EnvaptError` the moment a key is missing or empty. Call them at
-    startup, not lazily inside a request path, so a missing value fails the boot rather than a live request.
+    `require`, `getRequired`, and `getRequiredAll` throw `EnvaptError` the moment a key is missing or empty.
+
+    Best to call `require` and `getRequiredAll` at startup, not lazily inside a request path, so a missing value fails the boot rather than a live request.
+
 </Callout>
 
 ## Static vs instance

--- a/apps/guide/content/docs/migration-v7-to-v8.mdx
+++ b/apps/guide/content/docs/migration-v7-to-v8.mdx
@@ -3,7 +3,7 @@ title: Migration (v7 to v8)
 description: Moving from envapt v7 to v8. The source classes get shorter names, one universal envapt import replaces the workerd and browser subpaths, and the portable file APIs warn instead of throwing by default.
 ---
 
-v8 is a major release with four breaking changes. The source classes are renamed, the `envapt/workerd` and `envapt/browser` subpaths are removed, the portable build's filesystem-only config APIs warn once and no-op by default instead of throwing, and the public type surface is trimmed. Everything else (the `Envapter` readers, converters, decorators, and `envapt/legacy`) is unchanged.
+v8 is a major release with **five** breaking changes. The source classes are renamed, the `envapt/workerd` and `envapt/browser` subpaths are removed, the portable build's filesystem-only config APIs warn once and no-op by default instead of throwing, the public type surface is trimmed, and the functional required-read bag moves to `getRequired`. Everything else (the positional `Envapter` readers, converters, decorators, and `envapt/legacy`) is unchanged.
 
 ## Source and type renames
 
@@ -64,6 +64,28 @@ The safety net is unchanged. An unconfigured read still throws `NoSourceBound` o
 ## The portable types now include the file APIs
 
 Before v8 the portable build's types omitted the five file APIs, so calling one was a compile error. v8 drops that fence. The portable types include them, so a config module shared between your Node dev setup and a Workers deploy type-checks the same in both places. At runtime you get the warn-once and no-op above, or a throw under `fileApiMode = 'throw'`.
+
+## Required reads move to `getRequired`
+
+The `{ required: true }` options-bag form of `getUsing` and `getWith` is removed. A required read is now `getRequired(key, converter)`, which takes the converter positionally, returns the non-undefined value, and throws `MissingEnvValue` when the key is missing or empty. New in v8, `getRequiredAll(spec)` reads a group of required values in one call and returns a typed record, throwing once with every missing key.
+
+```ts
+// v7
+const url = Envapter.getUsing('DATABASE_URL', { converter: Converters.Url, required: true });
+const upper = Envapter.getWith('NAME', { converter: (raw) => (raw ?? '').toUpperCase(), required: true });
+
+// v8
+const url = Envapter.getRequired('DATABASE_URL', Converters.Url);
+const upper = Envapter.getRequired('NAME', (raw) => raw.toUpperCase());
+
+// v8, several at once
+const { DATABASE_URL: db, PORT: port } = Envapter.getRequiredAll({
+    DATABASE_URL: Converters.Url,
+    PORT: Converters.Number
+});
+```
+
+`getUsing` and `getWith` keep their positional fallback forms unchanged. The `@Envapt` decorator's `{ required: true }` option stays, only the functional readers dropped the bag.
 
 ## Trimmed public type exports
 

--- a/apps/guide/content/docs/strict-mode.mdx
+++ b/apps/guide/content/docs/strict-mode.mdx
@@ -30,20 +30,22 @@ Three behaviors tighten when strict mode is on:
 
 A plain reader still returns the fallback (or `undefined`) for a missing value, even under strict mode. Strict mode changes how whitespace, templates, and array elements are treated; it does not turn every missing variable into a throw.
 
-To fail fast on a specific value, use `require` or the `{ required: true }` form. These throw on a missing value regardless of strict mode.
+To fail fast on a specific value, use `require` or `getRequired`. These throw on a missing value regardless of strict mode.
 
 ```ts twoslash
 import { Envapter, Converters } from 'envapt';
 // ---cut---
 // throws if unset, independent of Envapter.strict
-const s3Endpoint = Envapter.getUsing('S3_ENDPOINT_URL', { converter: Converters.Url, required: true });
+const s3Endpoint = Envapter.getRequired('S3_ENDPOINT_URL', Converters.Url);
 //    ^?
 
+// A decoupled require call. Can be used at the top level of a module to fail fast
+// on all missing values in one spot instead of scattering them throughout the codebase.
 Envapter.require('API_KEY', 'SENTRY_DSN');
 ```
 
 <Callout type="tip">
-    Use `required` / `require` when one specific value must be present. Turn on strict mode when you want stricter
+    Use `getRequired` / `require` when one specific value must be present. Turn on strict mode when you want stricter
     whitespace, template, and array-element rules everywhere.
 </Callout>
 

--- a/apps/guide/content/docs/workers.mdx
+++ b/apps/guide/content/docs/workers.mdx
@@ -12,9 +12,12 @@ Import from `envapt`. The package export conditions resolve a node-free portable
 The filesystem-only config APIs have nothing to do on Workers, so they warn and no-op by default. Readers work as normal. See [Compatibility](/docs/compatibility) for `fileApiMode` and [Errors](/docs/errors) for the codes.
 
 ```ts twoslash
-import { Envapter, PortableSource } from 'envapt';
+// @lib: esnext
+/// <reference types="@cloudflare/workers-types" />
 // ---cut---
-declare const env: Record<string, string>; // the Cloudflare env binding
+import { env } from 'cloudflare:workers';
+import { Envapter, PortableSource } from 'envapt';
+
 Envapter.useSource(new PortableSource(env));
 Envapter.getNumber('PORT', 3000); // readers work once a source is bound
 Envapter.envPaths = ['.env']; // warns once and no-ops on Workers
@@ -26,30 +29,59 @@ Envapter.envPaths = ['.env']; // warns once and no-ops on Workers
 
 Env vars and secrets are readable at module scope through `cloudflare:workers`, and they are constant for a deployment. Bind the source in a config module and export the typed values the Worker needs, so binding happens once per isolate instead of on every request.
 
-```ts title="src/config.ts"
+```ts title="src/config.ts" twoslash
+// @lib: esnext
+/// <reference types="@cloudflare/workers-types" />
+// ---cut---
 import { env } from 'cloudflare:workers';
 import { Envapter, PortableSource, Converters } from 'envapt';
 
 Envapter.useSource(new PortableSource(env));
-Envapter.require('ORIGIN_URL', 'API_TOKEN');
+const values = Envapter.getRequiredAll(
+    {
+        ORIGIN_URL: Converters.Url,
+        API_TOKEN: Converters.String
+    },
+    'camelCase'
+);
 
 export const config = {
-    origin: Envapter.getUsing('ORIGIN_URL', Converters.Url)!,
-    token: Envapter.get('API_TOKEN')!,
+    ...values,
     cacheTtl: Envapter.getUsing('CACHE_TTL', Converters.Time, '1m')
 };
 ```
 
-```ts title="src/index.ts"
+```ts title="src/index.ts" twoslash
+// @lib: esnext
+// @filename: config.ts
+/// <reference types="@cloudflare/workers-types" />
+import { env } from 'cloudflare:workers';
+import { Envapter, PortableSource, Converters } from 'envapt';
+
+Envapter.useSource(new PortableSource(env));
+const values = Envapter.getRequiredAll(
+    {
+        ORIGIN_URL: Converters.Url,
+        API_TOKEN: Converters.String
+    },
+    'camelCase'
+);
+
+export const config = {
+    ...values,
+    cacheTtl: Envapter.getUsing('CACHE_TTL', Converters.Time, '1m')
+};
+// @filename: index.ts
+// ---cut---
 import { config } from './config';
 
 export default {
     async fetch(request: Request): Promise<Response> {
-        if (request.headers.get('authorization') !== `Bearer ${config.token}`) {
+        if (request.headers.get('authorization') !== `Bearer ${config.apiToken}`) {
             return new Response('Unauthorized', { status: 401 });
         }
         const url = new URL(request.url);
-        return fetch(new URL(url.pathname + url.search, config.origin), request);
+        return fetch(new URL(url.pathname + url.search, config.originUrl), request);
     }
 } satisfies ExportedHandler;
 ```
@@ -64,16 +96,19 @@ export default {
 
 On an older compatibility date, or anywhere `env` is not importable at module scope, bind it at the top of the handler instead. The `env` is the same on every request, so the re-bind is idempotent.
 
-```ts title="src/index.ts"
+```ts title="src/index.ts" twoslash
+// @lib: esnext
+/// <reference types="@cloudflare/workers-types" />
+// ---cut---
 import { Envapter, PortableSource, Converters } from 'envapt';
 
 export default {
     async fetch(request: Request, env: Record<string, unknown>): Promise<Response> {
         Envapter.useSource(new PortableSource(env));
-        const origin = Envapter.getUsing('ORIGIN_URL', { converter: Converters.Url, required: true });
+        const origin = Envapter.getRequired('ORIGIN_URL', Converters.Url);
         return fetch(new URL(new URL(request.url).pathname, origin), request);
     }
-} satisfies ExportedHandler;
+} satisfies ExportedHandler<Record<string, unknown>>;
 ```
 
 ## Non-string bindings

--- a/apps/guide/package.json
+++ b/apps/guide/package.json
@@ -28,6 +28,7 @@
         "tailwind-merge": "^3.6.0"
     },
     "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260623.1",
         "@seedcord/eslint-config": "catalog:dev",
         "@tailwindcss/postcss": "4.3.1",
         "@types/mdx": "^2.0.14",

--- a/packages/envapt/src/core/AdvancedMethods.ts
+++ b/packages/envapt/src/core/AdvancedMethods.ts
@@ -151,7 +151,18 @@ export class AdvancedMethods extends PrimitiveMethods {
         key: EnvKeyInput,
         converter: TConverter | ConverterFunction<TReturnType, string>
     ): InferConverterReturnType<TConverter> | TReturnType {
-        const { key: resolvedKey, value } = resolveRequired(this.resolveKeyInput(key), this.templateResolver);
+        // a required read treats empty as missing, so an empty value falls through to the next candidate.
+        const candidates: readonly string[] = typeof key === 'string' ? [key] : key;
+        let resolvedKey = '';
+        let value: string | undefined;
+        for (const candidate of candidates) {
+            const resolved = resolveRequired(this.resolveKeyInput(candidate), this.templateResolver);
+            resolvedKey = resolved.key;
+            if (resolved.value !== undefined) {
+                value = resolved.value;
+                break;
+            }
+        }
         if (value === undefined) {
             throw new EnvaptError(
                 EnvaptErrorCodes.MissingEnvValue,
@@ -159,12 +170,20 @@ export class AdvancedMethods extends PrimitiveMethods {
             );
         }
         // cast widens the raw-string parser back to convertValue's ConverterFunction<T> (value proven present above).
-        return this.valueConverter.convertValue<TReturnType>(
+        const result = this.valueConverter.convertValue<TReturnType>(
             resolvedKey,
             undefined,
             converter as EnvaptConverter<TReturnType>,
             false
-        ) as InferConverterReturnType<TConverter> | TReturnType;
+        );
+        // convertValue returns null for a present value it can't convert, which would break the non-undefined return.
+        if (result === undefined || result === null) {
+            throw new EnvaptError(
+                EnvaptErrorCodes.MissingEnvValue,
+                `Required environment variable "${formatKeyForError(key)}" is present but could not be converted.`
+            );
+        }
+        return result;
     }
 
     /**
@@ -208,12 +227,19 @@ export class AdvancedMethods extends PrimitiveMethods {
         const result: Record<string, unknown> = {};
         for (const key of keys) {
             // same widening cast as getRequired, every value was proven present above.
-            result[recase(key, casing)] = this.valueConverter.convertValue<unknown>(
+            const converted = this.valueConverter.convertValue<unknown>(
                 key,
                 undefined,
                 spec[key] as EnvaptConverter<unknown>,
                 false
             );
+            if (converted === undefined || converted === null) {
+                throw new EnvaptError(
+                    EnvaptErrorCodes.MissingEnvValue,
+                    `Required environment variable "${key}" is present but could not be converted.`
+                );
+            }
+            result[recase(key, casing)] = converted;
         }
         return result as { [K in keyof Spec as RecaseKey<K & string, Casing>]: InferSpecField<Spec[K]> };
     }

--- a/packages/envapt/src/core/AdvancedMethods.ts
+++ b/packages/envapt/src/core/AdvancedMethods.ts
@@ -1,38 +1,40 @@
 import { PrimitiveMethods } from './PrimitiveMethods';
 import { debugWarn } from '../infra/Debug';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
+import { recase } from '../infra/recase';
 
 import type { ArrayOf } from '../converters';
+import type { TemplateResolver } from '../engine/TemplateResolver';
 import type { InferSchemaOutput, StandardSchemaV1 } from '../infra/StandardSchema';
 import type {
     AdvancedConverterReturn,
     BuiltInConverter,
     ConditionalReturn,
     ConverterFunction,
+    EnvaptConverter,
     EnvKeyInput,
     InferConverterReturnType,
+    InferSpecField,
+    KeyCasing,
+    RecaseKey,
+    RequiredSpec,
     SchemaConstraint,
     TimeFallback
 } from '../types';
 
-interface GetUsingRequiredOptions<TConverter> {
-    converter: TConverter;
-    required: true;
-}
-
-interface GetWithRequiredOptions<TReturnType> {
-    converter: ConverterFunction<TReturnType>;
-    required: true;
-}
-
-function isOptionsBag(value: unknown): value is { converter: unknown; required?: boolean; fallback?: unknown } {
-    // `ArrayOf` tokens have `of`/`delimiter` but no `converter` key, so the presence of
-    // `converter` discriminates the options-bag form from a positional converter token.
-    return typeof value === 'object' && value !== null && 'converter' in value;
-}
-
 function formatKeyForError(key: EnvKeyInput): string {
     return Array.isArray(key) ? `[${key.join(', ')}]` : String(key);
+}
+
+// template-resolve a present value, treating a post-trim-empty result as missing regardless of strict.
+// a module function so getRequired/getRequiredAll and Envapter.require share it without exposing it on any subclass.
+export function resolveRequired(
+    resolved: { key: string; value: string | undefined },
+    templateResolver: TemplateResolver
+): { key: string; value: string | undefined } {
+    if (resolved.value === undefined) return resolved;
+    const value = templateResolver.resolveTemplate(resolved.key, resolved.value);
+    return { key: resolved.key, value: value.trim() === '' ? undefined : value };
 }
 
 /**
@@ -44,8 +46,8 @@ export class AdvancedMethods extends PrimitiveMethods {
      * Get an environment variable using a built-in converter.
      *
      * Supports both scalar tokens (e.g. `Converters.Number`) and `ArrayOf<...>` tokens
-     * produced by `Converters.array(...)`. The key can be a single name or an ordered list;
-     * the first defined value wins.
+     * produced by `Converters.array(...)`. The key can be a single name or an ordered list.
+     * The first defined value wins.
      */
     // Time-specific overload must precede the generic BuiltInConverter overload so it wins
     // overload resolution (TimeFallback accepts time-strings like `'10s'`).
@@ -60,42 +62,16 @@ export class AdvancedMethods extends PrimitiveMethods {
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback>;
     static getUsing<TReturn>(key: EnvKeyInput, converter: BuiltInConverter | ArrayOf, fallback?: TReturn): TReturn;
-    static getUsing(key: EnvKeyInput, options: GetUsingRequiredOptions<'time'>): number;
-    static getUsing<TConverter extends BuiltInConverter | ArrayOf>(
-        key: EnvKeyInput,
-        options: GetUsingRequiredOptions<TConverter>
-    ): InferConverterReturnType<TConverter>;
     static getUsing<TConverter extends BuiltInConverter | ArrayOf, TFallback = undefined>(
         key: EnvKeyInput,
-        converterOrOptions: TConverter | GetUsingRequiredOptions<TConverter>,
+        converter: TConverter,
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback> {
-        if (isOptionsBag(converterOrOptions)) {
-            const options = converterOrOptions;
-            const { key: resolvedKey, value } = this.resolveKeyInput(key);
-
-            if (value === undefined || value.trim() === '') {
-                throw new EnvaptError(
-                    EnvaptErrorCodes.MissingEnvValue,
-                    `Required environment variable "${formatKeyForError(key)}" is missing or empty.`
-                );
-            }
-
-            const result = this.valueConverter.convertValue(
-                resolvedKey,
-                undefined,
-                options.converter as TConverter,
-                false
-            );
-            return result as AdvancedConverterReturn<TConverter, TFallback>;
-        }
-
-        const converter = converterOrOptions as TConverter;
         const { key: resolvedKey, value } = this.resolveKeyInput(key);
 
-        // No env value AND no fallback: return undefined to match primitive-method semantics.
-        // Otherwise route through the parser so asymmetric fallback types (TimeFallback,
-        // TimeFallback[] for `of: time` arrays) get coerced to the declared return type.
+        // missing with no fallback returns undefined, matching the primitive methods. with a fallback,
+        // route through the parser so asymmetric types (TimeFallback, TimeFallback[] for `of: time`)
+        // coerce to the return type.
         if (this.treatAsMissing(value) && fallback === undefined) {
             debugWarn(`${resolvedKey} is missing or empty`);
             return undefined as AdvancedConverterReturn<TConverter, TFallback>;
@@ -121,17 +97,12 @@ export class AdvancedMethods extends PrimitiveMethods {
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback>;
     getUsing<TReturn>(key: EnvKeyInput, converter: BuiltInConverter | ArrayOf, fallback?: TReturn): TReturn;
-    getUsing(key: EnvKeyInput, options: GetUsingRequiredOptions<'time'>): number;
-    getUsing<TConverter extends BuiltInConverter | ArrayOf>(
-        key: EnvKeyInput,
-        options: GetUsingRequiredOptions<TConverter>
-    ): InferConverterReturnType<TConverter>;
     getUsing<TConverter extends BuiltInConverter | ArrayOf, TFallback = undefined>(
         key: EnvKeyInput,
-        converterOrOptions: TConverter | GetUsingRequiredOptions<TConverter>,
+        converter: TConverter,
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback> {
-        return AdvancedMethods.getUsing(key, converterOrOptions as TConverter, fallback);
+        return AdvancedMethods.getUsing(key, converter, fallback);
     }
 
     /**
@@ -142,34 +113,7 @@ export class AdvancedMethods extends PrimitiveMethods {
         key: EnvKeyInput,
         converter: ConverterFunction<TReturnType>,
         fallback?: TFallback
-    ): ConditionalReturn<TReturnType, TFallback>;
-    static getWith<TReturnType>(key: EnvKeyInput, options: GetWithRequiredOptions<TReturnType>): TReturnType;
-    static getWith<TReturnType, TFallback extends TReturnType | undefined = undefined>(
-        key: EnvKeyInput,
-        converterOrOptions: ConverterFunction<TReturnType> | GetWithRequiredOptions<TReturnType>,
-        fallback?: TFallback
     ): ConditionalReturn<TReturnType, TFallback> {
-        if (isOptionsBag(converterOrOptions)) {
-            const options = converterOrOptions;
-            const { key: resolvedKey, value } = this.resolveKeyInput(key);
-
-            if (value === undefined || value.trim() === '') {
-                throw new EnvaptError(
-                    EnvaptErrorCodes.MissingEnvValue,
-                    `Required environment variable "${formatKeyForError(key)}" is missing or empty.`
-                );
-            }
-
-            const result = this.valueConverter.convertValue(
-                resolvedKey,
-                undefined,
-                options.converter as ConverterFunction<undefined>,
-                false
-            );
-            return result as ConditionalReturn<TReturnType, TFallback>;
-        }
-
-        // Check if variable exists first, for consistency with primitive methods
         const { key: resolvedKey, value } = this.resolveKeyInput(key);
         if (this.treatAsMissing(value)) {
             debugWarn(`${resolvedKey} is missing or empty`);
@@ -177,13 +121,7 @@ export class AdvancedMethods extends PrimitiveMethods {
         }
 
         const hasFallback = fallback !== undefined;
-        // Convert the converter to match the expected signature via unknown
-        const result = this.valueConverter.convertValue(
-            resolvedKey,
-            fallback,
-            converterOrOptions as unknown as ConverterFunction<TFallback>,
-            hasFallback
-        );
+        const result = this.valueConverter.convertValue<TReturnType>(resolvedKey, fallback, converter, hasFallback);
 
         return result as ConditionalReturn<TReturnType, TFallback>;
     }
@@ -195,21 +133,106 @@ export class AdvancedMethods extends PrimitiveMethods {
         key: EnvKeyInput,
         converter: ConverterFunction<TReturnType>,
         fallback?: TFallback
-    ): ConditionalReturn<TReturnType, TFallback>;
-    getWith<TReturnType>(key: EnvKeyInput, options: GetWithRequiredOptions<TReturnType>): TReturnType;
-    getWith<TReturnType, TFallback extends TReturnType | undefined = undefined>(
-        key: EnvKeyInput,
-        converterOrOptions: ConverterFunction<TReturnType> | GetWithRequiredOptions<TReturnType>,
-        fallback?: TFallback
     ): ConditionalReturn<TReturnType, TFallback> {
-        return AdvancedMethods.getWith(key, converterOrOptions as ConverterFunction<TReturnType>, fallback);
+        return AdvancedMethods.getWith(key, converter, fallback);
+    }
+
+    /**
+     * Read a required environment variable and convert it, throwing `MissingEnvValue` when the value
+     * is missing or empty. Returns the non-undefined converter output. Accepts a built-in or `ArrayOf`
+     * token, or a custom parser function. The key can be a single name or an ordered list.
+     */
+    static getRequired<TConverter extends BuiltInConverter | ArrayOf>(
+        key: EnvKeyInput,
+        converter: TConverter
+    ): InferConverterReturnType<TConverter>;
+    static getRequired<TReturnType>(key: EnvKeyInput, converter: ConverterFunction<TReturnType, string>): TReturnType;
+    static getRequired<TConverter extends BuiltInConverter | ArrayOf, TReturnType>(
+        key: EnvKeyInput,
+        converter: TConverter | ConverterFunction<TReturnType, string>
+    ): InferConverterReturnType<TConverter> | TReturnType {
+        const { key: resolvedKey, value } = resolveRequired(this.resolveKeyInput(key), this.templateResolver);
+        if (value === undefined) {
+            throw new EnvaptError(
+                EnvaptErrorCodes.MissingEnvValue,
+                `Required environment variable "${formatKeyForError(key)}" is missing or empty.`
+            );
+        }
+        // cast widens the raw-string parser back to convertValue's ConverterFunction<T> (value proven present above).
+        return this.valueConverter.convertValue<TReturnType>(
+            resolvedKey,
+            undefined,
+            converter as EnvaptConverter<TReturnType>,
+            false
+        ) as InferConverterReturnType<TConverter> | TReturnType;
+    }
+
+    /**
+     * @see {@link AdvancedMethods.getRequired}
+     */
+    getRequired<TConverter extends BuiltInConverter | ArrayOf>(
+        key: EnvKeyInput,
+        converter: TConverter
+    ): InferConverterReturnType<TConverter>;
+    getRequired<TReturnType>(key: EnvKeyInput, converter: ConverterFunction<TReturnType, string>): TReturnType;
+    getRequired<TConverter extends BuiltInConverter | ArrayOf, TReturnType>(
+        key: EnvKeyInput,
+        converter: TConverter | ConverterFunction<TReturnType, string>
+    ): InferConverterReturnType<TConverter> | TReturnType {
+        return AdvancedMethods.getRequired(key, converter as ConverterFunction<TReturnType, string>);
+    }
+
+    /**
+     * Read a group of required environment variables in one call. Each key in `spec` maps to a
+     * converter (a token, an `array()` token, or a custom parser), and the returned record holds
+     * every converted value, all non-undefined. Collects every missing or empty key and throws one
+     * `MissingEnvValue` listing them all. Pass a `casing` (`'camelCase'`, `'PascalCase'`, or
+     * `'kebab-case'`) to rename the record keys, splitting on underscores, which assumes the
+     * conventional SCREAMING_SNAKE env-var names. With no casing the keys stay as-is.
+     */
+    static getRequiredAll<Spec extends RequiredSpec, Casing extends KeyCasing | undefined = undefined>(
+        spec: Spec,
+        casing?: Casing
+    ): { [K in keyof Spec as RecaseKey<K & string, Casing>]: InferSpecField<Spec[K]> } {
+        const keys = Object.keys(spec);
+        const missing = keys.filter(
+            (key) => resolveRequired(this.resolveKeyInput(key), this.templateResolver).value === undefined
+        );
+        if (missing.length > 0) {
+            throw new EnvaptError(
+                EnvaptErrorCodes.MissingEnvValue,
+                `Missing required environment variables: ${missing.join(', ')}.`
+            );
+        }
+
+        const result: Record<string, unknown> = {};
+        for (const key of keys) {
+            // same widening cast as getRequired, every value was proven present above.
+            result[recase(key, casing)] = this.valueConverter.convertValue<unknown>(
+                key,
+                undefined,
+                spec[key] as EnvaptConverter<unknown>,
+                false
+            );
+        }
+        return result as { [K in keyof Spec as RecaseKey<K & string, Casing>]: InferSpecField<Spec[K]> };
+    }
+
+    /**
+     * @see {@link AdvancedMethods.getRequiredAll}
+     */
+    getRequiredAll<Spec extends RequiredSpec, Casing extends KeyCasing | undefined = undefined>(
+        spec: Spec,
+        casing?: Casing
+    ): { [K in keyof Spec as RecaseKey<K & string, Casing>]: InferSpecField<Spec[K]> } {
+        return AdvancedMethods.getRequiredAll(spec, casing);
     }
 
     /**
      * Validate an environment variable through a {@link StandardSchemaV1}-conformant schema
      * (zod, valibot, arktype, etc). Throws `MissingEnvValue` if the env value is absent and
-     * no fallback is provided. The fallback, when provided, is returned as-is on missing;
-     * it does NOT pass through the schema (mirrors custom-converter behavior).
+     * no fallback is provided. The fallback, when provided, is returned as-is on missing.
+     * It does NOT pass through the schema, mirroring custom-converter behavior.
      *
      * Synchronous schemas only. A Promise-returning `validate` triggers an
      * `InvalidUserDefinedConfig` throw at the call site.

--- a/packages/envapt/src/engine/Envapter.ts
+++ b/packages/envapt/src/engine/Envapter.ts
@@ -1,4 +1,5 @@
 import { AdvancedMethods } from '../core';
+import { resolveRequired } from '../core/AdvancedMethods';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
 export { EnvaptCache, Environment } from '../core';
@@ -69,7 +70,7 @@ export class Envapter extends AdvancedMethods {
      * Assert that one or more environment variables are present and non-empty (post-trim,
      * after template resolution). Throws `MissingEnvValue` listing every missing key.
      *
-     * For typed fail-fast in functional code, use `Envapter.getUsing(key, { converter, required: true })`.
+     * For a typed required read in functional code, use `Envapter.getRequired(key, converter)`.
      *
      * @example
      * ```ts
@@ -78,10 +79,9 @@ export class Envapter extends AdvancedMethods {
      * ```
      */
     static require(...keys: [string, ...string[]]): void {
-        const missing: string[] = [];
-        for (const k of keys) {
-            if (Envapter.resolveAndValidate(k) === undefined) missing.push(k);
-        }
+        const missing = keys.filter(
+            (k) => resolveRequired(Envapter.resolveKeyInput(k), Envapter.templateResolver).value === undefined
+        );
 
         if (missing.length > 0) {
             throw new EnvaptError(
@@ -89,14 +89,6 @@ export class Envapter extends AdvancedMethods {
                 `Missing required environment variables: ${missing.join(', ')}.`
             );
         }
-    }
-
-    private static resolveAndValidate(key: string): string | undefined {
-        const { value } = this.resolveKeyInput(key);
-        if (value === undefined) return undefined;
-        const resolved = this.templateResolver.resolveTemplate(key, value);
-        if (resolved.trim() === '') return undefined;
-        return resolved;
     }
 
     /**

--- a/packages/envapt/src/infra/recase.ts
+++ b/packages/envapt/src/infra/recase.ts
@@ -1,0 +1,10 @@
+import type { KeyCasing } from '../types';
+
+// underscore-delimited words, kept in step with the RecaseKey type transforms in types/Casing.ts.
+export function recase(name: string, casing?: KeyCasing): string {
+    if (casing === undefined) return name;
+    const words = name.split('_').filter((word) => word.length > 0);
+    if (casing === 'kebab-case') return words.map((word) => word.toLowerCase()).join('-');
+    const pascal = words.map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()).join('');
+    return casing === 'PascalCase' ? pascal : pascal.charAt(0).toLowerCase() + pascal.slice(1);
+}

--- a/packages/envapt/src/types/Casing.ts
+++ b/packages/envapt/src/types/Casing.ts
@@ -1,0 +1,26 @@
+// getRequiredAll key casing, split on underscores. infra/recase.ts must produce the same keys at runtime.
+type KeyCasing = 'camelCase' | 'PascalCase' | 'kebab-case';
+
+type SnakeToPascal<Str extends string> = Str extends `${infer Head}_${infer Tail}`
+    ? `${Capitalize<Lowercase<Head>>}${SnakeToPascal<Tail>}`
+    : Capitalize<Lowercase<Str>>;
+
+// an empty segment (leading, trailing, or doubled underscore) is not a word, so the accumulator only
+// puts a hyphen between non-empty words, staying in step with recase's empty-segment filter at runtime.
+type SnakeToKebab<Str extends string, Acc extends string = ''> = Str extends `${infer Head}_${infer Tail}`
+    ? SnakeToKebab<Tail, Head extends '' ? Acc : Acc extends '' ? Lowercase<Head> : `${Acc}-${Lowercase<Head>}`>
+    : Str extends ''
+      ? Acc
+      : Acc extends ''
+        ? Lowercase<Str>
+        : `${Acc}-${Lowercase<Str>}`;
+
+type RecaseKey<Key extends string, Casing> = Casing extends 'camelCase'
+    ? Uncapitalize<SnakeToPascal<Key>>
+    : Casing extends 'PascalCase'
+      ? SnakeToPascal<Key>
+      : Casing extends 'kebab-case'
+        ? SnakeToKebab<Key>
+        : Key;
+
+export type { KeyCasing, RecaseKey };

--- a/packages/envapt/src/types/Conversion.ts
+++ b/packages/envapt/src/types/Conversion.ts
@@ -1,6 +1,6 @@
 import type { ArrayOf, ConverterToken, CustomElementConverter } from '../converters/Converters';
 
-// the scalar tokens, not the array() builder
+// scalar tokens only
 type BuiltInConverter = ConverterToken;
 
 type PrimitiveConstructor = typeof String | typeof Number | typeof Boolean | typeof BigInt | typeof Symbol;
@@ -8,13 +8,17 @@ type PrimitiveConstructor = typeof String | typeof Number | typeof Boolean | typ
 type BaseInput = string | undefined;
 
 /**
- * Custom parser function type for environment variables
- * @param raw - Raw string value from environment
- * @param fallback - Fallback value if parsing fails
- * @returns Parsed value of type T
+ * Custom parser function for an environment variable. `TRaw` is the raw input, `string | undefined` by
+ * default, narrowed to `string` by the readers that guarantee a present value (`getRequired`, `getRequiredAll`).
+ * @param raw - Raw value from the environment
+ * @param fallback - Fallback value when parsing is skipped
+ * @returns Parsed value of type `TFallback`
  * @public
  */
-type ConverterFunction<TFallback = unknown> = (raw: BaseInput, fallback?: TFallback) => TFallback;
+type ConverterFunction<TFallback = unknown, TRaw extends BaseInput = BaseInput> = (
+    raw: TRaw,
+    fallback?: TFallback
+) => TFallback;
 
 /**
  * Environment variable converter: a primitive constructor, a built-in scalar token, an `ArrayOf<...>`
@@ -85,6 +89,18 @@ type InferConverterReturnType<TConverter> =
           ? BuiltInConverterReturnType<TConverter>
           : never;
 
+// raw is `string` here (getRequiredAll throws before converting, so the value is always present).
+type RequiredSpec = Record<string, BuiltInConverter | ArrayOf | ConverterFunction<unknown, string>>;
+
+// InferConverterReturnType is never for a function, so a custom parser recovers its type from the return.
+// Match the bare `(raw) => infer R` form. `ConverterFunction<infer R>` would fail here because a required
+// parser's `raw: string` isn't assignable to ConverterFunction's `raw: string | undefined`, hitting never.
+type InferSpecField<TConverter> = TConverter extends BuiltInConverter | ArrayOf
+    ? InferConverterReturnType<TConverter>
+    : TConverter extends (raw: string) => infer TReturn
+      ? TReturn
+      : never;
+
 // time's fallback (TimeFallback) differs from its return, so add future asymmetric converters here
 type InferConverterFallbackType<TConverter> = TConverter extends 'time'
     ? TimeFallback
@@ -125,5 +141,7 @@ export type {
     InferConverterReturnType,
     InferConverterFallbackType,
     AdvancedConverterReturn,
-    InferPrimitiveReturnType
+    InferPrimitiveReturnType,
+    RequiredSpec,
+    InferSpecField
 };

--- a/packages/envapt/src/types/index.ts
+++ b/packages/envapt/src/types/index.ts
@@ -12,8 +12,11 @@ export type {
     InferConverterReturnType,
     InferConverterFallbackType,
     AdvancedConverterReturn,
-    InferPrimitiveReturnType
+    InferPrimitiveReturnType,
+    RequiredSpec,
+    InferSpecField
 } from './Conversion';
+export type { KeyCasing, RecaseKey } from './Casing';
 export type { Err, SchemaMustBeSync, SchemaConstraint } from './Schema';
 export type { EnvaptOptions, EnvProfile, ProfilesConfig, FileApiMode } from './Options';
 export type { EnvKeyInput } from './Env';

--- a/packages/envapt/tests/.env.037-required-reads
+++ b/packages/envapt/tests/.env.037-required-reads
@@ -1,0 +1,20 @@
+# Fixture for 037-required-reads.test.ts
+
+SET_NUMBER=42
+SET_VALUE=hello
+DATABASE_URL=postgres://localhost/db
+GITHUB_REPOSITORY=owner/repo
+PORT1=80
+PORT2=443
+PORT3=8080
+PORTS_CLEAN=${PORT1},${PORT2},${PORT3}
+TIMEOUT=10s
+
+# Empty value (KEY=).
+EMPTY_VALUE=
+
+# Whitespace-only value (must be quoted to survive trimming).
+WHITESPACE_ONLY="   "
+
+# References a variable defined nowhere. Under strict, resolving this throws; non-strict preserves the literal.
+TEMPLATE_MISSING=${NOT_DEFINED_ANYWHERE}

--- a/packages/envapt/tests/.env.037-required-reads
+++ b/packages/envapt/tests/.env.037-required-reads
@@ -3,7 +3,7 @@
 SET_NUMBER=42
 SET_VALUE=hello
 DATABASE_URL=postgres://localhost/db
-GITHUB_REPOSITORY=owner/repo
+SAMPLE_REPO=owner/repo
 PORT1=80
 PORT2=443
 PORT3=8080

--- a/packages/envapt/tests/020-strict-mode.test.ts
+++ b/packages/envapt/tests/020-strict-mode.test.ts
@@ -12,8 +12,7 @@ describe('Strict mode + required (v5)', () => {
     });
 
     afterEach(() => {
-        // Always reset strict to false so test isolation holds: leaking strict=true into the
-        // next file would change get* semantics globally.
+        // reset strict so it doesn't leak into the next file, where strict=true would change get* semantics globally.
         Envapter.strict = false;
     });
 
@@ -128,8 +127,7 @@ describe('Strict mode + required (v5)', () => {
             static readonly url: URL;
         }
 
-        // Exercises the `Array.isArray(key)` arm of `formatKeyForError`; both keys must be
-        // absent so the throw path runs.
+        // exercises the `Array.isArray(key)` arm of `formatKeyForError`. both keys must be absent so the throw path runs.
         class RequiredArrayKeyAllMissing {
             @Envapt(['NEVER_SET_KEY', 'ALSO_NEVER_SET'], { required: true })
             static readonly key: string;
@@ -196,66 +194,6 @@ describe('Strict mode + required (v5)', () => {
         });
     });
 
-    describe('Functional API options-bag with required: true', () => {
-        it('getUsing throws MissingEnvValue on missing/empty', () => {
-            expect(() => Envapter.getUsing('NEVER_SET_KEY', { converter: Converters.Number, required: true }))
-                .to.throw(EnvaptError)
-                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
-
-            expect(() => Envapter.getUsing('EMPTY_VALUE', { converter: Converters.Number, required: true }))
-                .to.throw(EnvaptError)
-                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
-        });
-
-        it('getUsing returns the typed value when present', () => {
-            const n = Envapter.getUsing('SET_NUMBER', { converter: Converters.Number, required: true });
-            expect(n).to.equal(42);
-        });
-
-        it('getWith throws MissingEnvValue on missing/empty', () => {
-            expect(() =>
-                Envapter.getWith('NEVER_SET_KEY', { converter: (raw) => (raw ?? '').toUpperCase(), required: true })
-            )
-                .to.throw(EnvaptError)
-                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
-        });
-
-        it('getWith returns the value from the custom converter when present', () => {
-            const v = Envapter.getWith('SET_VALUE', { converter: (raw) => (raw ?? '').toUpperCase(), required: true });
-            expect(v).to.equal('HELLO');
-        });
-
-        it('getUsing formats the array-key error message via formatKeyForError', () => {
-            try {
-                Envapter.getUsing(['NEVER_SET_KEY', 'ALSO_NEVER_SET'], {
-                    converter: Converters.Number,
-                    required: true
-                });
-                expect.fail('should have thrown');
-            } catch (err) {
-                expect(err).to.be.instanceOf(EnvaptError);
-                const e = err as EnvaptError;
-                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
-                expect(e.message).to.include('[NEVER_SET_KEY, ALSO_NEVER_SET]');
-            }
-        });
-
-        it('getWith formats the array-key error message via formatKeyForError', () => {
-            try {
-                Envapter.getWith(['NEVER_SET_KEY', 'ALSO_NEVER_SET'], {
-                    converter: (raw) => (raw ?? '').toUpperCase(),
-                    required: true
-                });
-                expect.fail('should have thrown');
-            } catch (err) {
-                expect(err).to.be.instanceOf(EnvaptError);
-                const e = err as EnvaptError;
-                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
-                expect(e.message).to.include('[NEVER_SET_KEY, ALSO_NEVER_SET]');
-            }
-        });
-    });
-
     describe('Envapter.require()', () => {
         it('does not throw when a single key is set', () => {
             expect(() => Envapter.require('API_KEY')).to.not.throw();
@@ -313,30 +251,6 @@ describe('Strict mode + required (v5)', () => {
     });
 
     describe('compile-time type checks (expect-type)', () => {
-        it('getUsing options-bag with required: true narrows away undefined for built-in converters', () => {
-            const port = Envapter.getUsing('SET_NUMBER', { converter: Converters.Number, required: true });
-            expectTypeOf(port).toEqualTypeOf<number>();
-
-            const url = Envapter.getUsing('DATABASE_URL', { converter: Converters.Url, required: true });
-            expectTypeOf(url).toEqualTypeOf<URL>();
-        });
-
-        it('getUsing options-bag with required: true narrows array converters too', () => {
-            const ports = Envapter.getUsing('PORTS_CLEAN', {
-                converter: Converters.array({ of: Converters.Number }),
-                required: true
-            });
-            expectTypeOf(ports).toEqualTypeOf<number[]>();
-        });
-
-        it('getWith options-bag with required: true returns the converter function return type', () => {
-            const upper = Envapter.getWith('SET_VALUE', {
-                converter: (raw) => (raw ?? '').toUpperCase(),
-                required: true
-            });
-            expectTypeOf(upper).toEqualTypeOf<string>();
-        });
-
         it('Envapter.require returns void for any number of keys', () => {
             const single = Envapter.require('API_KEY');
             const bulk = Envapter.require('API_KEY', 'DATABASE_URL');
@@ -366,18 +280,11 @@ describe('Strict mode + required (v5)', () => {
                 .to.throw(EnvaptError)
                 .with.property('code', EnvaptErrorCodes.InvalidUserDefinedConfig);
         });
-
-        it('functional getUsing: required + fallback combo is a TS error (excess property)', () => {
-            // No runtime mutex check on the functional path, so only the compile-time
-            // directive is asserted here.
-            // @ts-expect-error fallback not allowed when required: true
-            Envapter.getUsing('SET_NUMBER', { converter: Converters.Number, required: true, fallback: 3000 });
-        });
     });
 
     describe('Strict mode does NOT make missing keys throw on get*', () => {
-        // Locked behavior: strict tightens "empty value" semantics; it doesn't auto-require
-        // every absent key. That stays an explicit opt-in via `required:` or `Envapter.require()`.
+        // locked behavior. strict tightens "empty value" semantics. it doesn't auto-require absent keys,
+        // that stays an opt-in via `required:` or `Envapter.require()`.
         it('returns undefined for missing keys under strict (no fallback)', () => {
             Envapter.strict = true;
             expect(Envapter.get('NEVER_SET_KEY')).to.equal(undefined);

--- a/packages/envapt/tests/020-strict-mode.test.ts
+++ b/packages/envapt/tests/020-strict-mode.test.ts
@@ -127,7 +127,7 @@ describe('Strict mode + required (v5)', () => {
             static readonly url: URL;
         }
 
-        // exercises the `Array.isArray(key)` arm of `formatKeyForError`. both keys must be absent so the throw path runs.
+        // both keys must be absent so the required throw runs, exercising the `Array.isArray(key)` arm of `formatKeyForError`.
         class RequiredArrayKeyAllMissing {
             @Envapt(['NEVER_SET_KEY', 'ALSO_NEVER_SET'], { required: true })
             static readonly key: string;
@@ -283,8 +283,8 @@ describe('Strict mode + required (v5)', () => {
     });
 
     describe('Strict mode does NOT make missing keys throw on get*', () => {
-        // locked behavior. strict tightens "empty value" semantics. it doesn't auto-require absent keys,
-        // that stays an opt-in via `required:` or `Envapter.require()`.
+        // locked behavior. strict tightens "empty value" semantics but doesn't auto-require absent keys.
+        // requiring stays opt-in via `@Envapt`'s `required:`, `getRequired`/`getRequiredAll`, or `Envapter.require()`.
         it('returns undefined for missing keys under strict (no fallback)', () => {
             Envapter.strict = true;
             expect(Envapter.get('NEVER_SET_KEY')).to.equal(undefined);

--- a/packages/envapt/tests/037-required-reads.test.ts
+++ b/packages/envapt/tests/037-required-reads.test.ts
@@ -26,7 +26,7 @@ describe('Required reads (v8)', () => {
 
         it('returns a non-undefined typed array for an array token', () => {
             const parts = Envapter.getRequired(
-                'GITHUB_REPOSITORY',
+                'SAMPLE_REPO',
                 Converters.array({ delimiter: '/', of: Converters.String })
             );
             expect(parts).to.deep.equal(['owner', 'repo']);
@@ -87,12 +87,12 @@ describe('Required reads (v8)', () => {
             const cfg = Envapter.getRequiredAll({
                 SET_NUMBER: Converters.Number,
                 SET_VALUE: Converters.String,
-                GITHUB_REPOSITORY: Converters.array({ delimiter: '/', of: Converters.String })
+                SAMPLE_REPO: Converters.array({ delimiter: '/' })
             });
             expect(cfg.SET_NUMBER).to.equal(42);
             expect(cfg.SET_VALUE).to.equal('hello');
-            expect(cfg.GITHUB_REPOSITORY).to.deep.equal(['owner', 'repo']);
-            expectTypeOf(cfg).toEqualTypeOf<{ SET_NUMBER: number; SET_VALUE: string; GITHUB_REPOSITORY: string[] }>();
+            expect(cfg.SAMPLE_REPO).to.deep.equal(['owner', 'repo']);
+            expectTypeOf(cfg).toEqualTypeOf<{ SET_NUMBER: number; SET_VALUE: string; SAMPLE_REPO: string[] }>();
         });
 
         it('supports a custom function converter in the spec, inferring its return type', () => {
@@ -108,12 +108,12 @@ describe('Required reads (v8)', () => {
 
         it('recases the record keys when a casing is given, leaving them as-is otherwise', () => {
             const camel = Envapter.getRequiredAll(
-                { GITHUB_REPOSITORY: Converters.String, SET_NUMBER: Converters.Number },
+                { SAMPLE_REPO: Converters.String, SET_NUMBER: Converters.Number },
                 'camelCase'
             );
-            expect(camel.githubRepository).to.equal('owner/repo');
+            expect(camel.sampleRepo).to.equal('owner/repo');
             expect(camel.setNumber).to.equal(42);
-            expectTypeOf(camel).toEqualTypeOf<{ githubRepository: string; setNumber: number }>();
+            expectTypeOf(camel).toEqualTypeOf<{ sampleRepo: string; setNumber: number }>();
 
             const pascal = Envapter.getRequiredAll({ SET_NUMBER: Converters.Number }, 'PascalCase');
             expect(pascal.SetNumber).to.equal(42);
@@ -143,6 +143,20 @@ describe('Required reads (v8)', () => {
                 expect(e.message).to.include('EMPTY_VALUE');
                 expect(e.message).to.not.include('SET_NUMBER');
             }
+        });
+    });
+
+    describe('instance methods delegate to the static ones', () => {
+        it('getRequired reads through an instance', () => {
+            const env = new Envapter();
+            expect(env.getRequired('SET_NUMBER', Converters.Number)).to.equal(42);
+        });
+
+        it('getRequiredAll reads through an instance', () => {
+            const env = new Envapter();
+            const cfg = env.getRequiredAll({ SET_NUMBER: Converters.Number, SET_VALUE: Converters.String });
+            expect(cfg.SET_NUMBER).to.equal(42);
+            expect(cfg.SET_VALUE).to.equal('hello');
         });
     });
 

--- a/packages/envapt/tests/037-required-reads.test.ts
+++ b/packages/envapt/tests/037-required-reads.test.ts
@@ -80,6 +80,18 @@ describe('Required reads (v8)', () => {
             expect(timeout).to.equal(10000);
             expectTypeOf(timeout).toEqualTypeOf<number>();
         });
+
+        it('falls through an empty ordered key to the first non-empty one', () => {
+            const value = Envapter.getRequired(['EMPTY_VALUE', 'SET_VALUE'], Converters.String);
+            expect(value).to.equal('hello');
+            expectTypeOf(value).toEqualTypeOf<string>();
+        });
+
+        it('throws MissingEnvValue when a present value cannot be converted', () => {
+            expect(() => Envapter.getRequired('SET_VALUE', Converters.Number))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
     });
 
     describe('getRequiredAll', () => {
@@ -143,6 +155,12 @@ describe('Required reads (v8)', () => {
                 expect(e.message).to.include('EMPTY_VALUE');
                 expect(e.message).to.not.include('SET_NUMBER');
             }
+        });
+
+        it('throws MissingEnvValue when a present value in the spec cannot be converted', () => {
+            expect(() => Envapter.getRequiredAll({ SET_VALUE: Converters.Number }))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
         });
     });
 

--- a/packages/envapt/tests/037-required-reads.test.ts
+++ b/packages/envapt/tests/037-required-reads.test.ts
@@ -1,0 +1,244 @@
+import { resolve } from 'node:path';
+
+import { afterEach, beforeAll, describe, expect, expectTypeOf, it } from 'vitest';
+
+import { Converters, Envapter, EnvaptErrorCodes } from '../src';
+import { EnvaptError } from '../src/infra/Error';
+import { recase } from '../src/infra/recase';
+
+import type { RecaseKey } from '../src/types';
+
+describe('Required reads (v8)', () => {
+    beforeAll(() => {
+        Envapter.envPaths = resolve(import.meta.dirname, '.env.037-required-reads');
+    });
+
+    afterEach(() => {
+        Envapter.strict = false;
+    });
+
+    describe('getRequired', () => {
+        it('returns a non-undefined typed value for a scalar token', () => {
+            const port = Envapter.getRequired('SET_NUMBER', Converters.Number);
+            expect(port).to.equal(42);
+            expectTypeOf(port).toEqualTypeOf<number>();
+        });
+
+        it('returns a non-undefined typed array for an array token', () => {
+            const parts = Envapter.getRequired(
+                'GITHUB_REPOSITORY',
+                Converters.array({ delimiter: '/', of: Converters.String })
+            );
+            expect(parts).to.deep.equal(['owner', 'repo']);
+            expectTypeOf(parts).toEqualTypeOf<string[]>();
+
+            const ports = Envapter.getRequired('PORTS_CLEAN', Converters.array({ of: Converters.Number }));
+            expect(ports).to.deep.equal([80, 443, 8080]);
+            expectTypeOf(ports).toEqualTypeOf<number[]>();
+        });
+
+        it('returns the custom parser return type', () => {
+            const upper = Envapter.getRequired('SET_VALUE', (raw) => raw.toUpperCase());
+            expect(upper).to.equal('HELLO');
+            expectTypeOf(upper).toEqualTypeOf<string>();
+        });
+
+        it('throws MissingEnvValue on missing, empty, or whitespace-only (independent of strict)', () => {
+            expect(() => Envapter.getRequired('NEVER_SET_KEY', Converters.Number))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+
+            expect(() => Envapter.getRequired('EMPTY_VALUE', Converters.String))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+
+            Envapter.strict = false;
+            expect(() => Envapter.getRequired('WHITESPACE_ONLY', Converters.String))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('formats the array-key error message via formatKeyForError', () => {
+            try {
+                Envapter.getRequired(['NEVER_SET_KEY', 'ALSO_NEVER_SET'], Converters.Number);
+                expect.fail('should have thrown');
+            } catch (err) {
+                expect(err).to.be.instanceOf(EnvaptError);
+                const e = err as EnvaptError;
+                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
+                expect(e.message).to.include('[NEVER_SET_KEY, ALSO_NEVER_SET]');
+            }
+        });
+
+        it('takes no fallback argument', () => {
+            // @ts-expect-error getRequired throws on missing, so it has no fallback parameter
+            Envapter.getRequired('SET_NUMBER', Converters.Number, 3000);
+        });
+
+        it('returns number for the time converter with no special overload (no fallback to type)', () => {
+            const timeout = Envapter.getRequired('TIMEOUT', Converters.Time);
+            expect(timeout).to.equal(10000);
+            expectTypeOf(timeout).toEqualTypeOf<number>();
+        });
+    });
+
+    describe('getRequiredAll', () => {
+        it('returns a typed non-undefined record for a multi-key spec', () => {
+            const cfg = Envapter.getRequiredAll({
+                SET_NUMBER: Converters.Number,
+                SET_VALUE: Converters.String,
+                GITHUB_REPOSITORY: Converters.array({ delimiter: '/', of: Converters.String })
+            });
+            expect(cfg.SET_NUMBER).to.equal(42);
+            expect(cfg.SET_VALUE).to.equal('hello');
+            expect(cfg.GITHUB_REPOSITORY).to.deep.equal(['owner', 'repo']);
+            expectTypeOf(cfg).toEqualTypeOf<{ SET_NUMBER: number; SET_VALUE: string; GITHUB_REPOSITORY: string[] }>();
+        });
+
+        it('supports a custom function converter in the spec, inferring its return type', () => {
+            const cfg = Envapter.getRequiredAll({
+                SET_NUMBER: Converters.Number,
+                // eslint-disable-next-line @typescript-eslint/naming-convention -- a function-valued env-name key reads as an object method to the naming rule
+                SET_VALUE: (raw) => raw.toUpperCase()
+            });
+            expect(cfg.SET_NUMBER).to.equal(42);
+            expect(cfg.SET_VALUE).to.equal('HELLO');
+            expectTypeOf(cfg).toEqualTypeOf<{ SET_NUMBER: number; SET_VALUE: string }>();
+        });
+
+        it('recases the record keys when a casing is given, leaving them as-is otherwise', () => {
+            const camel = Envapter.getRequiredAll(
+                { GITHUB_REPOSITORY: Converters.String, SET_NUMBER: Converters.Number },
+                'camelCase'
+            );
+            expect(camel.githubRepository).to.equal('owner/repo');
+            expect(camel.setNumber).to.equal(42);
+            expectTypeOf(camel).toEqualTypeOf<{ githubRepository: string; setNumber: number }>();
+
+            const pascal = Envapter.getRequiredAll({ SET_NUMBER: Converters.Number }, 'PascalCase');
+            expect(pascal.SetNumber).to.equal(42);
+            expectTypeOf(pascal).toEqualTypeOf<{ SetNumber: number }>();
+
+            const kebab = Envapter.getRequiredAll({ SET_NUMBER: Converters.Number }, 'kebab-case');
+            expect(kebab['set-number']).to.equal(42);
+            expectTypeOf(kebab).toEqualTypeOf<{ 'set-number': number }>();
+
+            const asIs = Envapter.getRequiredAll({ SET_NUMBER: Converters.Number });
+            expectTypeOf(asIs).toEqualTypeOf<{ SET_NUMBER: number }>();
+        });
+
+        it('throws one MissingEnvValue listing every missing key', () => {
+            try {
+                Envapter.getRequiredAll({
+                    SET_NUMBER: Converters.Number,
+                    NEVER_SET_KEY: Converters.String,
+                    EMPTY_VALUE: Converters.String
+                });
+                expect.fail('should have thrown');
+            } catch (err) {
+                expect(err).to.be.instanceOf(EnvaptError);
+                const e = err as EnvaptError;
+                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
+                expect(e.message).to.include('NEVER_SET_KEY');
+                expect(e.message).to.include('EMPTY_VALUE');
+                expect(e.message).to.not.include('SET_NUMBER');
+            }
+        });
+    });
+
+    describe('RecaseKey type transforms', () => {
+        it('camelCase splits on underscores and lowercases each word', () => {
+            expectTypeOf<RecaseKey<'DATABASE_URL', 'camelCase'>>().toEqualTypeOf<'databaseUrl'>();
+            expectTypeOf<RecaseKey<'PORT', 'camelCase'>>().toEqualTypeOf<'port'>();
+            expectTypeOf<RecaseKey<'OAUTH2_CLIENT_ID', 'camelCase'>>().toEqualTypeOf<'oauth2ClientId'>();
+            expectTypeOf<RecaseKey<'H2O_SENSOR', 'camelCase'>>().toEqualTypeOf<'h2oSensor'>();
+        });
+
+        it('PascalCase capitalizes every word', () => {
+            expectTypeOf<RecaseKey<'DATABASE_URL', 'PascalCase'>>().toEqualTypeOf<'DatabaseUrl'>();
+            expectTypeOf<RecaseKey<'PORT', 'PascalCase'>>().toEqualTypeOf<'Port'>();
+        });
+
+        it('kebab-case lowercases and joins on hyphens', () => {
+            expectTypeOf<RecaseKey<'DATABASE_URL', 'kebab-case'>>().toEqualTypeOf<'database-url'>();
+            expectTypeOf<RecaseKey<'PORT', 'kebab-case'>>().toEqualTypeOf<'port'>();
+        });
+
+        it('leaves the key unchanged with no casing', () => {
+            expectTypeOf<RecaseKey<'DATABASE_URL', undefined>>().toEqualTypeOf<'DATABASE_URL'>();
+        });
+
+        it('handles multiple, consecutive, leading, and trailing underscores', () => {
+            expectTypeOf<RecaseKey<'A_B_C_D', 'camelCase'>>().toEqualTypeOf<'aBCD'>();
+            expectTypeOf<RecaseKey<'A_B_C_D', 'PascalCase'>>().toEqualTypeOf<'ABCD'>();
+            expectTypeOf<RecaseKey<'A_B_C_D', 'kebab-case'>>().toEqualTypeOf<'a-b-c-d'>();
+            expectTypeOf<RecaseKey<'FOO__BAR', 'camelCase'>>().toEqualTypeOf<'fooBar'>();
+            expectTypeOf<RecaseKey<'FOO__BAR', 'kebab-case'>>().toEqualTypeOf<'foo-bar'>();
+            expectTypeOf<RecaseKey<'_LEADING_KEY', 'kebab-case'>>().toEqualTypeOf<'leading-key'>();
+            expectTypeOf<RecaseKey<'TRAILING_KEY_', 'kebab-case'>>().toEqualTypeOf<'trailing-key'>();
+        });
+    });
+
+    describe('recase runtime matches RecaseKey', () => {
+        it('handles multiple, consecutive, leading, and trailing underscores', () => {
+            expect(recase('A_B_C_D', 'camelCase')).to.equal('aBCD');
+            expect(recase('A_B_C_D', 'PascalCase')).to.equal('ABCD');
+            expect(recase('A_B_C_D', 'kebab-case')).to.equal('a-b-c-d');
+            expect(recase('FOO__BAR', 'camelCase')).to.equal('fooBar');
+            expect(recase('FOO__BAR', 'kebab-case')).to.equal('foo-bar');
+            expect(recase('_LEADING_KEY', 'kebab-case')).to.equal('leading-key');
+            expect(recase('TRAILING_KEY_', 'kebab-case')).to.equal('trailing-key');
+            expect(recase('PORT')).to.equal('PORT');
+        });
+    });
+
+    describe('edge cases', () => {
+        it('returns an empty record for an empty spec', () => {
+            const empty = Envapter.getRequiredAll({});
+            expect(empty).to.deep.equal({});
+        });
+
+        it('resolves an ordered key list, the first present value wins', () => {
+            const port = Envapter.getRequired(['NEVER_SET_KEY', 'SET_NUMBER'], Converters.Number);
+            expect(port).to.equal(42);
+        });
+
+        it('treats a whitespace-only value as missing in the aggregated throw', () => {
+            try {
+                Envapter.getRequiredAll({ WHITESPACE_ONLY: Converters.String, NEVER_SET_KEY: Converters.String });
+                expect.fail('should have thrown');
+            } catch (err) {
+                const e = err as EnvaptError;
+                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
+                expect(e.message).to.include('WHITESPACE_ONLY');
+                expect(e.message).to.include('NEVER_SET_KEY');
+            }
+        });
+
+        it('returns the preserved literal when a template cannot resolve under non-strict', () => {
+            Envapter.strict = false;
+            expect(Envapter.getRequired('TEMPLATE_MISSING', Converters.String)).to.equal('${NOT_DEFINED_ANYWHERE}');
+        });
+
+        it('throws MissingEnvValue when a required template cannot resolve under strict', () => {
+            Envapter.strict = true;
+            expect(() => Envapter.getRequired('TEMPLATE_MISSING', Converters.String))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        // under strict, resolveTemplate throws on the unresolved ${VAR} before the aggregation finishes,
+        // so getRequiredAll surfaces that template error rather than the combined missing-key list.
+        it('surfaces the template error, not the aggregated list, when a spec value is unresolvable under strict', () => {
+            Envapter.strict = true;
+            try {
+                Envapter.getRequiredAll({ TEMPLATE_MISSING: Converters.String, NEVER_SET_KEY: Converters.String });
+                expect.fail('should have thrown');
+            } catch (err) {
+                const e = err as EnvaptError;
+                expect(e.code).to.equal(EnvaptErrorCodes.MissingEnvValue);
+                expect(e.message).to.include('NOT_DEFINED_ANYWHERE');
+            }
+        });
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
         specifier: ^3.6.0
         version: 3.6.0
     devDependencies:
+      '@cloudflare/workers-types':
+        specifier: ^4.20260623.1
+        version: 4.20260623.1
       '@seedcord/eslint-config':
         specifier: catalog:dev
         version: 1.4.2(@types/eslint@9.6.1)(jiti@2.7.0)(oxlint@1.66.0)(prettier-plugin-tailwindcss@0.8.0(prettier@3.8.4))(tailwindcss@4.3.1)(typescript@6.0.3)
@@ -8783,12 +8786,12 @@ snapshots:
     dependencies:
       '@types/eslint-plugin-security': 3.0.1
       '@typescript-eslint/eslint-plugin': 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-config-prettier: 10.1.8(eslint@9.39.2(jiti@2.7.0))
       eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-better-tailwindcss: 4.6.0(eslint@9.39.4(jiti@2.7.0))(oxlint@1.66.0)(tailwindcss@4.3.1)(typescript@6.0.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-mdx: 3.8.1(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-prettier: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(prettier@3.8.4)
       eslint-plugin-security: 4.0.1
@@ -9116,7 +9119,7 @@ snapshots:
   '@typescript-eslint/eslint-plugin@8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.62.0
       '@typescript-eslint/type-utils': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       '@typescript-eslint/utils': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
@@ -9135,18 +9138,6 @@ snapshots:
       '@typescript-eslint/types': 8.61.0
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.61.0
-      debug: 4.4.3
-      eslint: 9.39.2(jiti@2.7.0)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/parser@8.62.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.62.0
-      '@typescript-eslint/types': 8.62.0
-      '@typescript-eslint/typescript-estree': 8.62.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.62.0
       debug: 4.4.3
       eslint: 9.39.2(jiti@2.7.0)
       typescript: 6.0.3
@@ -10208,8 +10199,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.9
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.2(jiti@2.7.0))
@@ -10242,7 +10233,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10253,7 +10244,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -10268,7 +10259,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -10310,24 +10301,25 @@ snapshots:
       - bluebird
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-module-utils@2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 9.39.2(jiti@2.7.0)
+      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
+      eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -10367,7 +10359,7 @@ snapshots:
       - '@eslint/css'
       - typescript
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10378,7 +10370,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0)))(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.61.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10396,7 +10388,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.2(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10405,9 +10397,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.39.2(jiti@2.7.0)
+      eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.2(jiti@2.7.0))
+      eslint-module-utils: 2.13.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -10419,7 +10411,7 @@ snapshots:
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.62.0(eslint@9.39.2(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.62.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack

--- a/scripts/semver-label.ts
+++ b/scripts/semver-label.ts
@@ -35,14 +35,16 @@ interface Ctx {
 }
 
 function readCtx(): Ctx {
-    const repository = Envapter.getUsing('GITHUB_REPOSITORY', { converter: Converters.String, required: true });
-    const pr = Envapter.getUsing('PR_NUMBER', { converter: Converters.Number, required: true });
-    const sha = Envapter.getUsing('HEAD_SHA', { converter: Converters.String, required: true });
-    const token = Envapter.getUsing('GITHUB_TOKEN', { converter: Converters.String, required: true });
+    const env = Envapter.getRequiredAll({
+        GITHUB_REPOSITORY: Converters.String,
+        PR_NUMBER: Converters.Number,
+        HEAD_SHA: Converters.String,
+        GITHUB_TOKEN: Converters.String
+    });
 
-    const [owner, repo] = repository.split('/');
+    const [owner, repo] = env.GITHUB_REPOSITORY.split('/');
     if (!owner || !repo) throw new Error('[semver-label] GITHUB_REPOSITORY must be "owner/repo"');
-    return { owner, repo, pr, sha, token };
+    return { owner, repo, pr: env.PR_NUMBER, sha: env.HEAD_SHA, token: env.GITHUB_TOKEN };
 }
 
 function api(token: string, method: string, path: string, body?: unknown): Promise<Response> {

--- a/skills/envapt/SKILL.md
+++ b/skills/envapt/SKILL.md
@@ -36,7 +36,7 @@ Envapter.getWith('FLAGS', (raw) => (raw ? raw.split(',') : [])); // string[]
 
 // Throw instead of returning a fallback:
 Envapter.require('DATABASE_URL', 'JWT_SECRET'); // throws EnvaptError listing every missing key
-Envapter.getUsing('PORT', { converter: Converters.Number, required: true }); // options-bag form, throws if unset
+Envapter.getRequired('PORT', Converters.Number); // throws if unset
 ```
 
 `Envapter.resolve` is a tagged template that interpolates env values: ``Envapter.resolve`postgres://${'DB_HOST'}:${'DB_PORT'}` ``. `Envapter.getRaw('KEY')` returns the raw string with no parsing.


### PR DESCRIPTION
## What and why

Required reads move to `getRequired`. This is a breaking change to the functional API.

1. **`getRequired(key, converter)`** reads one required value and converts it, taking the converter positionally. It returns the non-undefined result and throws `MissingEnvValue` when the key is missing or empty. The converter is a built-in token, an `array()` token, or a custom `(raw) => T` parser, and the key can be a single name or an ordered list.
2. **`getRequiredAll(spec, casing?)`** reads a group in one call. Each spec key maps to a converter, and the returned record holds every converted value, all non-undefined. It collects every missing or empty key and throws one `MissingEnvValue` listing them all. An optional `casing` (`'camelCase'`, `'PascalCase'`, or `'kebab-case'`) renames the record keys, splitting on underscores, so it expects the conventional `SCREAMING_SNAKE` names. With no casing the keys stay as written.
3. **The `{ required: true }` options bag is removed** from `getUsing` and `getWith`. Migrate `getUsing('KEY', { converter, required: true })` to `getRequired('KEY', converter)`. The `@Envapt` decorator's `{ required: true }` option is unchanged.
4. **Custom parsers in required reads get a non-nullable `raw: string`.** A required read throws before converting, so the parser never sees `undefined`, and `(raw) => new Set(raw.split(','))` needs no `?? ''` guard. `getUsing` and `getWith` parsers still receive `string | undefined`.

`require`, `getRequired`, and `getRequiredAll` share one rule for what counts as missing. Each resolves `${VAR}` templates first, then treats a value that is empty after trimming as missing, regardless of `strict`.

The label workflow's `semver-label` script now reads its GitHub context through `getRequiredAll`, dogfooding the new API.

## Checklist

- [x] New or regression tests cover the change
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added required-value reads with typed lookups (`getRequired`) and grouped reads (`getRequiredAll`) with optional key casing/renaming.
* **Bug Fixes**
  * Required reads now fail fast consistently when values are missing, empty, or whitespace-only, with clearer `MissingEnvValue` errors and improved strict-mode handling for template resolution.
* **Documentation**
  * Updated all examples and the migration guide to use `getRequired` / `getRequiredAll`, including Workers and converter docs.
* **Breaking Changes**
  * Removed the `{ required: true }` options-bag form for `getUsing`/`getWith`; use `getRequired` instead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->