### PR TITLE
refactor(core): make engine state and internal API module-private

### DIFF
--- a/.changeset/module-private-engine-state.md
+++ b/.changeset/module-private-engine-state.md
@@ -1,0 +1,5 @@
+---
+'envapt': patch
+---
+
+Move the engine's mutable state and read cache into a module that the `exports` map does not include. They are no longer fields on the class and have no import path, so outside code cannot read or write them through an `as`-cast or a subclass. Drop the internal `TimeUnit` type and `isStrict()` method from the public exports.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,24 +1,26 @@
 '📦 envapt':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/envapt/**'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/envapt/**'
 '📚 docs':
-    - changed-files:
-          - any-glob-to-any-file: 'apps/guide/**'
-          - any-glob-to-any-file: '**/*.md'
-          - any-glob-to-any-file: '**/*.mdx'
+  - changed-files:
+      - any-glob-to-any-file: 'apps/guide/**'
+      - any-glob-to-any-file: '**/*.md'
+      - any-glob-to-any-file: '**/*.mdx'
+      - any-glob-to-any-file: '!(**/CHANGELOG.md)'
+      - any-glob-to-any-file: '!(**/.changesets/**)'
 '🧪 tests':
-    - changed-files:
-          - any-glob-to-any-file: '**/*.test.ts'
-          - any-glob-to-any-file: '**/*.spec.ts'
-          - any-glob-to-any-file: '**/__tests__/**/*'
+  - changed-files:
+      - any-glob-to-any-file: '**/*.test.ts'
+      - any-glob-to-any-file: '**/*.spec.ts'
+      - any-glob-to-any-file: '**/__tests__/**/*'
 '🤖 ci':
-    - changed-files:
-          - any-glob-to-any-file: '.github/**'
-          - any-glob-to-any-file: turbo.json
-          - any-glob-to-any-file: turbo.jsonc
-          - any-glob-to-any-file: pnpm-workspace.yaml
-          - any-glob-to-any-file: pnpm-lock.yaml
-          - any-glob-to-any-file: 'tsconfig*.json'
-          - any-glob-to-any-file: eslint.config.mjs
-          - any-glob-to-any-file: vitest.config.ts
-          - any-glob-to-any-file: tsdown.config.ts
+  - changed-files:
+      - any-glob-to-any-file: '.github/**'
+      - any-glob-to-any-file: turbo.json
+      - any-glob-to-any-file: turbo.jsonc
+      - any-glob-to-any-file: pnpm-workspace.yaml
+      - any-glob-to-any-file: pnpm-lock.yaml
+      - any-glob-to-any-file: 'tsconfig*.json'
+      - any-glob-to-any-file: eslint.config.mjs
+      - any-glob-to-any-file: vitest.config.ts
+      - any-glob-to-any-file: tsdown.config.ts

--- a/.github/skills/writing-voice/SKILL.md
+++ b/.github/skills/writing-voice/SKILL.md
@@ -60,6 +60,7 @@ This list is illustrative, not exhaustive. When a word isn't on it, apply the ru
 | **without any manual wiring / zero config** | sells absence of work | state what happens automatically |
 | **robust** | empty adjective | name the guarantee: "validates …", "throws on …" |
 | **performant** | vague performance claim | a precise figure: "p99 under 5 ms", "O(1) lookup" |
+| **harden / hardening** | vague security verb, hides the change | name the change: "make private", "remove the export", "block the write" |
 | **does more than X** | tease, not information | just state what it does |
 | **under the hood** | filler | "internally", or delete |
 | **out of the box** | filler | "by default" |
@@ -78,7 +79,7 @@ This list is illustrative, not exhaustive. When a word isn't on it, apply the ru
 | **handle / handling** (vague) | hides behavior | name the action: "parses", "coerces", "rejects" |
 | **rich set of / suite of** | brochure | "a set of", or just list them |
 | **magic / magical** | mystifies behavior | explain the rule |
-| **reach for X** | folksy filler for "use" | "use X", or name the action |
+| **reach for X (or variations of reach)** | folksy filler for "use" | "use X", or name the action |
 | **blast radius** | war metaphor for scope of impact; dramatizes it | name what's affected: "every caller of `parse()`", "all rows in `users`" |
 | **lives in / lives on** | folksy for where something is defined; anthropomorphizes a location | "is defined in", "is set on", name the file or element |
 | **owns** | anthropomorphizes; a module isn't an agent with property | name the relationship: "defines", "sets", "is the only writer of" |

--- a/packages/envapt/src/common.ts
+++ b/packages/envapt/src/common.ts
@@ -11,7 +11,6 @@ export type {
     ConverterFunction,
     EnvaptConverter,
     JsonValue,
-    TimeUnit,
     TimeFallback,
     EnvaptOptions,
     EnvProfile,

--- a/packages/envapt/src/converters/ValueConverter.ts
+++ b/packages/envapt/src/converters/ValueConverter.ts
@@ -1,4 +1,5 @@
 import { BuiltInConverters } from './BuiltInConverters';
+import { state } from '../core/state';
 import { Validator } from '../engine/Validators';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
@@ -139,7 +140,7 @@ export class ValueConverter {
             return fallback;
         }
 
-        const result = BuiltInConverters.processArrayConverter(parsed, resolvedConverter, this.envService.isStrict());
+        const result = BuiltInConverters.processArrayConverter(parsed, resolvedConverter, state.strict);
         return result as TFallback;
     }
 

--- a/packages/envapt/src/core/EnvapterBase.ts
+++ b/packages/envapt/src/core/EnvapterBase.ts
@@ -115,7 +115,7 @@ export abstract class EnvapterBase {
 
     protected static refreshCache(): void {
         cache.clear();
-        state.dotenvAddedKeys = new Set();
+        state.dotenvAddedKeys = new Set<string>();
         debugVerbose('cache cleared, reloading config');
         void this.config; // getter rebuilds the cache as a side effect
     }
@@ -144,7 +144,7 @@ export abstract class EnvapterBase {
         return value;
     }
 
-    // Default returns the explicit `_envPaths`. EnvironmentMethods overrides to layer the dotenv-flow
+    // Default returns the explicit `state.envPaths`. EnvironmentMethods overrides to layer the dotenv-flow
     // cascade + configureProfiles when envPaths was never explicitly set.
     protected static resolveEffectivePaths(): string[] {
         /* v8 ignore next -- @preserve */

--- a/packages/envapt/src/core/EnvapterBase.ts
+++ b/packages/envapt/src/core/EnvapterBase.ts
@@ -1,45 +1,27 @@
+import { cache, state } from './state';
 import { Validator } from '../engine/Validators';
 import { debugVerbose, getDebugLevel, setDebugLevel } from '../infra/Debug';
 import { loadDotenv } from '../infra/Dotenv';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 import { bindRuntimeFromSource } from '../infra/runtime';
-import { UnboundSource } from '../sources/UnboundSource';
 
 import type { DebugLevel } from '../infra/Debug';
-import type { EnvFileOptions } from '../infra/Dotenv';
 import type { EnvKeyInput, FileApiMode, FileCapableSource, Source } from '../types';
 
 /** @internal */
-export const EnvaptCache = new Map<string, unknown>();
-
-/** @internal */
 export abstract class EnvapterBase {
-    protected static _envPaths: string[] = ['.env'];
-    protected static _envPathsExplicitlySet = false;
-    protected static _baseDir: string | undefined = undefined;
-    protected static _userDefinedEnvFileOptions: EnvFileOptions = {};
-    protected static _strict = false;
-    protected static _syncProcessEnv = false;
-    protected static _fileApiMode: FileApiMode = 'warn';
-    // Loader-written keys only (collisions skipped). Refilled on every cache rebuild.
-    protected static _dotenvAddedKeys: Set<string> = new Set<string>();
-    // Unbound by default so non-Node builds throw NoSourceBound on read until useSource() is called.
-    // NodeEnvapter's static block binds FileSource when referenced, so `import 'envapt'` needs no setup.
-    protected static _source: Source = new UnboundSource();
-
     /**
      * Enable or disable strict mode. Default `false`. Setting refreshes the cache so
      * previously-cached converted values get re-evaluated under the new rule.
      */
     static set strict(value: boolean) {
-        // Anchored to EnvapterBase: `this._strict` would write an own-property on the subclass that base readers miss.
-        EnvapterBase._strict = value;
+        state.strict = value;
         // rebuild via `this` so the subclass `resolveEffectivePaths` override is honored (EnvapterBase would skip it).
         this.refreshCache();
     }
 
     static get strict(): boolean {
-        return EnvapterBase._strict;
+        return state.strict;
     }
 
     /**
@@ -68,14 +50,13 @@ export abstract class EnvapterBase {
      */
     static set syncProcessEnv(value: boolean) {
         Validator.validateSyncProcessEnv(value);
-        const previous = EnvapterBase._syncProcessEnv;
-        // Anchored to EnvapterBase: `this._syncProcessEnv` would write an own-property on the subclass that base readers miss.
-        EnvapterBase._syncProcessEnv = value;
-        if (!previous && value && EnvaptCache.size > 0) this.mirrorToProcessEnv();
+        const previous = state.syncProcessEnv;
+        state.syncProcessEnv = value;
+        if (!previous && value && cache.size > 0) this.mirrorToProcessEnv();
     }
 
     static get syncProcessEnv(): boolean {
-        return EnvapterBase._syncProcessEnv;
+        return state.syncProcessEnv;
     }
 
     /**
@@ -86,26 +67,26 @@ export abstract class EnvapterBase {
      */
     static set fileApiMode(mode: FileApiMode) {
         Validator.validateFileApiMode(mode);
-        // anchored to EnvapterBase like _strict. no refreshCache, it only gates the portable stubs.
-        EnvapterBase._fileApiMode = mode;
+        // no refreshCache, this only gates the portable stubs.
+        state.fileApiMode = mode;
     }
 
     static get fileApiMode(): FileApiMode {
-        return EnvapterBase._fileApiMode;
+        return state.fileApiMode;
     }
 
     protected static treatAsMissing(value: string | undefined): boolean {
         if (value === undefined || value === '') return true;
-        if (EnvapterBase._strict && value.trim() === '') return true;
+        if (state.strict && value.trim() === '') return true;
         return false;
     }
 
     // No baseDir: candidate returned unchanged so the source resolves it against its own default
     // (process.cwd() on Node). Resolution goes through the source to keep this class node-free.
     protected static resolveAgainstBase(candidate: string): string {
-        const baseDir = EnvapterBase._baseDir;
+        const baseDir = state.baseDir;
         if (baseDir === undefined) return candidate;
-        const source = EnvapterBase._source;
+        const source = state.source;
         /* v8 ignore next -- @preserve callers are all file-gated, so the source is never bare here */
         if (!source.supportsFiles) return candidate;
         return source.resolvePath(baseDir, candidate);
@@ -126,34 +107,34 @@ export abstract class EnvapterBase {
     // Existence via the bound source instead of fs.existsSync/accessSync: a file "exists" when the
     // source can read it.
     protected static sourceFileExists(path: string): boolean {
-        const source = EnvapterBase._source;
+        const source = state.source;
         /* v8 ignore next -- @preserve every caller is file-gated, so this never sees a bare source */
         if (!source.supportsFiles) return false;
         return source.readFile(path, 'utf8') !== undefined;
     }
 
     protected static refreshCache(): void {
-        EnvaptCache.clear();
-        EnvapterBase._dotenvAddedKeys = new Set();
+        cache.clear();
+        state.dotenvAddedKeys = new Set();
         debugVerbose('cache cleared, reloading config');
         void this.config; // getter rebuilds the cache as a side effect
     }
 
     protected static mirrorToProcessEnv(): void {
-        if (EnvapterBase._dotenvAddedKeys.size === 0) return;
-        const source = EnvapterBase._source;
+        if (state.dotenvAddedKeys.size === 0) return;
+        const source = state.source;
         /* v8 ignore next -- @preserve dotenv keys only accumulate under a file source, so the delta implies supportsFiles here */
         if (!source.supportsFiles) return;
         const mirrored: Record<string, string> = {};
-        for (const key of EnvapterBase._dotenvAddedKeys) {
-            const value = EnvaptCache.get(key);
+        for (const key of state.dotenvAddedKeys) {
+            const value = cache.get(key);
             /* v8 ignore next -- @preserve loader only writes strings, defensive against future cache contents */
             if (typeof value !== 'string') continue;
             mirrored[key] = this.resolveForMirror(key, value);
             debugVerbose(`mirrored ${key} to the ambient environment`);
         }
         source.writeVars(mirrored);
-        debugVerbose(`mirrored ${EnvapterBase._dotenvAddedKeys.size} keys to the ambient environment`);
+        debugVerbose(`mirrored ${state.dotenvAddedKeys.size} keys to the ambient environment`);
     }
 
     // The template resolver is defined in PrimitiveMethods, and EnvapterBase can't call it without an
@@ -167,7 +148,7 @@ export abstract class EnvapterBase {
     // cascade + configureProfiles when envPaths was never explicitly set.
     protected static resolveEffectivePaths(): string[] {
         /* v8 ignore next -- @preserve */
-        return this._envPaths.map((p) => this.resolveAgainstBase(p));
+        return state.envPaths.map((p) => this.resolveAgainstBase(p));
     }
 
     protected static resolveKeyInput(keyInput: EnvKeyInput): { key: string; value: string | undefined } {
@@ -197,8 +178,8 @@ export abstract class EnvapterBase {
     }
 
     protected static get config(): Map<string, unknown> {
-        if (EnvaptCache.size === 0) {
-            const source = EnvapterBase._source;
+        if (cache.size === 0) {
+            const source = state.source;
             // Clone so the loader and downstream reads never mutate the source's backing object.
             const isolatedEnv: Record<string, string> = { ...source.readVars() };
 
@@ -206,7 +187,7 @@ export abstract class EnvapterBase {
             // Sources without a filesystem (injected objects on the browser or Workers) skip the
             // .env cascade, profiles, and envPaths. Only the readVars() snapshot populates the cache.
             if (source.supportsFiles) {
-                debugVerbose(`base dir: ${EnvapterBase._baseDir ?? 'working directory'}`);
+                debugVerbose(`base dir: ${state.baseDir ?? 'working directory'}`);
                 // Outside the try below so a missing configured profile path surfaces its EnvaptError. Only dotenv parse errors stay caught.
                 const effectivePaths = this.resolveEffectivePaths();
                 debugVerbose(
@@ -214,20 +195,20 @@ export abstract class EnvapterBase {
                 );
                 try {
                     added = loadDotenv({
-                        ...this._userDefinedEnvFileOptions,
+                        ...state.userDefinedEnvFileOptions,
                         path: effectivePaths,
                         processEnv: isolatedEnv,
                         readFile: source.readFile.bind(source)
                     });
                 } catch {}
             }
-            EnvapterBase._dotenvAddedKeys = added;
-            for (const [key, value] of Object.entries(isolatedEnv)) EnvaptCache.set(key, value);
-            debugVerbose(`cache populated: ${EnvaptCache.size} keys total`);
-            if (EnvapterBase._syncProcessEnv) this.mirrorToProcessEnv();
+            state.dotenvAddedKeys = added;
+            for (const [key, value] of Object.entries(isolatedEnv)) cache.set(key, value);
+            debugVerbose(`cache populated: ${cache.size} keys total`);
+            if (state.syncProcessEnv) this.mirrorToProcessEnv();
         }
 
-        return EnvaptCache;
+        return cache;
     }
 
     /**
@@ -245,7 +226,7 @@ export abstract class EnvapterBase {
      * `PortableSource` (or any `Source`) before reading. Clears and rebuilds the cache.
      */
     static useSource(source: Source): void {
-        EnvapterBase._source = source;
+        state.source = source;
         bindRuntimeFromSource(source);
         this.refreshCache();
     }

--- a/packages/envapt/src/core/EnvironmentMethods.ts
+++ b/packages/envapt/src/core/EnvironmentMethods.ts
@@ -1,8 +1,9 @@
 import { EnvapterBase } from './EnvapterBase';
+import { state } from './state';
 import { debugWarn } from '../infra/Debug';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
-import type { EnvProfile, ProfilesConfig } from '../types';
+import type { EnvProfile } from '../types';
 
 /**
  * Environment types supported by Envapter
@@ -49,19 +50,15 @@ function parseEnvironment(raw: string): Environment | undefined {
  * @internal
  */
 export class EnvironmentMethods extends EnvapterBase {
-    protected static _environment: Environment | undefined;
-    protected static _environmentExplicitlySet = false;
-    protected static _profiles: ProfilesConfig | undefined;
-
     protected static determineEnvironment(env?: string | Environment): void {
         if (typeof env === 'number') {
-            this._environment = env;
-            this._environmentExplicitlySet = true;
+            state.environment = env;
+            state.environmentExplicitlySet = true;
             return;
         }
         if (typeof env === 'string') {
-            this._environment = parseEnvironment(env) ?? Environment.Development;
-            this._environmentExplicitlySet = true;
+            state.environment = parseEnvironment(env) ?? Environment.Development;
+            state.environmentExplicitlySet = true;
             return;
         }
 
@@ -71,16 +68,16 @@ export class EnvironmentMethods extends EnvapterBase {
         });
         if (raw === undefined) {
             debugWarn(`no environment set (looked for ${ENV_KEYS.join(', ')}); defaulting to development`);
-            this._environment = Environment.Development;
+            state.environment = Environment.Development;
             return;
         }
         const parsed = parseEnvironment(raw);
         if (parsed === undefined) {
             debugWarn(`unrecognized environment "${raw}"; defaulting to development`);
-            this._environment = Environment.Development;
+            state.environment = Environment.Development;
             return;
         }
-        this._environment = parsed;
+        state.environment = parsed;
     }
 
     private static firstEnvKeyValue(read: (key: string) => string | undefined): string | undefined {
@@ -95,10 +92,10 @@ export class EnvironmentMethods extends EnvapterBase {
      * Get the current application environment
      */
     static get environment(): Environment {
-        if (this._environment === undefined) {
+        if (state.environment === undefined) {
             this.determineEnvironment();
         }
-        return this._environment as Environment;
+        return state.environment as Environment;
     }
 
     /**
@@ -183,7 +180,7 @@ export class EnvironmentMethods extends EnvapterBase {
         // from current state. If the user explicitly set Envapter.environment = X, preserve
         // that value through the refresh. The immediate re-hydration inside super.refreshCache()
         // will use it for cascade selection.
-        if (!this._environmentExplicitlySet) this._environment = undefined;
+        if (!state.environmentExplicitlySet) state.environment = undefined;
         super.refreshCache();
     }
 
@@ -193,9 +190,9 @@ export class EnvironmentMethods extends EnvapterBase {
      * @internal
      */
     protected static getCascadeEnvironment(): Environment {
-        if (this._environment !== undefined) return this._environment;
+        if (state.environment !== undefined) return state.environment;
 
-        const vars = EnvapterBase._source.readVars();
+        const vars = state.source.readVars();
         const raw = this.firstEnvKeyValue((key) => vars[key]);
         return raw === undefined ? Environment.Development : (parseEnvironment(raw) ?? Environment.Development);
     }
@@ -242,10 +239,10 @@ export class EnvironmentMethods extends EnvapterBase {
      * @internal
      */
     protected static override resolveEffectivePaths(): string[] {
-        if (this._envPathsExplicitlySet) return this._envPaths.map((p) => this.resolveAgainstBase(p));
+        if (state.envPathsExplicitlySet) return state.envPaths.map((p) => this.resolveAgainstBase(p));
 
         const env = this.getCascadeEnvironment();
-        const profileEntry = this._profiles?.[env];
+        const profileEntry = state.profiles?.[env];
         const profilePaths = this.normalizeProfilePaths(profileEntry);
 
         // Validate that explicitly configured profile paths exist for the active env.
@@ -259,7 +256,7 @@ export class EnvironmentMethods extends EnvapterBase {
             }
         }
 
-        const cascade = this._profiles?.useDefaults === false ? [] : this.buildCascadePaths(env);
+        const cascade = state.profiles?.useDefaults === false ? [] : this.buildCascadePaths(env);
         return [...profilePaths.map((p) => this.resolveAgainstBase(p)), ...cascade];
     }
 }

--- a/packages/envapt/src/core/EnvironmentMethods.ts
+++ b/packages/envapt/src/core/EnvironmentMethods.ts
@@ -224,7 +224,7 @@ export class EnvironmentMethods extends EnvapterBase {
 
     /**
      * Override the base implementation to layer the dotenv-flow cascade + any
-     * `Envapter.configureProfiles` overrides on top of `_envPaths` when the user has NOT
+     * `Envapter.configureProfiles` overrides on top of `state.envPaths` when the user has NOT
      * explicitly set `envPaths`.
      *
      * Precedence (passed to dotenv with first-wins semantics):

--- a/packages/envapt/src/core/PrimitiveMethods.ts
+++ b/packages/envapt/src/core/PrimitiveMethods.ts
@@ -1,5 +1,4 @@
 import { BuiltInConverters, ValueConverter } from '../converters';
-import { EnvapterBase } from './EnvapterBase';
 import { EnvironmentMethods } from './EnvironmentMethods';
 import { TemplateResolver } from '../engine/TemplateResolver';
 import { debugWarn } from '../infra/Debug';
@@ -25,13 +24,6 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
     private static readonly service = new PrimitiveMethods();
     protected static readonly templateResolver: TemplateResolver = new TemplateResolver(PrimitiveMethods.service);
     protected static readonly valueConverter: ValueConverter = new ValueConverter(PrimitiveMethods.service);
-
-    // Read `EnvapterBase.strict` directly: `PrimitiveMethods._strict` would resolve to the
-    // BaseClass default because a `Envapter.strict = true` write lands as an own-property
-    // on `Envapter`, which is a descendant of `PrimitiveMethods`, not an ancestor.
-    isStrict(): boolean {
-        return EnvapterBase.strict;
-    }
 
     protected static override resolveForMirror(key: string, value: string): string {
         return this.templateResolver.resolveTemplate(key, value);

--- a/packages/envapt/src/core/index.ts
+++ b/packages/envapt/src/core/index.ts
@@ -1,3 +1,2 @@
-export { EnvaptCache } from './EnvapterBase';
 export { Environment } from './EnvironmentMethods';
 export { AdvancedMethods } from './AdvancedMethods';

--- a/packages/envapt/src/core/state.ts
+++ b/packages/envapt/src/core/state.ts
@@ -1,0 +1,25 @@
+import { UnboundSource } from '../sources/UnboundSource';
+
+import type { Environment } from './EnvironmentMethods';
+import type { EnvFileOptions } from '../infra/Dotenv';
+import type { FileApiMode, ProfilesConfig, Source } from '../types';
+
+// The engine's mutable state that should not be exposed in the package exports map.
+export const state = {
+    envPaths: ['.env'] as string[],
+    envPathsExplicitlySet: false,
+    baseDir: undefined as string | undefined,
+    userDefinedEnvFileOptions: {} as EnvFileOptions,
+    strict: false,
+    syncProcessEnv: false,
+    fileApiMode: 'warn' as FileApiMode,
+    // loader-written keys only (collisions skipped), refilled on every cache rebuild.
+    dotenvAddedKeys: new Set<string>(),
+    // unbound by default so non-Node builds throw NoSourceBound on read until useSource() runs.
+    source: new UnboundSource() as Source,
+    environment: undefined as Environment | undefined,
+    environmentExplicitlySet: false,
+    profiles: undefined as ProfilesConfig | undefined
+};
+
+export const cache = new Map<string, unknown>();

--- a/packages/envapt/src/decorators/resolveDecoratorValue.ts
+++ b/packages/envapt/src/decorators/resolveDecoratorValue.ts
@@ -1,5 +1,5 @@
 import { ValueConverter } from '../converters';
-import { EnvaptCache } from '../core';
+import { cache } from '../core/state';
 import { Envapter } from '../engine/Envapter';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
@@ -41,7 +41,7 @@ export function resolveDecoratorValue<TFallback>(
 
     // .has(), not a get()-truthiness check, so a cached undefined (fallback: undefined, or a converter
     // that returns undefined) resolves once instead of re-running on every access
-    if (EnvaptCache.has(cacheKey)) return EnvaptCache.get(cacheKey) as TFallback | null | undefined;
+    if (cache.has(cacheKey)) return cache.get(cacheKey) as TFallback | null | undefined;
 
     const envapter = new Envapter();
 
@@ -61,6 +61,6 @@ export function resolveDecoratorValue<TFallback>(
             ? (valueConverter.convertWithSchema(key, schema, fallback, hasFallback) as TFallback)
             : valueConverter.convertValue(key, fallback, converter, hasFallback);
 
-    EnvaptCache.set(cacheKey, value);
+    cache.set(cacheKey, value);
     return value;
 }

--- a/packages/envapt/src/engine/Envapter.ts
+++ b/packages/envapt/src/engine/Envapter.ts
@@ -2,7 +2,7 @@ import { AdvancedMethods } from '../core';
 import { resolveRequired } from '../core/AdvancedMethods';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
-export { EnvaptCache, Environment } from '../core';
+export { Environment } from '../core';
 
 /**
  * Main configuration class for environment variable management.

--- a/packages/envapt/src/engine/NodeEnvapter.ts
+++ b/packages/envapt/src/engine/NodeEnvapter.ts
@@ -2,8 +2,7 @@ import process from 'node:process';
 
 import { Envapter } from './Envapter';
 import { Validator } from './Validators';
-import { EnvapterBase } from '../core/EnvapterBase';
-import { EnvironmentMethods } from '../core/EnvironmentMethods';
+import { state } from '../core/state';
 import { setRuntimeSink } from '../infra/runtime';
 import { FileSource } from '../sources/FileSource';
 
@@ -15,9 +14,6 @@ import type { ProfilesConfig } from '../types';
  * path selection, base directory, dotenv options, and per-environment profiles). On the portable
  * build (Workers, the browser, edge) these same APIs warn once and no-op by default, controlled by
  * `Envapter.fileApiMode`.
- *
- * Writes target the state-owning class (`EnvapterBase`/`EnvironmentMethods`), not `this`: the engine
- * reads that state through `EnvapterBase`-anchored paths, so a subclass own-property would be invisible.
  * @public
  */
 export class NodeEnvapter extends Envapter {
@@ -37,15 +33,15 @@ export class NodeEnvapter extends Envapter {
      * `Envapter.configureProfiles` configuration are ignored.
      */
     static set envPaths(paths: string[] | string) {
-        this.assertFileApiSupported('envPaths', EnvapterBase._source);
+        this.assertFileApiSupported('envPaths', state.source);
         const newPaths = Array.isArray(paths) ? paths : [paths];
         Validator.validateEnvFilesExist(
             newPaths.map((p) => this.resolveAgainstBase(p)),
             (p) => this.sourceFileExists(p)
         );
 
-        EnvapterBase._envPaths = newPaths;
-        EnvapterBase._envPathsExplicitlySet = true;
+        state.envPaths = newPaths;
+        state.envPathsExplicitlySet = true;
         this.refreshCache();
     }
 
@@ -53,7 +49,7 @@ export class NodeEnvapter extends Envapter {
      * Get currently configured .env file paths
      */
     static get envPaths(): string[] {
-        return EnvapterBase._envPaths;
+        return state.envPaths;
     }
 
     /**
@@ -67,21 +63,21 @@ export class NodeEnvapter extends Envapter {
      * Unset (`undefined`) restores `process.cwd()` resolution.
      */
     static set baseDir(value: string | URL | undefined) {
-        const source = EnvapterBase._source;
+        const source = state.source;
         this.assertFileApiSupported('baseDir', source);
-        EnvapterBase._baseDir = value === undefined ? undefined : source.normalizeBaseDir(value);
+        state.baseDir = value === undefined ? undefined : source.normalizeBaseDir(value);
         this.refreshCache();
     }
 
     /** The configured base directory, or `undefined` when relative paths resolve against the working directory. */
     static get baseDir(): string | undefined {
-        return EnvapterBase._baseDir;
+        return state.baseDir;
     }
 
     /** Set the env file loader options (`encoding`, `override`). Refreshes the cache. */
     static set envFileOptions(config: EnvFileOptions) {
         Validator.validateEnvFileOptions(config);
-        EnvapterBase._userDefinedEnvFileOptions = config;
+        state.userDefinedEnvFileOptions = config;
         this.refreshCache();
     }
 
@@ -89,7 +85,7 @@ export class NodeEnvapter extends Envapter {
      * Get current env file loader options
      */
     static get envFileOptions(): EnvFileOptions {
-        return EnvapterBase._userDefinedEnvFileOptions;
+        return state.userDefinedEnvFileOptions;
     }
 
     /**
@@ -110,8 +106,8 @@ export class NodeEnvapter extends Envapter {
      * ```
      */
     static configureProfiles(config: ProfilesConfig): void {
-        this.assertFileApiSupported('configureProfiles', EnvapterBase._source);
-        EnvironmentMethods._profiles = config;
+        this.assertFileApiSupported('configureProfiles', state.source);
+        state.profiles = config;
         this.refreshCache();
     }
 
@@ -121,13 +117,11 @@ export class NodeEnvapter extends Envapter {
      * Returns the resolver to the pure dotenv-flow cascade.
      */
     static resetProfiles(): void {
-        EnvironmentMethods._profiles = undefined;
-        EnvapterBase._envPaths = ['.env'];
-        EnvapterBase._envPathsExplicitlySet = false;
-        // Clear via `this`, not EnvironmentMethods: determineEnvironment writes `_environment*` via
-        // `this`, so a base-anchored clear would leave a subclass own-property shadowing it.
-        this._environmentExplicitlySet = false;
-        this._environment = undefined;
+        state.profiles = undefined;
+        state.envPaths = ['.env'];
+        state.envPathsExplicitlySet = false;
+        state.environmentExplicitlySet = false;
+        state.environment = undefined;
         this.refreshCache();
     }
 }

--- a/packages/envapt/src/engine/TemplateResolver.ts
+++ b/packages/envapt/src/engine/TemplateResolver.ts
@@ -1,3 +1,4 @@
+import { state } from '../core/state';
 import { debugWarn } from '../infra/Debug';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
@@ -15,7 +16,7 @@ export class TemplateResolver {
 
     resolveTemplate(key: string, value: string, stack: Set<string> = new Set<string>()): string {
         stack.add(key);
-        const strict = this.envService.isStrict();
+        const strict = state.strict;
 
         const out = value.replace(this.TEMPLATE_REGEX, (template) => {
             const variable = template.slice(2, -1);

--- a/packages/envapt/src/types/Env.ts
+++ b/packages/envapt/src/types/Env.ts
@@ -7,7 +7,6 @@ type EnvKeyInput = string | readonly [string, ...string[]];
 interface EnvapterService {
     getRaw(key: EnvKeyInput): string | undefined;
     get(key: EnvKeyInput, def?: string): string | undefined;
-    isStrict(): boolean;
 }
 
 export type { EnvKeyInput, EnvapterService };

--- a/packages/envapt/tests/026-config-entry.test.ts
+++ b/packages/envapt/tests/026-config-entry.test.ts
@@ -4,7 +4,7 @@ import process from 'node:process';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { Envapter } from '../src';
-import { EnvaptCache } from '../src/core/EnvapterBase';
+import { cache } from '../src/core/state';
 
 const FIXTURE_KEYS = ['CONFIG_KEY_A', 'CONFIG_KEY_B'] as const;
 const FIXTURE_PATH = resolve(import.meta.dirname, '.env.config-entry');
@@ -16,10 +16,10 @@ function cleanFixtureKeys(): void {
 describe('Envapter.load()', () => {
     it('eagerly populates the cache and is idempotent', () => {
         Envapter.load();
-        const size = EnvaptCache.size;
+        const size = cache.size;
         expect(size).to.be.greaterThan(0);
         Envapter.load();
-        expect(EnvaptCache.size).to.equal(size);
+        expect(cache.size).to.equal(size);
     });
 });
 

--- a/packages/envapt/tests/030-source-portability.test.ts
+++ b/packages/envapt/tests/030-source-portability.test.ts
@@ -3,7 +3,6 @@ import { resolve } from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { Converters, Envapter, EnvaptErrorCodes, FileSource, PortableSource } from '../src';
-import { EnvapterBase } from '../src/core/EnvapterBase';
 import { EnvaptError } from '../src/infra/Error';
 import { UnboundSource } from '../src/sources/UnboundSource';
 
@@ -110,15 +109,12 @@ describe('Source portability (v5.2)', () => {
         });
     });
 
-    describe('NodeEnvapter state anchoring', () => {
-        it('writes envPaths to EnvapterBase, where the engine reads it', () => {
-            // A mis-anchored setter (writing this._envPaths) is behaviorally invisible because its own
-            // refresh warms the shared cache, so this pins that the write happens on EnvapterBase.
-            // pragmatic white-box read of protected state -- justified, asserts where the write landed
-            const base = EnvapterBase as unknown as { _envPaths: string[] };
+    describe('the envPaths setter takes effect for the engine', () => {
+        it('loads variables from the newly set path', () => {
             const fixture = resolve(import.meta.dirname, '.env.extra');
             Envapter.envPaths = fixture;
-            expect(base._envPaths).to.deep.equal([fixture]);
+            expect(Envapter.envPaths).to.deep.equal([fixture]);
+            expect(Envapter.getBoolean('VAR_IN_EXTRA_FILE')).to.equal(true);
         });
     });
 });

--- a/packages/envapt/tests/039-module-private-state.test.ts
+++ b/packages/envapt/tests/039-module-private-state.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import { EnvapterBase } from '../src/core/EnvapterBase';
+import { EnvironmentMethods } from '../src/core/EnvironmentMethods';
+
+describe("engine's mutable state is module-private and should not be exposed as class properties", () => {
+    it('holds no mutable engine-state fields on EnvapterBase', () => {
+        const fields = [
+            '_source',
+            '_strict',
+            '_syncProcessEnv',
+            '_fileApiMode',
+            '_baseDir',
+            '_envPaths',
+            '_envPathsExplicitlySet',
+            '_userDefinedEnvFileOptions',
+            '_dotenvAddedKeys'
+        ];
+        const present = fields.filter((f) => Object.prototype.hasOwnProperty.call(EnvapterBase, f));
+        expect(present).to.deep.equal([]);
+    });
+
+    it('holds no mutable environment-state fields on EnvironmentMethods', () => {
+        const fields = ['_environment', '_environmentExplicitlySet', '_profiles'];
+        const present = fields.filter((f) => Object.prototype.hasOwnProperty.call(EnvironmentMethods, f));
+        expect(present).to.deep.equal([]);
+    });
+});


### PR DESCRIPTION
## What and why

Move the engine's mutable state and read cache out of `protected static` class fields into a module the `exports` map does not include, so outside code cannot read or write them through an `as`-cast or a subclass. Also drops the internal `TimeUnit` type and `isStrict()` method from the public exports.

## Checklist

- [x] New or regression tests cover the change
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved engine state handling so configuration, caching, and strict-mode behavior are more consistent during repeated loads and template resolution.
  * Environment and `.env` path settings now apply more reliably across engine operations.

* **Chores**
  * Reduced public API surface by removing a few internal-only exports and methods, including strict-mode accessors and cache exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->