### PR TITLE
ci: scope push triggers to main and next

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -10,14 +10,6 @@ on:
             - '.changeset/**'
             - '.github/ISSUE_TEMPLATE/**'
             - '.github/PULL_REQUEST_TEMPLATE.md'
-    push:
-        branches-ignore: [main, next]
-        paths-ignore:
-            - '**/*.md'
-            - '.vscode/**'
-            - '.changeset/**'
-            - '.github/ISSUE_TEMPLATE/**'
-            - '.github/PULL_REQUEST_TEMPLATE.md'
 
 concurrency:
     group: checks-${{ github.ref }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -3,6 +3,7 @@ name: commitlint
 on:
     pull_request:
     push:
+        branches: [main, next]
 
 permissions:
     contents: read

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,11 @@ name: codecov
 on:
     pull_request:
     push:
+        branches: [main, next]
+
+concurrency:
+    group: codecov-${{ github.ref }}
+    cancel-in-progress: true
 
 permissions:
     contents: read

--- a/scripts/semver-label.ts
+++ b/scripts/semver-label.ts
@@ -79,7 +79,9 @@ async function prChangedFiles(ctx: Ctx): Promise<{ filename: string; status: str
             'GET',
             `/repos/${ctx.owner}/${ctx.repo}/pulls/${ctx.pr}/files?per_page=100&page=${page}`
         );
-        if (!res.ok) break;
+        // a failed listing must stop the job, an empty list here would silently apply no label.
+        if (!res.ok)
+            throw new Error(`[semver-label] listing PR #${ctx.pr} files failed: ${res.status} ${res.statusText}`);
         // justified: GitHub "list pull request files" returns an array of file entries
         const pageFiles = (await res.json()) as { filename: string; status: string }[];
         files.push(...pageFiles);
@@ -92,7 +94,8 @@ async function changesetBodies(ctx: Ctx): Promise<string[]> {
     const bodies: string[] = [];
     for (const path of changesetPathsFromFiles(await prChangedFiles(ctx))) {
         const file = await api(ctx.token, 'GET', `/repos/${ctx.owner}/${ctx.repo}/contents/${path}?ref=${ctx.sha}`);
-        if (!file.ok) continue;
+        // same reason as the listing, a skipped changeset would drop its bump and mislabel the PR.
+        if (!file.ok) throw new Error(`[semver-label] reading ${path} failed: ${file.status} ${file.statusText}`);
         // justified: GitHub "get file contents" returns base64 content
         const { content } = (await file.json()) as { content: string };
         bodies.push(Buffer.from(content, 'base64').toString('utf8'));

--- a/scripts/semver-label.ts
+++ b/scripts/semver-label.ts
@@ -26,6 +26,17 @@ export function maxBump(changesets: string[]): Bump | null {
     return top;
 }
 
+/** The changeset files this PR adds or edits. */
+export function changesetPathsFromFiles(files: { filename: string; status: string }[]): string[] {
+    return files
+        .filter((file) => {
+            const name = file.filename.split('/').pop() ?? '';
+            const touched = file.status === 'added' || file.status === 'modified';
+            return file.filename.startsWith('.changeset/') && name.endsWith('.md') && name !== 'README.md' && touched;
+        })
+        .map((file) => file.filename);
+}
+
 interface Ctx {
     owner: string;
     repo: string;
@@ -60,19 +71,27 @@ function api(token: string, method: string, path: string, body?: unknown): Promi
     });
 }
 
-async function changesetBodies(ctx: Ctx): Promise<string[]> {
-    const list = await api(ctx.token, 'GET', `/repos/${ctx.owner}/${ctx.repo}/contents/.changeset?ref=${ctx.sha}`);
-    if (!list.ok) return [];
-    // justified: GitHub "get directory contents" returns an array of entries
-    const entries = (await list.json()) as { type: string; name: string; path: string }[];
-    const bodies: string[] = [];
-    for (const entry of entries) {
-        if (entry.type !== 'file' || !entry.name.endsWith('.md') || entry.name === 'README.md') continue;
-        const file = await api(
+async function prChangedFiles(ctx: Ctx): Promise<{ filename: string; status: string }[]> {
+    const files: { filename: string; status: string }[] = [];
+    for (let page = 1; ; page++) {
+        const res = await api(
             ctx.token,
             'GET',
-            `/repos/${ctx.owner}/${ctx.repo}/contents/${entry.path}?ref=${ctx.sha}`
+            `/repos/${ctx.owner}/${ctx.repo}/pulls/${ctx.pr}/files?per_page=100&page=${page}`
         );
+        if (!res.ok) break;
+        // justified: GitHub "list pull request files" returns an array of file entries
+        const pageFiles = (await res.json()) as { filename: string; status: string }[];
+        files.push(...pageFiles);
+        if (pageFiles.length < 100) break;
+    }
+    return files;
+}
+
+async function changesetBodies(ctx: Ctx): Promise<string[]> {
+    const bodies: string[] = [];
+    for (const path of changesetPathsFromFiles(await prChangedFiles(ctx))) {
+        const file = await api(ctx.token, 'GET', `/repos/${ctx.owner}/${ctx.repo}/contents/${path}?ref=${ctx.sha}`);
         if (!file.ok) continue;
         // justified: GitHub "get file contents" returns base64 content
         const { content } = (await file.json()) as { content: string };

--- a/scripts/tests/semver-label.test.ts
+++ b/scripts/tests/semver-label.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { maxBump } from '../semver-label';
+import { changesetPathsFromFiles, maxBump } from '../semver-label';
 
 const changeset = (bump: string): string => `---\n'envapt': ${bump}\n---\n\nsummary line`;
 
@@ -35,5 +35,35 @@ describe('maxBump', () => {
 
     it('returns null for an empty list', () => {
         expect(maxBump([])).to.equal(null);
+    });
+});
+
+describe('changesetPathsFromFiles', () => {
+    it('yields nothing for a PR that adds no changeset (a CI-only PR)', () => {
+        const files = [
+            { filename: '.github/workflows/checks.yml', status: 'modified' },
+            { filename: '.github/workflows/coverage.yml', status: 'modified' }
+        ];
+        expect(changesetPathsFromFiles(files)).to.deep.equal([]);
+    });
+
+    it('picks up a changeset the PR adds or edits', () => {
+        const files = [
+            { filename: '.changeset/strict-converters.md', status: 'added' },
+            { filename: '.changeset/existing-edit.md', status: 'modified' },
+            { filename: 'packages/envapt/src/x.ts', status: 'modified' }
+        ];
+        expect(changesetPathsFromFiles(files)).to.deep.equal([
+            '.changeset/strict-converters.md',
+            '.changeset/existing-edit.md'
+        ]);
+    });
+
+    it('skips the changeset README and removed changesets', () => {
+        const files = [
+            { filename: '.changeset/README.md', status: 'modified' },
+            { filename: '.changeset/dropped.md', status: 'removed' }
+        ];
+        expect(changesetPathsFromFiles(files)).to.deep.equal([]);
     });
 });


### PR DESCRIPTION
Some workflows were running twice in PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release labeling accuracy by detecting only changeset files that are actually added or modified in the pull request.
  * Ignored irrelevant changeset files (including the changeset README) and excluded removed entries from consideration.
  * Updated error handling so failures to read pull request file data or retrieve changeset contents surface instead of being silently skipped.
* **Tests**
  * Added coverage for the changeset-path filtering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->