### PR TITLE
fix(converters)!: reject malformed integer and float values

### DIFF
--- a/.changeset/strict-integer-float-converters.md
+++ b/.changeset/strict-integer-float-converters.md
@@ -1,0 +1,7 @@
+---
+'envapt': major
+---
+
+**BREAKING:** Tighten the `Integer` and `Float` converters.
+
+`Converters.Integer` parses with `Number` and requires `Number.isSafeInteger`, so trailing characters (`42abc`), non-integers (`3.9`), and values past 2^53 now fall back. `Converters.Float` parses with `Number`, so trailing characters (`3.14xyz`) now fall back. `Float` still accepts `Infinity`.

--- a/apps/guide/content/docs/converters.mdx
+++ b/apps/guide/content/docs/converters.mdx
@@ -23,8 +23,8 @@ const retries = Envapter.getWith('RETRIES', (raw) => Number(raw ?? 0), 3);
 | -------------------- | ----------- | --------------------------------------------------------- |
 | `Converters.String`  | `string`    | the raw value, unchanged                                  |
 | `Converters.Number`  | `number`    | `Number(raw)`; `NaN` uses the fallback                    |
-| `Converters.Integer` | `number`    | `parseInt(raw, 10)`                                       |
-| `Converters.Float`   | `number`    | `parseFloat(raw)`                                         |
+| `Converters.Integer` | `number`    | `Number(raw)`, must be a safe integer                     |
+| `Converters.Float`   | `number`    | `Number(raw)`, `NaN` uses the fallback                    |
 | `Converters.Boolean` | `boolean`   | `1`/`yes`/`true`/`on` and `0`/`no`/`false`/`off`          |
 | `Converters.Bigint`  | `bigint`    | `BigInt(raw)`                                             |
 | `Converters.Symbol`  | `symbol`    | `Symbol.for(raw)`                                         |
@@ -53,13 +53,16 @@ A fallback removes `undefined` from the return type, the same way it does for th
 
 ## Number, Integer, and Float
 
-`Number` accepts anything JavaScript's `Number()` does, including floats, hex, and scientific notation. `Integer` stops at the first non-digit, so `42px` reads as `42` and `3.9` reads as `3`. `Float` parses a leading decimal and tolerates trailing text.
+`Number` accepts anything JavaScript's `Number()` does, including floats, hex, and scientific notation. `Integer` and `Float` now parse with `Number` as well. `Integer` requires a safe integer, so `42px`, `3.9`, and values past 2^53 fall back. `Float` rejects trailing text like `3.14px` and keeps `Infinity` like `Number`. Both accept the same literal forms as `Number`, including `0x`, `0o`, and `0b`.
 
 ```ts twoslash
 import { Envapter, Converters } from 'envapt';
 // ---cut---
 // MAX_CONNECTIONS=100
 const maxConnections = Envapter.getUsing('MAX_CONNECTIONS', Converters.Integer); // 100
+
+// PORT="8080abc" is not a clean integer, so it falls back
+const port = Envapter.getUsing('PORT', Converters.Integer, 3000); // 3000
 const sampleRate = Envapter.getUsing('SAMPLE_RATE', Converters.Float, 1.0);
 ```
 

--- a/apps/guide/content/docs/migration-v7-to-v8.mdx
+++ b/apps/guide/content/docs/migration-v7-to-v8.mdx
@@ -3,7 +3,7 @@ title: Migration (v7 to v8)
 description: Moving from envapt v7 to v8. The source classes get shorter names, one universal envapt import replaces the workerd and browser subpaths, and the portable file APIs warn instead of throwing by default.
 ---
 
-v8 is a major release with **five** breaking changes. The source classes are renamed, the `envapt/workerd` and `envapt/browser` subpaths are removed, the portable build's filesystem-only config APIs warn once and no-op by default instead of throwing, the public type surface is trimmed, and the functional required-read bag moves to `getRequired`. Everything else (the positional `Envapter` readers, converters, decorators, and `envapt/legacy`) is unchanged.
+v8 is a major release with **six** breaking changes. The source classes are renamed, the `envapt/workerd` and `envapt/browser` subpaths are removed, the portable build's filesystem-only config APIs warn once and no-op by default instead of throwing, the public type surface is trimmed, the functional required-read bag moves to `getRequired`, and the `Integer` and `Float` converters reject malformed values. Everything else (the positional `Envapter` readers, decorators, and `envapt/legacy`) is unchanged.
 
 ## Source and type renames
 
@@ -95,3 +95,20 @@ You only need a change here if you imported one of these by name.
 
 - A custom source typed against `BareEnvSource` / `FileEnvSource` uses the `Source` union instead.
 - A schema output type from `InferSchemaOutput<typeof schema>` uses your validator's own inference (`z.infer`, valibot's `InferOutput`, arktype's `.infer`) or `StandardSchemaV1.InferOutput`.
+
+## Stricter `Integer` and `Float` converters
+
+`Converters.Integer` and `Converters.Float` used to parse with `parseInt` and `parseFloat`, which read a leading number and ignored the rest. `42abc` became `42`, `3.9` became `3` under `Integer`, and a value past 2^53 lost precision. v8 parses both with `Number` and validates the result, so a value that is not a clean number falls back to the default, or throws under `getRequired`.
+
+`Integer` requires `Number.isSafeInteger`, so `42abc`, `3.9`, and magnitudes past 2^53 all fall back. `Float` rejects trailing characters like `3.14xyz`. `Float` still accepts `Infinity`, matching the `number` converter and `getNumber`.
+
+```ts
+import { Converters, Envapter } from 'envapt';
+
+// with PORT="8080abc"
+Envapter.getRequired('PORT', Converters.Integer);
+// v7: 8080 (parseInt read the leading number)
+// v8: throws MissingEnvValue (Number rejects it)
+```
+
+You only need a change here if an env value was relying on the loose parse. A value that is already a clean integer or float reads the same.

--- a/packages/envapt/src/converters/BuiltInConverters.ts
+++ b/packages/envapt/src/converters/BuiltInConverters.ts
@@ -100,12 +100,18 @@ export class BuiltInConverters {
     }
 
     static integer(raw: string, fallback?: number): number | undefined {
-        const parsed = Number.parseInt(raw, 10);
-        return Number.isNaN(parsed) ? fallback : parsed;
+        const trimmed = raw.trim();
+        if (trimmed === '') return fallback;
+        const parsed = Number(trimmed);
+        // isSafeInteger also guards the 2^53 boundary, past which an integer value silently loses precision.
+        return Number.isSafeInteger(parsed) ? parsed : fallback;
     }
 
     static float(raw: string, fallback?: number): number | undefined {
-        const parsed = Number.parseFloat(raw);
+        const trimmed = raw.trim();
+        if (trimmed === '') return fallback;
+        const parsed = Number(trimmed);
+        // isNaN keeps Infinity valid, matching the number converter.
         return Number.isNaN(parsed) ? fallback : parsed;
     }
 

--- a/packages/envapt/tests/.env.038-numeric-strictness
+++ b/packages/envapt/tests/.env.038-numeric-strictness
@@ -1,0 +1,15 @@
+# Fixture for 038-numeric-converter-strictness.test.ts
+
+INT_VALID=42
+INT_NEGATIVE=-7
+INT_GARBAGE=42abc
+INT_FLOATLIKE=3.9
+# 2^53 + 1, the first integer past Number.MAX_SAFE_INTEGER.
+INT_UNSAFE=9007199254740993
+INT_WHITESPACE="   "
+
+FLOAT_VALID=3.14
+FLOAT_SCI=1e3
+FLOAT_GARBAGE=3.14xyz
+FLOAT_INFINITY=Infinity
+FLOAT_WHITESPACE="   "

--- a/packages/envapt/tests/038-numeric-converter-strictness.test.ts
+++ b/packages/envapt/tests/038-numeric-converter-strictness.test.ts
@@ -1,0 +1,102 @@
+import { resolve } from 'node:path';
+
+import { beforeAll, describe, expect, expectTypeOf, it } from 'vitest';
+
+import { Converters, Envapter } from '../src';
+import { Envapt } from '../src/legacy';
+
+// A rejected value returns undefined from the converter, which the decorator replaces with the fallback.
+// The fallbacks (99, 1.5) are values no leading-number parse of the fixtures would produce, so a loose
+// parse would surface the wrong number and fail these assertions instead of passing.
+describe('Numeric converter strictness (v8)', () => {
+    beforeAll(() => {
+        Envapter.envPaths = resolve(import.meta.dirname, '.env.038-numeric-strictness');
+    });
+
+    describe('integer', () => {
+        class Ints {
+            @Envapt('INT_VALID', { converter: Converters.Integer, fallback: 0 })
+            static readonly valid: number;
+
+            @Envapt('INT_NEGATIVE', { converter: Converters.Integer, fallback: 0 })
+            static readonly negative: number;
+
+            @Envapt('INT_GARBAGE', { converter: Converters.Integer, fallback: 99 })
+            static readonly garbage: number;
+
+            @Envapt('INT_FLOATLIKE', { converter: Converters.Integer, fallback: 99 })
+            static readonly floatlike: number;
+
+            @Envapt('INT_UNSAFE', { converter: Converters.Integer, fallback: 99 })
+            static readonly unsafe: number;
+
+            @Envapt('INT_WHITESPACE', { converter: Converters.Integer, fallback: 5 })
+            static readonly whitespace: number;
+        }
+
+        it('reads a plain integer', () => {
+            expect(Ints.valid).to.equal(42);
+            expectTypeOf(Ints.valid).toEqualTypeOf<number>();
+        });
+
+        it('reads a negative integer', () => {
+            expect(Ints.negative).to.equal(-7);
+        });
+
+        it('falls back on a value with trailing non-digits', () => {
+            expect(Ints.garbage).to.equal(99);
+        });
+
+        it('falls back on a non-integer', () => {
+            expect(Ints.floatlike).to.equal(99);
+        });
+
+        it('falls back on a magnitude past the safe-integer range', () => {
+            expect(Ints.unsafe).to.equal(99);
+        });
+
+        it('falls back on whitespace', () => {
+            expect(Ints.whitespace).to.equal(5);
+        });
+    });
+
+    describe('float', () => {
+        class Floats {
+            @Envapt('FLOAT_VALID', { converter: Converters.Float, fallback: 0 })
+            static readonly valid: number;
+
+            @Envapt('FLOAT_SCI', { converter: Converters.Float, fallback: 0 })
+            static readonly sci: number;
+
+            @Envapt('FLOAT_INFINITY', { converter: Converters.Float, fallback: 0 })
+            static readonly infinity: number;
+
+            @Envapt('FLOAT_GARBAGE', { converter: Converters.Float, fallback: 99 })
+            static readonly garbage: number;
+
+            @Envapt('FLOAT_WHITESPACE', { converter: Converters.Float, fallback: 1.5 })
+            static readonly whitespace: number;
+        }
+
+        it('reads a decimal', () => {
+            expect(Floats.valid).to.equal(3.14);
+            expectTypeOf(Floats.valid).toEqualTypeOf<number>();
+        });
+
+        it('reads scientific notation', () => {
+            expect(Floats.sci).to.equal(1000);
+        });
+
+        it('keeps Infinity, matching the number converter', () => {
+            expect(Floats.infinity).to.equal(Number.POSITIVE_INFINITY);
+        });
+
+        it('falls back on a value with trailing non-numeric characters', () => {
+            expect(Floats.garbage).to.equal(99);
+        });
+
+        it('falls back on whitespace', () => {
+            expect(Floats.whitespace).to.equal(1.5);
+        });
+    });
+});

--- a/packages/envapt/tests/038-numeric-converter-strictness.test.ts
+++ b/packages/envapt/tests/038-numeric-converter-strictness.test.ts
@@ -2,12 +2,13 @@ import { resolve } from 'node:path';
 
 import { beforeAll, describe, expect, expectTypeOf, it } from 'vitest';
 
-import { Converters, Envapter } from '../src';
+import { Converters, Envapter, EnvaptErrorCodes } from '../src';
+import { EnvaptError } from '../src/infra/Error';
 import { Envapt } from '../src/legacy';
 
-// A rejected value returns undefined from the converter, which the decorator replaces with the fallback.
-// The fallbacks (99, 1.5) are values no leading-number parse of the fixtures would produce, so a loose
-// parse would surface the wrong number and fail these assertions instead of passing.
+// A rejected value makes the converter return the fallback it was given, and that becomes the decorator field.
+// The fallbacks (99, 1.5) are values no leading-number parse of the fixtures would produce, so a loose parse
+// would surface the wrong number and fail these assertions.
 describe('Numeric converter strictness (v8)', () => {
     beforeAll(() => {
         Envapter.envPaths = resolve(import.meta.dirname, '.env.038-numeric-strictness');
@@ -97,6 +98,20 @@ describe('Numeric converter strictness (v8)', () => {
 
         it('falls back on whitespace', () => {
             expect(Floats.whitespace).to.equal(1.5);
+        });
+    });
+
+    describe('getRequired surfaces a rejected value as a throw', () => {
+        it('throws on a malformed integer', () => {
+            expect(() => Envapter.getRequired('INT_GARBAGE', Converters.Integer))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
+        });
+
+        it('throws on a malformed float', () => {
+            expect(() => Envapter.getRequired('FLOAT_GARBAGE', Converters.Float))
+                .to.throw(EnvaptError)
+                .with.property('code', EnvaptErrorCodes.MissingEnvValue);
         });
     });
 });


### PR DESCRIPTION
## What and why

`Converters.Integer` and `Converters.Float` parsed with `parseInt`/`parseFloat`, which accepted trailing garbage (`42abc` became `42`), truncated non-integers under `Integer`, and lost precision past 2^53. Both now parse with `Number` and validate (`Integer` requires `Number.isSafeInteger`), so a malformed value falls back to the default or throws under `getRequired`. `Float` still accepts `Infinity` and `number` is unchanged. This is a breaking behavior change, noted in the v7 to v8 migration guide.

## Checklist

- [x] New or regression tests cover the change
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how numeric converters parse values and when they fall back to defaults.
  * Updated examples to show stricter handling of invalid, trailing, or out-of-range numeric input.

* **Tests**
  * Added coverage for integer and float parsing behavior.
  * Verified fallback behavior for malformed values, whitespace, and unsafe integers.
  * Confirmed required values still raise an error when numeric input is invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->