### PR TITLE
feat: merge combinator and some other fixes

### DIFF
--- a/.changeset/frank-years-warn.md
+++ b/.changeset/frank-years-warn.md
@@ -1,0 +1,5 @@
+---
+'envapt': patch
+---
+
+Fix the read cache rebuilding on every access when a bound source and the `.env` cascade resolve to no keys. It now builds once per `useSource`, matching a non-empty source.

--- a/.changeset/merge-source-combinator.md
+++ b/.changeset/merge-source-combinator.md
@@ -1,0 +1,5 @@
+---
+'envapt': minor
+---
+
+Add `merge`, a source combinator that layers several sources with last-wins precedence. It keeps the `.env` cascade and file APIs on one filesystem-backed member, and throws `InvalidMergedSource` with no members or more than one file-backed member.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,17 +1,12 @@
-# yaml-language-server: $schema=https://json.schemastore.org/pull-request-labeler-5.json
 '📦 envapt':
     - changed-files:
           - any-glob-to-any-file: 'packages/envapt/**'
 '📚 docs':
-    - all:
-          - changed-files:
-                - any-glob-to-any-file:
-                      - 'apps/guide/**'
-                      - '**/*.md'
-                      - '**/*.mdx'
-                - all-globs-to-all-files:
-                      - '!**/CHANGELOG.md'
-                      - '!.changeset/**'
+    - changed-files:
+          - any-glob-to-any-file:
+                - 'apps/guide/**'
+                - '**/*.mdx'
+                - '**/README.md'
 '🧪 tests':
     - changed-files:
           - any-glob-to-any-file: '**/*.test.ts'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,25 +1,34 @@
+# yaml-language-server: $schema=https://json.schemastore.org/pull-request-labeler-5.json
 '📦 envapt':
-    - changed-files:
-          - any-glob-to-any-file: 'packages/envapt/**'
+  - changed-files:
+      - any-glob-to-any-file: 'packages/envapt/**'
 '📚 docs':
-    - changed-files:
-          - any-glob-to-any-file:
-                - 'apps/guide/**'
-                - '**/*.mdx'
-                - '**/README.md'
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'apps/guide/**'
+          - '**/*.mdx'
+          - '**/README.md'
 '🧪 tests':
-    - changed-files:
-          - any-glob-to-any-file: '**/*.test.ts'
-          - any-glob-to-any-file: '**/*.spec.ts'
-          - any-glob-to-any-file: '**/__tests__/**/*'
+  - changed-files:
+      - any-glob-to-any-file: '**/*.test.ts'
+      - any-glob-to-any-file: '**/*.spec.ts'
+      - any-glob-to-any-file: '**/__tests__/**/*'
+'🔧 build':
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'turbo.json'
+          - 'turbo.jsonc'
+          - '**/tsconfig*.json'
+          - '**/tsdown.config.*'
+          - '**/eslint.config.*'
+          - '**/vitest*.config.*'
+          - 'pnpm-workspace.yaml'
+'🔗 deps':
+  - changed-files:
+      - any-glob-to-any-file: 'pnpm-lock.yaml'
 '🤖 ci':
-    - changed-files:
-          - any-glob-to-any-file: '.github/**'
-          - any-glob-to-any-file: turbo.json
-          - any-glob-to-any-file: turbo.jsonc
-          - any-glob-to-any-file: pnpm-workspace.yaml
-          - any-glob-to-any-file: pnpm-lock.yaml
-          - any-glob-to-any-file: 'tsconfig*.json'
-          - any-glob-to-any-file: eslint.config.mjs
-          - any-glob-to-any-file: vitest.config.ts
-          - any-glob-to-any-file: tsdown.config.ts
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/actions/**'
+          - '.github/labeler.yml'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -10,6 +10,12 @@
 - name: '🤖 ci'
   color: 6287bc
   description: ci, workflows, and tooling config
+- name: '🔧 build'
+  color: f9b233
+  description: build and config changes
+- name: '🔗 deps'
+  color: 9e7cb5
+  description: dependency changes
 - name: '🩹 patch'
   color: 59c58f
   description: semver patch bump

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,9 +36,11 @@ jobs:
                   enable_fallback_cache: 'true'
             - name: Setup workspace
               uses: ./.github/actions/setup
-            - name: Build, type-check, lint, format, test, and build guards
+            - name: Build, type-check, lint, format, and build guards
               run: >
-                  pnpm exec turbo run build tc lint fmt:check test build:verify
+                  pnpm exec turbo run build tc lint fmt:check build:verify
                   test:exports-dedup test:resolution-matrix test:cjs-validity test:tsc-emit test:stage3-emit test:tree-shaking
+            - name: Test
+              run: pnpm exec turbo run test
             - name: Run audit
               run: pnpm audit --audit-level=high

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,27 +36,9 @@ jobs:
                   enable_fallback_cache: 'true'
             - name: Setup workspace
               uses: ./.github/actions/setup
-            - name: Build project
-              run: pnpm build
-            - name: Verify portable builds are node-free
-              run: pnpm --filter envapt build:verify
-            - name: Run type check
-              run: pnpm tc
-            - name: Check formatting
-              run: pnpm fmt:check
-            - name: Run lint
-              run: pnpm lint
-            - name: Run tests
-              run: pnpm test
-            - name: Run exports-dedup guard
-              run: pnpm --filter envapt test:exports-dedup
-            - name: Run resolution-matrix guard
-              run: pnpm --filter envapt test:resolution-matrix
-            - name: Run cjs-validity guard
-              run: pnpm --filter envapt test:cjs-validity
-            - name: Run tsc-emit decorator guard
-              run: pnpm --filter envapt test:tsc-emit
-            - name: Run stage3-emit decorator guard
-              run: pnpm --filter envapt test:stage3-emit
+            - name: Build, type-check, lint, format, test, and build guards
+              run: >
+                  pnpm exec turbo run build tc lint fmt:check test build:verify
+                  test:exports-dedup test:resolution-matrix test:cjs-validity test:tsc-emit test:stage3-emit test:tree-shaking
             - name: Run audit
               run: pnpm audit --audit-level=high

--- a/apps/guide/components/Code.tsx
+++ b/apps/guide/components/Code.tsx
@@ -14,7 +14,7 @@ interface CodeProps {
 export async function Code({ code, lang = 'ts', dense = false }: CodeProps): Promise<ReactNode> {
     const html = await codeToHtml(code, {
         lang,
-        themes: { light: 'ayu-light', dark: 'ayu-dark' },
+        themes: { light: 'gruvbox-light-hard', dark: 'ayu-dark' },
         defaultColor: false
     });
 

--- a/apps/guide/content/docs/compatibility.mdx
+++ b/apps/guide/content/docs/compatibility.mdx
@@ -3,7 +3,25 @@ title: Compatibility
 description: Runtime support, engine versions, module formats, the portable and node builds, and how decorators behave across runtimes.
 ---
 
-envapt runs on Node, Bun, and Deno with the same API and zero runtime dependencies. It also runs on Cloudflare Workers (workerd) and in the browser, where you bind the source yourself (a `PortableSource`) and read with the same typed API. The functional reader API works on every runtime with no build step. The default `@Envapt` accessor decorators need no flag either, the legacy `envapt/legacy` decorators have per-runtime requirements covered below.
+envapt runs on Node, Bun, and Deno with the same API and zero runtime dependencies. It also runs on Cloudflare Workers (workerd), other edge runtimes, and the browser, where you bind the source yourself (a `PortableSource`) and read with the same typed API. The functional reader API works on every runtime with no build step. The default `@Envapt` accessor decorators need no flag either, the legacy `envapt/legacy` decorators have per-runtime requirements covered below.
+
+## Binding by runtime
+
+Which `exports` condition resolves, the source that gets bound, where the values come from, and the per-runtime catch.
+
+| Runtime | Condition | Source | Seed from | `process.env` | Gotcha |
+| ------- | --------- | ------ | --------- | ------------- | ------ |
+| Node | `node` | `FileSource` auto | `process.env` and the `.env` cascade | yes | — |
+| Bun | `node` | `FileSource` auto | `process.env` and the `.env` cascade | yes | — |
+| Deno | `deno` | `FileSource` auto | `process.env` and the `.env` cascade | yes | needs Deno 2.5+ |
+| Deno Deploy | `deno` | `FileSource` auto | dashboard vars via `process.env` / `Deno.env` | yes | no `.env` files, set vars in the dashboard |
+| [Cloudflare Workers](/docs/workers) | `workerd` | bind `PortableSource` | the `env` binding | no | bind once at module load |
+| [Vercel Edge](/docs/edge-runtimes) | `edge-light` | bind `PortableSource` | `process.env` | yes | deprecated by Vercel, the Node runtime auto-binds |
+| [Fastly Compute](/docs/edge-runtimes) | `fastly` | bind `PortableSource` | `env()` keys, no bulk object | no | add the `fastly` condition |
+| [Expo / React Native](/docs/edge-runtimes) | `react-native` | bind `PortableSource` | `Constants.expoConfig.extra` | build-inlined | `process.env` is not a runtime object |
+| [Browser](/docs/browser) | `browser` | bind `PortableSource` | bundler-injected config | no | ships in the client bundle |
+
+On the node build a source is bound on import, so the first read works right away. On the portable build you bind a source first, an unbound read throws [`NoSourceBound`](/docs/errors). The file-only APIs warn once and no-op on the portable build, governed by `fileApiMode`, covered below.
 
 ## Engine versions
 
@@ -40,7 +58,7 @@ Bind a source before your first read on the portable build; see [Sources](/docs/
 
 Import from `envapt` on every runtime, no subpath import is needed. On the portable build, the file-only config APIs (`envPaths`, `baseDir`, `envFileOptions`, `configureProfiles`, `resetProfiles`) warn once and no-op by default. Set `Envapter.fileApiMode = 'throw'` to make them throw [`FileApiUnsupported`](/docs/errors) instead. `fileApiMode` governs only the portable file-API behavior. On the node build a bare (non-filesystem) source still throws `FileApiUnsupported` when a file API is called. An unbound read throws `NoSourceBound` on all runtimes regardless of `fileApiMode`.
 
-Deno and Deno Deploy resolve the node build by design, so the file APIs work there.
+Deno and Deno Deploy resolve the node build by design. On Deno the `.env` cascade and file APIs work as on Node. Deno Deploy has no `.env` files on disk, so set variables in its dashboard and read them through `process.env` / `Deno.env`.
 
 ## Decorators per runtime
 

--- a/apps/guide/content/docs/compatibility.mdx
+++ b/apps/guide/content/docs/compatibility.mdx
@@ -7,21 +7,30 @@ envapt runs on Node, Bun, and Deno with the same API and zero runtime dependenci
 
 ## Binding by runtime
 
-Which `exports` condition resolves, the source that gets bound, where the values come from, and the per-runtime catch.
+envapt splits into two builds, selected by the package `exports` conditions. On the node build a source binds on import. On the portable build you bind one yourself.
 
-| Runtime | Condition | Source | Seed from | `process.env` | Gotcha |
-| ------- | --------- | ------ | --------- | ------------- | ------ |
-| Node | `node` | `FileSource` auto | `process.env` and the `.env` cascade | yes | — |
-| Bun | `node` | `FileSource` auto | `process.env` and the `.env` cascade | yes | — |
-| Deno | `deno` | `FileSource` auto | `process.env` and the `.env` cascade | yes | needs Deno 2.5+ |
-| Deno Deploy | `deno` | `FileSource` auto | dashboard vars via `process.env` / `Deno.env` | yes | no `.env` files, set vars in the dashboard |
-| [Cloudflare Workers](/docs/workers) | `workerd` | bind `PortableSource` | the `env` binding | no | bind once at module load |
-| [Vercel Edge](/docs/edge-runtimes) | `edge-light` | bind `PortableSource` | `process.env` | yes | deprecated by Vercel, the Node runtime auto-binds |
-| [Fastly Compute](/docs/edge-runtimes) | `fastly` | bind `PortableSource` | `env()` keys, no bulk object | no | add the `fastly` condition |
-| [Expo / React Native](/docs/edge-runtimes) | `react-native` | bind `PortableSource` | `Constants.expoConfig.extra` | build-inlined | `process.env` is not a runtime object |
-| [Browser](/docs/browser) | `browser` | bind `PortableSource` | bundler-injected config | no | ships in the client bundle |
+### Node build, binds automatically
 
-On the node build a source is bound on import, so the first read works right away. On the portable build you bind a source first, an unbound read throws [`NoSourceBound`](/docs/errors). The file-only APIs warn once and no-op on the portable build, governed by `fileApiMode`, covered below.
+`FileSource` binds on import and reads `process.env` plus the `.env` cascade, so the first read works with no setup.
+
+| Runtime | Condition | Reads | Gotcha |
+| ----------- | --------- | ---------------------------------------------- | ------------------------------------------- |
+| Node | `node` | `process.env` and the `.env` cascade | — |
+| Bun | `node` | `process.env` and the `.env` cascade | — |
+| Deno | `deno` | `process.env` and the `.env` cascade | needs Deno 2.5+ |
+| Deno Deploy | `deno` | dashboard vars via `process.env` / `Deno.env` | no `.env` files, set vars in the dashboard |
+
+### Portable build, you bind a source
+
+Bind a `PortableSource` from the object the platform gives you before your first read. An unbound read throws [`NoSourceBound`](/docs/errors), and the file-only APIs warn once and no-op (see `fileApiMode` below).
+
+| Runtime | Condition | Seed from | `process.env` | Gotcha |
+| ----------------------------------------------- | -------------- | ---------------------------- | ------------- | -------------------------------------------------- |
+| [Cloudflare Workers](/docs/workers) | `workerd` | the `env` binding | no | bind once at module load |
+| [Vercel Edge](/docs/edge-runtimes) | `edge-light` | `process.env` | yes | deprecated by Vercel, the Node runtime auto-binds |
+| [Fastly Compute](/docs/edge-runtimes) | `fastly` | `env()` keys, no bulk object | no | add the `fastly` condition |
+| [Expo / React Native](/docs/edge-runtimes) | `react-native` | `Constants.expoConfig.extra` | build-inlined | `process.env` is not a runtime object |
+| [Browser](/docs/browser) | `browser` | bundler-injected config | no | ships in the client bundle |
 
 ## Engine versions
 

--- a/apps/guide/content/docs/edge-runtimes.mdx
+++ b/apps/guide/content/docs/edge-runtimes.mdx
@@ -1,0 +1,84 @@
+---
+title: Edge runtimes
+description: Bind a PortableSource on Vercel Edge, Fastly Compute, and Expo, then read typed config with the same API as everywhere else.
+---
+
+These runtimes have no filesystem and no `.env` cascade. Import from `envapt` (the portable build resolves automatically through the `edge-light`, `fastly`, and `react-native` conditions), hand envapt the config object the platform gives you once, and read with the same typed API as everywhere else. On Node-like runtimes, including Vercel's Node.js functions, `FileSource` binds on import, so even that step is automatic.
+
+<Callout type="info">
+    The filesystem-only config APIs have nothing to do on these runtimes, so they warn and no-op by default. Readers
+    work as normal. See [Compatibility](/docs/compatibility) for `fileApiMode` and [Errors](/docs/errors) for the codes.
+</Callout>
+
+## Vercel
+
+Vercel's Node.js runtime (the default, and the one Vercel now recommends) runs the node build, so `FileSource` binds on import and reads `process.env` for you. Nothing to bind.
+
+```ts twoslash
+import { Envapter, Converters } from 'envapt';
+
+const origin = Envapter.getRequired('ORIGIN_URL', Converters.Url);
+```
+
+The Edge runtime is the exception. Vercel is [moving away from it](https://vercel.com/docs/functions/runtimes/edge), but if you use it, it resolves the portable build (`edge-light`) and exposes your variables on `process.env` as a real object. Bind it once.
+
+```ts twoslash
+import { Envapter, PortableSource, Converters } from 'envapt';
+
+Envapter.useSource(new PortableSource(process.env));
+const origin = Envapter.getRequired('ORIGIN_URL', Converters.Url);
+```
+
+## Fastly Compute
+
+Fastly is the one runtime that hands you no environment object. You read values one key at a time with `env` from `fastly:env`, and `ConfigStore` is the same shape (a keyed `.get()`, no listing). So name the keys you read and build the object from them. Add the `fastly` condition to your bundler's resolve conditions so bare `envapt` resolves the portable build.
+
+```ts
+import { env } from 'fastly:env';
+import { Envapter, PortableSource, Converters } from 'envapt';
+
+Envapter.useSource(
+    new PortableSource({
+        ORIGIN_URL: env('ORIGIN_URL'),
+        API_TOKEN: env('API_TOKEN')
+    })
+);
+const origin = Envapter.getRequired('ORIGIN_URL', Converters.Url);
+```
+
+Custom variables are inlined into the Wasm binary at build time through the `--env` flag, so changing one needs a redeploy. For values that change without a redeploy, read a `ConfigStore` by key the same way. See Fastly's [environment variables](https://www.fastly.com/documentation/reference/compute/ecp-env/) docs.
+
+## Expo and React Native
+
+Put your config under `extra` in `app.config.js`. It is a real object at runtime through `expo-constants`, so you bind it whole and envapt does the rest.
+
+```ts
+import Constants from 'expo-constants';
+import { Envapter, PortableSource } from 'envapt';
+
+Envapter.useSource(new PortableSource(Constants.expoConfig?.extra ?? {}));
+```
+
+You cannot pass `process.env` here. On Metro it is not a runtime object, the bundler replaces each static `process.env.EXPO_PUBLIC_*` reference with its literal string at build time, so spreading it gives you nothing. If your config already lives in `EXPO_PUBLIC_*` variables, reference each by name.
+
+```ts
+import { Envapter, PortableSource, Converters } from 'envapt';
+
+Envapter.useSource(
+    new PortableSource({
+        API_URL: process.env.EXPO_PUBLIC_API_URL,
+        FEATURE_BETA: process.env.EXPO_PUBLIC_FEATURE_BETA
+    })
+);
+const api = Envapter.getRequired('API_URL', Converters.Url);
+```
+
+<Callout type="warn">
+    Both Expo surfaces ship in your app bundle. Pass public configuration only, never a secret or a server-side key.
+</Callout>
+
+See Expo's [environment variables](https://docs.expo.dev/guides/environment-variables/) docs for the prefix rules and inlining.
+
+## No filesystem
+
+There is no `.env` cascade on these runtimes. Bind a source before your first read, else an unbound read throws [`NoSourceBound`](/docs/errors). `PortableSource` snapshots its object at construction, so mutating that object afterward does not change what envapt reads. The default `@Envapt` accessor decorators work on all three, the legacy `envapt/legacy` form needs a compile step. For the providers and the contract see [Sources](/docs/sources).

--- a/apps/guide/content/docs/errors.mdx
+++ b/apps/guide/content/docs/errors.mdx
@@ -57,7 +57,7 @@ try {
 | 208  | `SchemaValidationFailed`       | A Standard Schema returns issues for a non-empty value. The only code that populates `issues`. |
 | 209  | `SchemaThrew`                  | A schema's `validate` itself throws. The original error is on `cause`.                         |
 
-### Configuration and lookup (301-307)
+### Configuration and lookup (301-308)
 
 | Code | Name                       | Thrown when                                                                                                                                                                                                      |
 | ---- | -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -68,6 +68,7 @@ try {
 | 305  | `MissingEnvValue`          | A required value is missing or empty: `require`, `{ required: true }`, a schema with no fallback, or an unresolved template under strict mode.                                                                   |
 | 306  | `FileApiUnsupported`       | On the portable build: a file-only API (`envPaths`, `baseDir`, `envFileOptions`, `configureProfiles`, `resetProfiles`) is called and `Envapter.fileApiMode = 'throw'` (the default warns once and no-ops). On the node build: a non-filesystem source is bound and a file API is called. See [Sources](/docs/sources). |
 | 307  | `NoSourceBound`            | A value is read before a source is bound with `Envapter.useSource`. Cannot occur on Node, where the source is bound on import.                                                                                   |
+| 308  | `InvalidMergedSource`      | `merge` is called with no members, or with more than one filesystem-backed source.                                                                                                                              |
 
 <Callout type="info">
     `issues` is set only for `SchemaValidationFailed` (208), so you can read `error.issues` after checking `error.code

--- a/apps/guide/content/docs/meta.json
+++ b/apps/guide/content/docs/meta.json
@@ -19,6 +19,7 @@
         "compatibility",
         "sources",
         "workers",
+        "edge-runtimes",
         "browser",
         "---Reference---",
         "migrations"

--- a/apps/guide/content/docs/meta.json
+++ b/apps/guide/content/docs/meta.json
@@ -13,16 +13,14 @@
         "errors",
         "---Configuration---",
         "configuration",
-        "sources",
         "secret-stores",
+        "env-file-syntax",
+        "---Runtimes---",
+        "compatibility",
+        "sources",
         "workers",
         "browser",
-        "env-file-syntax",
         "---Reference---",
-        "compatibility",
-        "migration-v4-to-v5",
-        "migration-v5-to-v6",
-        "migration-v6-to-v7",
-        "migration-v7-to-v8"
+        "migrations"
     ]
 }

--- a/apps/guide/content/docs/migrations.mdx
+++ b/apps/guide/content/docs/migrations.mdx
@@ -1,0 +1,11 @@
+---
+title: Migrations
+description: The breaking changes, renames, and behavior shifts for every envapt major-version upgrade.
+---
+
+Each guide covers one major-version jump and the changes to expect when you take it.
+
+- **[v7 to v8](/docs/migration-v7-to-v8).** The source classes get shorter names, one universal `envapt` import replaces the `workerd` and `browser` subpaths, and the portable file APIs warn instead of throwing by default.
+- **[v6 to v7](/docs/migration-v6-to-v7).** The default decorators become TC39 Stage 3 accessors, and the legacy decorators move to `envapt/legacy`.
+- **[v5 to v6](/docs/migration-v5-to-v6).** The positional decorator form is removed, and the test-environment behavior changes.
+- **[v4 to v5](/docs/migration-v4-to-v5).** Renames and behavior shifts to watch when moving off v4.

--- a/apps/guide/content/docs/secret-stores.mdx
+++ b/apps/guide/content/docs/secret-stores.mdx
@@ -54,7 +54,7 @@ const poolSize = Envapter.getNumber('DB_POOL_SIZE', 10);
 <Callout type="warn">
     On Node, `useSource` replaces the default Node source, so the `.env` cascade and the file-only config APIs
     (`envPaths`, `baseDir`, `configureProfiles`) stop working after the swap. Bind a store source only if you do not
-    also need those. To keep both, see the bridge pattern below.
+    also need those. To keep both, use `merge` (below).
 </Callout>
 
 ### Inline object or PortableSource
@@ -205,17 +205,17 @@ const smtpPort = Envapter.getNumber('SMTP_PORT', 587);
 
 `list()` returns identifiers only, fetch the values with `getByIds`. The package ships native binaries, so it runs on Node only. It is in beta.
 
-## Bridge through process.env on Node
+## Keep the .env cascade with merge
 
-To keep the default Node source and the `.env` cascade, write the fetched secrets onto `process.env` instead of calling `useSource`. This only works if the `Object.assign` runs before the first envapt read, before `Envapter.load()`, and before importing `envapt/config`. The cache builds once on first access and ignores any later writes to `process.env`.
+To read fetched secrets AND the `.env` cascade, bind both with `merge` instead of replacing the Node source. It layers the secrets over `process.env` and the `.env` files in one bind, with no ordering trap and no write to `process.env`.
 
-```ts
-import { Envapter, Converters } from 'envapt';
-
+```ts twoslash
+import { Envapter, FileSource, PortableSource, merge, Converters } from 'envapt';
+// ---cut---
 declare const secrets: Record<string, string>; // fetched and awaited
-Object.assign(process.env, secrets);
+Envapter.useSource(merge(new FileSource(), new PortableSource(secrets)));
 
 const dbUrl = Envapter.getUsing('DATABASE_URL', Converters.Url);
 ```
 
-If the fetch cannot finish before that first read, write a filesystem-backed `Source` (`supportsFiles: true` plus `readFile`, `resolvePath`, `normalizeBaseDir`, and `writeVars`). It keeps the `.env` cascade running alongside your fetched values. See [Sources](/docs/sources).
+The secrets win over `.env` and `process.env`, and `.env` backfills any key the secrets omit. See [Sources](/docs/sources).

--- a/apps/guide/content/docs/sources.mdx
+++ b/apps/guide/content/docs/sources.mdx
@@ -52,6 +52,21 @@ An optional `supportsFiles` flag marks a source as backing the file-only config 
 
 For fetching that secrets object from 1Password, Vault, Doppler, AWS Secrets Manager, and others, see [Using secret stores](/docs/secret-stores).
 
+## Combining sources
+
+`merge` composes several sources into one, read last-wins. A later member overrides an earlier member's key. Keep the `.env` cascade and layer fetched secrets on top in a single bind, with no write to `process.env`.
+
+```ts twoslash
+import { Envapter, FileSource, PortableSource, merge, Converters } from 'envapt';
+// ---cut---
+declare const secrets: Record<string, string>; // fetched and awaited
+Envapter.useSource(merge(new FileSource(), new PortableSource(secrets)));
+
+const dbUrl = Envapter.getUsing('DATABASE_URL', Converters.Url);
+```
+
+At most one member is filesystem-backed, and the `.env` cascade and file APIs route to it. `merge` throws [`InvalidMergedSource`](/docs/errors) with no members or more than one file-backed member.
+
 ## When nothing is bound
 
 Reading a value before you call `useSource` throws `EnvaptError` with code `NoSourceBound`. It cannot happen on Node, where the source is bound on import.

--- a/apps/guide/lib/og/snippets.ts
+++ b/apps/guide/lib/og/snippets.ts
@@ -119,6 +119,14 @@ HOST=localhost # inline comment, stripped
 COLOR=#ff0000 # kept: no space before the #
 TLS_KEY="line one\\nline two"`
     },
+    migrations: {
+        filename: 'config.ts',
+        lang: 'ts',
+        code: `// Migrations - one major version at a time
+// v6 to v7: decorators become TC39 accessors
+// v7 to v8: one universal 'envapt' import
+import { Envapter, PortableSource } from 'envapt';`
+    },
     'migration-v4-to-v5': {
         filename: 'config.ts',
         lang: 'ts',
@@ -149,6 +157,15 @@ static readonly port: number;
 // v7 - now exported via 'envapt'
 @Envapt('PORT', { fallback: 3000 })
 static accessor port: number;`
+    },
+    'migration-v7-to-v8': {
+        filename: 'config.ts',
+        lang: 'ts',
+        code: `// Migration - one universal import in v8
+// v7
+import { WorkerEnvSource } from 'envapt/workerd';
+// v8
+import { PortableSource } from 'envapt';`
     },
     compatibility: {
         filename: 'tsconfig.json',
@@ -201,5 +218,14 @@ Envapter.useSource(
 const api = Envapter.getUsing(
   'VITE_API_URL', Converters.Url
 );`
+    },
+    'edge-runtimes': {
+        filename: 'edge.ts',
+        lang: 'ts',
+        code: `// Edge runtimes - hand envapt the platform's config
+import { Envapter, PortableSource, Converters } from 'envapt';
+
+Envapter.useSource(new PortableSource(platformEnv));
+const url = Envapter.getRequired('ORIGIN_URL', Converters.Url);`
     }
 };

--- a/apps/guide/source.config.ts
+++ b/apps/guide/source.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
     mdxOptions: {
         remarkPlugins: [[remarkNpm, { persist: { id: 'package-manager' }, packageManagers: PACKAGE_MANAGERS }]],
         rehypeCodeOptions: {
-            themes: { light: 'ayu-light', dark: 'ayu-dark' },
+            themes: { light: 'gruvbox-light-hard', dark: 'ayu-dark' },
             transformers: [
                 ...(rehypeCodeDefaultOptions.transformers ?? []),
                 ...(twoslashEnabled

--- a/packages/envapt/src/common.ts
+++ b/packages/envapt/src/common.ts
@@ -1,6 +1,7 @@
 export { Environment } from './engine/Envapter';
 export { Converters, isArrayOf } from './converters';
 export { PortableSource } from './sources/PortableSource';
+export { merge } from './sources/merge';
 export type { ConverterToken, CustomElementConverter } from './converters';
 export type { DebugLevel } from './infra/Debug';
 export type { EnvFileOptions } from './infra/Dotenv';

--- a/packages/envapt/src/core/EnvapterBase.ts
+++ b/packages/envapt/src/core/EnvapterBase.ts
@@ -115,6 +115,7 @@ export abstract class EnvapterBase {
 
     protected static refreshCache(): void {
         cache.clear();
+        state.cacheBuilt = false;
         state.dotenvAddedKeys = new Set<string>();
         debugVerbose('cache cleared, reloading config');
         void this.config; // getter rebuilds the cache as a side effect
@@ -178,7 +179,7 @@ export abstract class EnvapterBase {
     }
 
     protected static get config(): Map<string, unknown> {
-        if (cache.size === 0) {
+        if (!state.cacheBuilt) {
             const source = state.source;
             // Clone so the loader and downstream reads never mutate the source's backing object.
             const isolatedEnv: Record<string, string> = { ...source.readVars() };
@@ -205,6 +206,8 @@ export abstract class EnvapterBase {
             state.dotenvAddedKeys = added;
             for (const [key, value] of Object.entries(isolatedEnv)) cache.set(key, value);
             debugVerbose(`cache populated: ${cache.size} keys total`);
+            // set before mirroring, whose template expansion reads config and would re-enter this build otherwise
+            state.cacheBuilt = true;
             if (state.syncProcessEnv) this.mirrorToProcessEnv();
         }
 

--- a/packages/envapt/src/core/state.ts
+++ b/packages/envapt/src/core/state.ts
@@ -15,6 +15,8 @@ export const state = {
     fileApiMode: 'warn' as FileApiMode,
     // loader-written keys only (collisions skipped), refilled on every cache rebuild.
     dotenvAddedKeys: new Set<string>(),
+    // cache.size can't tell built-and-empty from not-built, so a source resolving to no keys would rebuild on every read without this.
+    cacheBuilt: false,
     // unbound by default so non-Node builds throw NoSourceBound on read until useSource() runs.
     source: new UnboundSource() as Source,
     environment: undefined as Environment | undefined,

--- a/packages/envapt/src/infra/Error.ts
+++ b/packages/envapt/src/infra/Error.ts
@@ -53,7 +53,9 @@ export enum EnvaptErrorCodes {
     /** Thrown when a file-based API (envPaths, baseDir, configureProfiles) is used on a source without filesystem support */
     FileApiUnsupported = 306,
     /** Thrown when an environment value is read before a source is bound via Envapter.useSource */
-    NoSourceBound = 307
+    NoSourceBound = 307,
+    /** Thrown when `merge` is called with no members, or with more than one filesystem-backed source */
+    InvalidMergedSource = 308
 }
 
 interface EnvaptErrorOptions {

--- a/packages/envapt/src/sources/coerce.ts
+++ b/packages/envapt/src/sources/coerce.ts
@@ -1,5 +1,5 @@
-// Shared by PortableSource and its deprecated aliases. The returned record is fresh, so a caller
-// mutating its object later cannot leak into the source, and non-string values are JSON-stringified.
+// The returned record is fresh, so a caller mutating its object
+// later cannot leak into the source, and non-string values are JSON-stringified.
 export function coerceToStringRecord(env: object): Record<string, string> {
     const snapshot: Record<string, string> = {};
     // `object` so a Cloudflare `Env` (an interface with no index signature) is accepted. cast to a record
@@ -10,7 +10,7 @@ export function coerceToStringRecord(env: object): Record<string, string> {
             continue;
         }
         const encoded = JSON.stringify(value);
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- TS lib mistypes JSON.stringify's return as always-string; it is string | undefined at runtime
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- TS lib mistypes JSON.stringify's return as always-string when it is string | undefined at runtime
         if (encoded !== undefined) snapshot[key] = encoded;
     }
     return snapshot;

--- a/packages/envapt/src/sources/merge.ts
+++ b/packages/envapt/src/sources/merge.ts
@@ -1,0 +1,42 @@
+import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
+
+import type { FileCapableSource, Source } from '../types';
+
+/**
+ * Compose several sources into one, read last-wins. A later member's value overrides an earlier
+ * member's value for the same key. Bind the result with `Envapter.useSource`. Throws
+ * {@link EnvaptErrorCodes.InvalidMergedSource} with no members or with more than one file-backed member.
+ * @public
+ */
+export function merge(...members: Source[]): Source {
+    if (members.length === 0) {
+        throw new EnvaptError(EnvaptErrorCodes.InvalidMergedSource, 'merge requires at least one source.');
+    }
+
+    const fileMembers = members.filter((m): m is FileCapableSource => m.supportsFiles === true);
+    if (fileMembers.length > 1) {
+        throw new EnvaptError(
+            EnvaptErrorCodes.InvalidMergedSource,
+            'merge accepts at most one filesystem-backed source, so the .env cascade and file APIs route to a single member.'
+        );
+    }
+
+    const readVars = (): Record<string, string> => {
+        const merged: Record<string, string> = {};
+        for (const m of members) Object.assign(merged, m.readVars());
+        return merged;
+    };
+
+    const fileMember = fileMembers[0];
+    if (!fileMember) return { readVars };
+
+    const fileCapable: FileCapableSource = {
+        readVars,
+        supportsFiles: true,
+        readFile: (path, encoding) => fileMember.readFile(path, encoding),
+        resolvePath: (baseDir, candidate) => fileMember.resolvePath(baseDir, candidate),
+        normalizeBaseDir: (value) => fileMember.normalizeBaseDir(value),
+        writeVars: (vars) => fileMember.writeVars(vars)
+    };
+    return fileCapable;
+}

--- a/packages/envapt/tests/.env.041-merge
+++ b/packages/envapt/tests/.env.041-merge
@@ -1,0 +1,2 @@
+FROM_FILE=file
+SHARED=file

--- a/packages/envapt/tests/021-type-error-messages.test.ts
+++ b/packages/envapt/tests/021-type-error-messages.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -11,7 +11,7 @@ import { describe, expect, it } from 'vitest';
  * SchemaMustBeSync brand relies on a specific literal appearing in the diagnostic, so we run
  * `tsc` directly against fixtures and assert message fragments.
  *
- * Fixtures live in `tests/type-error-fixtures/` and are excluded from both the package's
+ * Fixtures are in `tests/type-error-fixtures/` and are excluded from both the package's
  * tsconfig and eslint. A dedicated tsconfig inside that directory exists so the IDE shows
  * the same diagnostic this test sees (a default tsconfig would emit TS1206 for the
  * decorators and mask the actual error).
@@ -28,34 +28,46 @@ interface ParsedDiagnostic {
     message: string;
 }
 
+// A ts.createProgram per fixture reloads the default libs and re-checks envapt's whole src each time.
+// The fixtures in a dir are isolated modules on one tsconfig, so compile them together once.
+const diagnosticsByDir = new Map<string, Map<string, ParsedDiagnostic[]>>();
+
+function diagnosticsForDir(fixtureDir: string, configFileName: string): Map<string, ParsedDiagnostic[]> {
+    const cached = diagnosticsByDir.get(fixtureDir);
+    if (cached) return cached;
+
+    const configFile = ts.readConfigFile(configFileName, (path) => readFileSync(path, 'utf8'));
+    const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, dirname(configFileName));
+    const rootNames = readdirSync(fixtureDir)
+        .filter((name) => name.endsWith('.ts'))
+        .map((name) => resolve(fixtureDir, name));
+
+    const program = ts.createProgram({ rootNames, options: { ...parsed.options, noEmit: true } });
+
+    const byFile = new Map<string, ParsedDiagnostic[]>();
+    for (const d of ts.getPreEmitDiagnostics(program)) {
+        if (!d.file) continue;
+        const pos = d.start === undefined ? { line: -1, character: -1 } : d.file.getLineAndCharacterOfPosition(d.start);
+        const entry: ParsedDiagnostic = {
+            code: d.code,
+            line: pos.line + 1,
+            message: ts.flattenDiagnosticMessageText(d.messageText, '\n')
+        };
+        const list = byFile.get(d.file.fileName);
+        if (list) list.push(entry);
+        else byFile.set(d.file.fileName, [entry]);
+    }
+
+    diagnosticsByDir.set(fixtureDir, byFile);
+    return byFile;
+}
+
 function compileFixture(
     fixtureRelativePath: string,
     configFileName: string = resolve(PROJECT_ROOT, 'tsconfig.json')
 ): ParsedDiagnostic[] {
     const fixturePath = resolve(FIXTURE_DIR, fixtureRelativePath);
-
-    const configFile = ts.readConfigFile(configFileName, (path) => readFileSync(path, 'utf8'));
-    const parsed = ts.parseJsonConfigFileContent(configFile.config, ts.sys, dirname(configFileName));
-
-    const program = ts.createProgram({
-        rootNames: [fixturePath],
-        options: { ...parsed.options, noEmit: true }
-    });
-
-    return ts
-        .getPreEmitDiagnostics(program)
-        .filter((d) => d.file?.fileName === fixturePath)
-        .map((d) => {
-            const pos =
-                d.file && d.start !== undefined
-                    ? d.file.getLineAndCharacterOfPosition(d.start)
-                    : { line: -1, character: -1 };
-            return {
-                code: d.code,
-                line: pos.line + 1,
-                message: ts.flattenDiagnosticMessageText(d.messageText, '\n')
-            };
-        });
+    return diagnosticsForDir(dirname(fixturePath), configFileName).get(fixturePath) ?? [];
 }
 
 function joinedMessages(diagnostics: readonly ParsedDiagnostic[]): string {

--- a/packages/envapt/tests/040-cache-build-once.test.ts
+++ b/packages/envapt/tests/040-cache-build-once.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Envapter, FileSource } from '../src';
+
+import type { Source } from '../src';
+
+describe('the read cache builds once per bound source', () => {
+    afterEach(() => {
+        Envapter.useSource(new FileSource());
+    });
+
+    it('does not re-read a source that resolves to no keys on every access', () => {
+        let reads = 0;
+        const source: Source = {
+            readVars() {
+                reads++;
+                return {};
+            }
+        };
+        Envapter.useSource(source);
+        // useSource builds the cache once; count only the reads after that point.
+        reads = 0;
+
+        Envapter.get('A');
+        Envapter.get('B');
+        Envapter.get('C');
+
+        expect(reads).to.equal(0);
+    });
+});

--- a/packages/envapt/tests/041-source-merge.test.ts
+++ b/packages/envapt/tests/041-source-merge.test.ts
@@ -1,0 +1,171 @@
+import { resolve } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Envapter, EnvaptError, EnvaptErrorCodes, FileSource, merge, PortableSource } from '../src';
+
+import type { FileCapableSource } from '../src/types';
+
+describe('merge composes sources with last-wins precedence', () => {
+    afterEach(() => {
+        Envapter.useSource(new FileSource());
+        Envapter.baseDir = undefined;
+        Envapter.resetProfiles();
+        Envapter.envFileOptions = {};
+        Envapter.syncProcessEnv = false;
+        delete process.env.FROM_FILE;
+        delete process.env.SHARED;
+        delete process.env.SECRET;
+    });
+
+    it('layers members last-wins, a later member overrides an earlier key', () => {
+        Envapter.useSource(
+            merge(new PortableSource({ A: '1', SHARED: 'first' }), new PortableSource({ SHARED: 'second', B: '2' }))
+        );
+
+        expect(Envapter.get('A')).to.equal('1');
+        expect(Envapter.get('B')).to.equal('2');
+        expect(Envapter.get('SHARED')).to.equal('second');
+    });
+
+    it('keeps the .env cascade through a single file member, later members win over it', () => {
+        Envapter.useSource(merge(new FileSource(), new PortableSource({ SHARED: 'secret', FROM_SECRET: 'secret' })));
+        Envapter.envPaths = resolve(import.meta.dirname, '.env.041-merge');
+
+        expect(Envapter.get('FROM_FILE')).to.equal('file');
+        expect(Envapter.get('SHARED')).to.equal('secret');
+        expect(Envapter.get('FROM_SECRET')).to.equal('secret');
+    });
+
+    it('throws InvalidMergedSource when given no members', () => {
+        expect(() => merge())
+            .to.throw(EnvaptError)
+            .with.property('code', EnvaptErrorCodes.InvalidMergedSource);
+    });
+
+    it('throws InvalidMergedSource when given more than one file-capable member', () => {
+        expect(() => merge(new FileSource(), new FileSource()))
+            .to.throw(EnvaptError)
+            .with.property('code', EnvaptErrorCodes.InvalidMergedSource);
+    });
+
+    it('resolves a relative .env path against baseDir through the file member', () => {
+        Envapter.useSource(merge(new FileSource(), new PortableSource({ X: '1' })));
+        Envapter.baseDir = import.meta.dirname;
+        Envapter.envPaths = ['.env.041-merge'];
+
+        expect(Envapter.get('FROM_FILE')).to.equal('file');
+    });
+
+    it('mirrors the .env delta to process.env through the file member when syncProcessEnv is on', () => {
+        Envapter.syncProcessEnv = true;
+        Envapter.useSource(merge(new FileSource(), new PortableSource({ X: '1' })));
+        Envapter.envPaths = resolve(import.meta.dirname, '.env.041-merge');
+        Envapter.load();
+
+        expect(process.env.FROM_FILE).to.equal('file');
+    });
+
+    it('lifts the .env cascade above every member when envFileOptions.override is true', () => {
+        Envapter.envFileOptions = { override: true };
+        Envapter.useSource(merge(new FileSource(), new PortableSource({ SHARED: 'secret' })));
+        Envapter.envPaths = resolve(import.meta.dirname, '.env.041-merge');
+
+        expect(Envapter.get('SHARED')).to.equal('file');
+    });
+
+    it('a file-less merge never writes to process.env even with syncProcessEnv on', () => {
+        Envapter.syncProcessEnv = true;
+        Envapter.useSource(merge(new PortableSource({ ONLY_A: 'a' }), new PortableSource({ ONLY_B: 'b' })));
+        Envapter.load();
+
+        expect(process.env.ONLY_A).to.equal(undefined);
+        expect(process.env.ONLY_B).to.equal(undefined);
+    });
+
+    it('mirrors only the .env delta, never an overlay member, when syncProcessEnv is on', () => {
+        Envapter.syncProcessEnv = true;
+        Envapter.useSource(merge(new FileSource(), new PortableSource({ SECRET: 'shh' })));
+        Envapter.envPaths = resolve(import.meta.dirname, '.env.041-merge');
+        Envapter.load();
+
+        expect(process.env.FROM_FILE).to.equal('file');
+        expect(process.env.SECRET).to.equal(undefined);
+    });
+
+    it('counts a nested single-file merge as a file member, so a second file member throws', () => {
+        expect(() => merge(merge(new FileSource()), new FileSource()))
+            .to.throw(EnvaptError)
+            .with.property('code', EnvaptErrorCodes.InvalidMergedSource);
+    });
+
+    it('counts the same file-source instance passed twice as two file members', () => {
+        const fs = new FileSource();
+        expect(() => merge(fs, fs))
+            .to.throw(EnvaptError)
+            .with.property('code', EnvaptErrorCodes.InvalidMergedSource);
+    });
+
+    it('returns a fresh record per readVars call, so mutating one read does not leak into the next', () => {
+        const source = merge(new PortableSource({ K: 'v' }));
+        source.readVars().K = 'mutated';
+
+        expect(source.readVars().K).to.equal('v');
+    });
+
+    it('coerces each member through its own source, so non-string values become strings', () => {
+        Envapter.useSource(merge(new PortableSource({ N: 1 }), new PortableSource({ B: true })));
+
+        expect(Envapter.get('N')).to.equal('1');
+        expect(Envapter.get('B')).to.equal('true');
+    });
+
+    it('keeps a null member value as "null" and drops an undefined so it never clears the key', () => {
+        Envapter.useSource(merge(new PortableSource({ K: null }), new PortableSource({ K: undefined })));
+
+        expect(Envapter.get('K')).to.equal('null');
+    });
+
+    it('a later empty-string value wins in the merge', () => {
+        Envapter.useSource(merge(new PortableSource({ K: 'value' }), new PortableSource({ K: '' })));
+
+        expect(new Envapter().getRaw('K')).to.equal('');
+    });
+
+    it('a single member binds equivalently to that source directly', () => {
+        Envapter.useSource(merge(new PortableSource({ K: 'v' })));
+
+        expect(Envapter.get('K')).to.equal('v');
+        expect(Envapter.get('MISSING')).to.equal(undefined);
+    });
+
+    it('a merge that throws leaves the previously bound source intact', () => {
+        Envapter.useSource(new PortableSource({ KEEP: 'yes' }));
+        expect(() => merge(new FileSource(), new FileSource())).to.throw(EnvaptError);
+
+        expect(Envapter.get('KEEP')).to.equal('yes');
+    });
+
+    it('delegates the file APIs to a custom FileCapableSource member', () => {
+        const customFile: FileCapableSource = {
+            supportsFiles: true,
+            readVars: () => ({ FROM_CUSTOM_VARS: 'vars' }),
+            readFile: () => 'FROM_CUSTOM_FILE=filecontent\n',
+            resolvePath: (_baseDir, candidate) => candidate,
+            normalizeBaseDir: (value) => String(value),
+            writeVars: () => {}
+        };
+        Envapter.useSource(merge(customFile, new PortableSource({ X: '1' })));
+        Envapter.envPaths = ['anything.env'];
+
+        expect(Envapter.get('FROM_CUSTOM_VARS')).to.equal('vars');
+        expect(Envapter.get('FROM_CUSTOM_FILE')).to.equal('filecontent');
+    });
+
+    it('loads the .env cascade through a nested single-file merge', () => {
+        Envapter.useSource(merge(merge(new FileSource()), new PortableSource({ X: '1' })));
+        Envapter.envPaths = resolve(import.meta.dirname, '.env.041-merge');
+
+        expect(Envapter.get('FROM_FILE')).to.equal('file');
+    });
+});

--- a/scripts/test-all.mjs
+++ b/scripts/test-all.mjs
@@ -11,7 +11,7 @@ const captureBytes = 64 * 1024 * 1024;
 
 // build first because every slice below reads the built dist
 process.stdout.write('── build ──\n');
-execFileSync('pnpm', ['--filter', 'envapt', 'build'], { stdio: 'inherit' });
+execFileSync('pnpm', ['exec', 'turbo', 'run', 'build', '--filter=envapt'], { stdio: 'inherit' });
 
 const playwrightCache = [
     process.env.PLAYWRIGHT_BROWSERS_PATH,

--- a/turbo.json
+++ b/turbo.json
@@ -21,7 +21,7 @@
             "cache": false
         },
         "tc": {
-            "dependsOn": ["^build"],
+            "dependsOn": ["^build", "build"],
             "inputs": ["$TURBO_DEFAULT$", "tsconfig*.json"]
         },
         "test": {

--- a/turbo.json
+++ b/turbo.json
@@ -27,6 +27,34 @@
         "test": {
             "inputs": ["$TURBO_DEFAULT$", "jest.config.*", "vitest.config.*", "src/**", "tests/**"]
         },
+        "build:verify": {
+            "dependsOn": ["build"],
+            "outputs": []
+        },
+        "test:exports-dedup": {
+            "dependsOn": ["build"],
+            "outputs": []
+        },
+        "test:resolution-matrix": {
+            "dependsOn": ["build"],
+            "outputs": []
+        },
+        "test:cjs-validity": {
+            "dependsOn": ["build"],
+            "outputs": []
+        },
+        "test:tsc-emit": {
+            "dependsOn": ["build"],
+            "outputs": []
+        },
+        "test:stage3-emit": {
+            "dependsOn": ["build"],
+            "outputs": []
+        },
+        "test:tree-shaking": {
+            "dependsOn": ["build"],
+            "outputs": []
+        },
         "test:watch": {
             "cache": false,
             "persistent": true


### PR DESCRIPTION
## What and why

- Add `merge(...sources)`, a source combinator. It layers sources last-wins with a single filesystem-backed member, so the `.env` cascade and fetched secrets bind together. Throws `InvalidMergedSource` (308) with no members or more than one file-backed member.
- Fix the read cache rebuilding on every access when a source and the `.env` cascade resolve to no keys.
- Runtime and compatibility docs: a new Edge runtimes page (Vercel, Fastly, Expo), the binding-by-runtime table split into two (node auto-binds, portable you bind), one migrations index, and the secret-stores bridge now binds with `merge`, dropping the fragile `Object.assign`.
- Make turbo's `tc` depend on the package `build` so the integration suite's `dist` imports type-check.

## Checklist

- [x] New or regression tests cover the change
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for combining multiple configuration sources with last-wins precedence.
  * Introduced a new edge-runtime guide and a migrations landing page.

* **Bug Fixes**
  * Fixed repeated cache rebuilding when a source resolves to no values.
  * Added clearer error handling for invalid source combinations.

* **Documentation**
  * Expanded runtime, edge, secrets, and compatibility guidance.
  * Updated navigation and examples across the docs.

* **Chores**
  * Updated code highlighting theme and streamlined CI/test workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->