### PR TITLE
refactor(core): move the read core into module functions under core/

### DIFF
--- a/.changeset/nice-garlics-joke.md
+++ b/.changeset/nice-garlics-joke.md
@@ -1,0 +1,5 @@
+---
+'envapt': patch
+---
+
+Move the engine read-path into module functions under core/ so a consumer subclass can no longer reach or mutate the read cache. No public API change.

--- a/packages/envapt/src/core/AdvancedMethods.ts
+++ b/packages/envapt/src/core/AdvancedMethods.ts
@@ -1,3 +1,4 @@
+import { resolveKeyInput, templateResolver, treatAsMissing, valueConverter } from './engine';
 import { PrimitiveMethods } from './PrimitiveMethods';
 import { debugWarn } from '../infra/Debug';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
@@ -67,18 +68,18 @@ export class AdvancedMethods extends PrimitiveMethods {
         converter: TConverter,
         fallback?: TFallback
     ): AdvancedConverterReturn<TConverter, TFallback> {
-        const { key: resolvedKey, value } = this.resolveKeyInput(key);
+        const { key: resolvedKey, value } = resolveKeyInput(key);
 
         // missing with no fallback returns undefined, matching the primitive methods. with a fallback,
         // route through the parser so asymmetric types (TimeFallback, TimeFallback[] for `of: time`)
         // coerce to the return type.
-        if (this.treatAsMissing(value) && fallback === undefined) {
+        if (treatAsMissing(value) && fallback === undefined) {
             debugWarn(`${resolvedKey} is missing or empty`);
             return undefined as AdvancedConverterReturn<TConverter, TFallback>;
         }
 
         const hasFallback = fallback !== undefined;
-        const result = this.valueConverter.convertValue(resolvedKey, fallback, converter, hasFallback);
+        const result = valueConverter.convertValue(resolvedKey, fallback, converter, hasFallback);
 
         return result as AdvancedConverterReturn<TConverter, TFallback>;
     }
@@ -114,14 +115,14 @@ export class AdvancedMethods extends PrimitiveMethods {
         converter: ConverterFunction<TReturnType>,
         fallback?: TFallback
     ): ConditionalReturn<TReturnType, TFallback> {
-        const { key: resolvedKey, value } = this.resolveKeyInput(key);
-        if (this.treatAsMissing(value)) {
+        const { key: resolvedKey, value } = resolveKeyInput(key);
+        if (treatAsMissing(value)) {
             debugWarn(`${resolvedKey} is missing or empty`);
             return fallback as ConditionalReturn<TReturnType, TFallback>;
         }
 
         const hasFallback = fallback !== undefined;
-        const result = this.valueConverter.convertValue<TReturnType>(resolvedKey, fallback, converter, hasFallback);
+        const result = valueConverter.convertValue<TReturnType>(resolvedKey, fallback, converter, hasFallback);
 
         return result as ConditionalReturn<TReturnType, TFallback>;
     }
@@ -156,7 +157,7 @@ export class AdvancedMethods extends PrimitiveMethods {
         let resolvedKey = '';
         let value: string | undefined;
         for (const candidate of candidates) {
-            const resolved = resolveRequired(this.resolveKeyInput(candidate), this.templateResolver);
+            const resolved = resolveRequired(resolveKeyInput(candidate), templateResolver);
             resolvedKey = resolved.key;
             if (resolved.value !== undefined) {
                 value = resolved.value;
@@ -170,7 +171,7 @@ export class AdvancedMethods extends PrimitiveMethods {
             );
         }
         // cast widens the raw-string parser back to convertValue's ConverterFunction<T> (value proven present above).
-        const result = this.valueConverter.convertValue<TReturnType>(
+        const result = valueConverter.convertValue<TReturnType>(
             resolvedKey,
             undefined,
             converter as EnvaptConverter<TReturnType>,
@@ -215,7 +216,7 @@ export class AdvancedMethods extends PrimitiveMethods {
     ): { [K in keyof Spec as RecaseKey<K & string, Casing>]: InferSpecField<Spec[K]> } {
         const keys = Object.keys(spec);
         const missing = keys.filter(
-            (key) => resolveRequired(this.resolveKeyInput(key), this.templateResolver).value === undefined
+            (key) => resolveRequired(resolveKeyInput(key), templateResolver).value === undefined
         );
         if (missing.length > 0) {
             throw new EnvaptError(
@@ -227,7 +228,7 @@ export class AdvancedMethods extends PrimitiveMethods {
         const result: Record<string, unknown> = {};
         for (const key of keys) {
             // same widening cast as getRequired, every value was proven present above.
-            const converted = this.valueConverter.convertValue<unknown>(
+            const converted = valueConverter.convertValue<unknown>(
                 key,
                 undefined,
                 spec[key] as EnvaptConverter<unknown>,
@@ -277,7 +278,7 @@ export class AdvancedMethods extends PrimitiveMethods {
         const hasFallback = arguments.length > 2;
         // SchemaConstraint resolves to the unsatisfiable SchemaMustBeSync brand for async
         // schemas, so reaching this body means the input is structurally a sync Schema.
-        const result = this.valueConverter.convertWithSchema(
+        const result = valueConverter.convertWithSchema(
             key,
             schema as unknown as StandardSchemaV1,
             fallback,
@@ -295,7 +296,7 @@ export class AdvancedMethods extends PrimitiveMethods {
         fallback?: InferSchemaOutput<Schema>
     ): InferSchemaOutput<Schema> {
         const hasFallback = arguments.length > 2;
-        const result = AdvancedMethods.valueConverter.convertWithSchema(
+        const result = valueConverter.convertWithSchema(
             key,
             schema as unknown as StandardSchemaV1,
             fallback,

--- a/packages/envapt/src/core/EnvapterBase.ts
+++ b/packages/envapt/src/core/EnvapterBase.ts
@@ -1,12 +1,11 @@
+import { ensureLoaded, mirrorToProcessEnv, refreshCache, resolveKeyInput } from './engine';
 import { cache, state } from './state';
 import { Validator } from '../engine/Validators';
-import { debugVerbose, getDebugLevel, setDebugLevel } from '../infra/Debug';
-import { loadDotenv } from '../infra/Dotenv';
-import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
+import { getDebugLevel, setDebugLevel } from '../infra/Debug';
 import { bindRuntimeFromSource } from '../infra/runtime';
 
 import type { DebugLevel } from '../infra/Debug';
-import type { EnvKeyInput, FileApiMode, FileCapableSource, Source } from '../types';
+import type { EnvKeyInput, FileApiMode, Source } from '../types';
 
 /** @internal */
 export abstract class EnvapterBase {
@@ -16,8 +15,7 @@ export abstract class EnvapterBase {
      */
     static set strict(value: boolean) {
         state.strict = value;
-        // rebuild via `this` so the subclass `resolveEffectivePaths` override is honored (EnvapterBase would skip it).
-        this.refreshCache();
+        refreshCache();
     }
 
     static get strict(): boolean {
@@ -52,7 +50,7 @@ export abstract class EnvapterBase {
         Validator.validateSyncProcessEnv(value);
         const previous = state.syncProcessEnv;
         state.syncProcessEnv = value;
-        if (!previous && value && cache.size > 0) this.mirrorToProcessEnv();
+        if (!previous && value && cache.size > 0) mirrorToProcessEnv();
     }
 
     static get syncProcessEnv(): boolean {
@@ -75,152 +73,13 @@ export abstract class EnvapterBase {
         return state.fileApiMode;
     }
 
-    protected static treatAsMissing(value: string | undefined): boolean {
-        if (value === undefined || value === '') return true;
-        if (state.strict && value.trim() === '') return true;
-        return false;
-    }
-
-    // No baseDir: candidate returned unchanged so the source resolves it against its own default
-    // (process.cwd() on Node). Resolution goes through the source to keep this class node-free.
-    protected static resolveAgainstBase(candidate: string): string {
-        const baseDir = state.baseDir;
-        if (baseDir === undefined) return candidate;
-        const source = state.source;
-        /* v8 ignore next -- @preserve callers are all file-gated, so the source is never bare here */
-        if (!source.supportsFiles) return candidate;
-        return source.resolvePath(baseDir, candidate);
-    }
-
-    // File-based config (envPaths/baseDir/configureProfiles) is meaningless without a filesystem, and
-    // it throws instead of silently ignoring it on the browser or Workers. Narrows the source so callers
-    // can reach the file capabilities (resolvePath/normalizeBaseDir) after the check.
-    protected static assertFileApiSupported(api: string, source: Source): asserts source is FileCapableSource {
-        if (!source.supportsFiles) {
-            throw new EnvaptError(
-                EnvaptErrorCodes.FileApiUnsupported,
-                `${api} requires a filesystem-backed source; the bound source does not support .env files.`
-            );
-        }
-    }
-
-    // Existence via the bound source instead of fs.existsSync/accessSync: a file "exists" when the
-    // source can read it.
-    protected static sourceFileExists(path: string): boolean {
-        const source = state.source;
-        /* v8 ignore next -- @preserve every caller is file-gated, so this never sees a bare source */
-        if (!source.supportsFiles) return false;
-        return source.readFile(path, 'utf8') !== undefined;
-    }
-
-    protected static refreshCache(): void {
-        cache.clear();
-        state.cacheBuilt = false;
-        state.dotenvAddedKeys = new Set<string>();
-        debugVerbose('cache cleared, reloading config');
-        void this.config; // getter rebuilds the cache as a side effect
-    }
-
-    protected static mirrorToProcessEnv(): void {
-        if (state.dotenvAddedKeys.size === 0) return;
-        const source = state.source;
-        /* v8 ignore next -- @preserve dotenv keys only accumulate under a file source, so the delta implies supportsFiles here */
-        if (!source.supportsFiles) return;
-        const mirrored: Record<string, string> = {};
-        for (const key of state.dotenvAddedKeys) {
-            const value = cache.get(key);
-            /* v8 ignore next -- @preserve loader only writes strings, defensive against future cache contents */
-            if (typeof value !== 'string') continue;
-            mirrored[key] = this.resolveForMirror(key, value);
-            debugVerbose(`mirrored ${key} to the ambient environment`);
-        }
-        source.writeVars(mirrored);
-        debugVerbose(`mirrored ${state.dotenvAddedKeys.size} keys to the ambient environment`);
-    }
-
-    // The template resolver is defined in PrimitiveMethods, and EnvapterBase can't call it without an
-    // import cycle, so the mirror expands ${VAR} through this override.
-    protected static resolveForMirror(_key: string, value: string): string {
-        /* v8 ignore next -- @preserve overridden by PrimitiveMethods on every concrete class */
-        return value;
-    }
-
-    // Default returns the explicit `state.envPaths`. EnvironmentMethods overrides to layer the dotenv-flow
-    // cascade + configureProfiles when envPaths was never explicitly set.
-    protected static resolveEffectivePaths(): string[] {
-        /* v8 ignore next -- @preserve */
-        return state.envPaths.map((p) => this.resolveAgainstBase(p));
-    }
-
-    protected static resolveKeyInput(keyInput: EnvKeyInput): { key: string; value: string | undefined } {
-        const keys = Array.isArray(keyInput) ? keyInput : [keyInput];
-        const normalizedKeys = keys as readonly string[];
-
-        if (normalizedKeys.length === 0) {
-            throw new EnvaptError(EnvaptErrorCodes.InvalidKeyInput, 'At least one environment key must be provided.');
-        }
-
-        if (normalizedKeys.some((k) => typeof k !== 'string')) {
-            throw new EnvaptError(EnvaptErrorCodes.InvalidKeyInput, 'Environment keys must be strings.');
-        }
-
-        if (normalizedKeys.some((k) => k.trim() === '')) {
-            throw new EnvaptError(EnvaptErrorCodes.InvalidKeyInput, 'Environment keys cannot be empty strings.');
-        }
-
-        for (const candidate of normalizedKeys) {
-            const value = this.config.get(candidate) as string | undefined;
-            if (value !== undefined) {
-                return { key: candidate, value };
-            }
-        }
-
-        return { key: normalizedKeys[0] as string, value: undefined };
-    }
-
-    protected static get config(): Map<string, unknown> {
-        if (!state.cacheBuilt) {
-            const source = state.source;
-            // Clone so the loader and downstream reads never mutate the source's backing object.
-            const isolatedEnv: Record<string, string> = { ...source.readVars() };
-
-            let added = new Set<string>();
-            // Sources without a filesystem (injected objects on the browser or Workers) skip the
-            // .env cascade, profiles, and envPaths. Only the readVars() snapshot populates the cache.
-            if (source.supportsFiles) {
-                debugVerbose(`base dir: ${state.baseDir ?? 'working directory'}`);
-                // Outside the try below so a missing configured profile path surfaces its EnvaptError. Only dotenv parse errors stay caught.
-                const effectivePaths = this.resolveEffectivePaths();
-                debugVerbose(
-                    `effective .env paths: ${effectivePaths.length === 0 ? '(none)' : effectivePaths.join(', ')}`
-                );
-                try {
-                    added = loadDotenv({
-                        ...state.userDefinedEnvFileOptions,
-                        path: effectivePaths,
-                        processEnv: isolatedEnv,
-                        readFile: source.readFile.bind(source)
-                    });
-                } catch {}
-            }
-            state.dotenvAddedKeys = added;
-            for (const [key, value] of Object.entries(isolatedEnv)) cache.set(key, value);
-            debugVerbose(`cache populated: ${cache.size} keys total`);
-            // set before mirroring, whose template expansion reads config and would re-enter this build otherwise
-            state.cacheBuilt = true;
-            if (state.syncProcessEnv) this.mirrorToProcessEnv();
-        }
-
-        return cache;
-    }
-
     /**
      * Eagerly load the `.env` cascade now instead of lazily on the first read. Idempotent: a no-op
      * once the cache is built. Useful before mirroring to `process.env` (see {@link syncProcessEnv}),
      * which is what the `envapt/config` side-effect entry does.
      */
     static load(): void {
-        void this.config;
+        ensureLoaded();
     }
 
     /**
@@ -231,13 +90,13 @@ export abstract class EnvapterBase {
     static useSource(source: Source): void {
         state.source = source;
         bindRuntimeFromSource(source);
-        this.refreshCache();
+        refreshCache();
     }
 
     /**
      * Read an environment variable as its raw string, skipping parsing and conversion.
      */
     getRaw(key: EnvKeyInput): string | undefined {
-        return EnvapterBase.resolveKeyInput(key).value;
+        return resolveKeyInput(key).value;
     }
 }

--- a/packages/envapt/src/core/Environment.ts
+++ b/packages/envapt/src/core/Environment.ts
@@ -1,0 +1,47 @@
+/**
+ * Environment types supported by Envapter
+ *
+ * The following keys are checked in order until the first with a non-empty value is found, or defaulting to development if none are set:
+ * - `ENVIRONMENT`
+ * - `ENV`
+ * - `NODE_ENV`
+ * - `MODE`
+ *
+ * @public
+ */
+export enum Environment {
+    /** The default when no environment variable names a known environment. */
+    Development,
+    /** Selected when an environment variable reads `staging`. */
+    Staging,
+    /** Selected when an environment variable reads `production`. */
+    Production,
+    /** Selected when an environment variable reads `test`. */
+    Test
+}
+
+// highest precedence first
+export const ENV_KEYS = ['ENVIRONMENT', 'ENV', 'NODE_ENV', 'MODE'] as const;
+
+export function parseEnvironment(raw: string): Environment | undefined {
+    switch (raw.toLowerCase()) {
+        case 'production':
+            return Environment.Production;
+        case 'staging':
+            return Environment.Staging;
+        case 'test':
+            return Environment.Test;
+        case 'development':
+            return Environment.Development;
+        default:
+            return undefined;
+    }
+}
+
+export function firstEnvKeyValue(read: (key: string) => string | undefined): string | undefined {
+    for (const key of ENV_KEYS) {
+        const value = read(key);
+        if (value !== undefined && value.length > 0) return value;
+    }
+    return undefined;
+}

--- a/packages/envapt/src/core/EnvironmentMethods.ts
+++ b/packages/envapt/src/core/EnvironmentMethods.ts
@@ -1,99 +1,19 @@
+import { determineEnvironment } from './engine';
 import { EnvapterBase } from './EnvapterBase';
+import { Environment } from './Environment';
 import { state } from './state';
-import { debugWarn } from '../infra/Debug';
-import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
-
-import type { EnvProfile } from '../types';
-
-/**
- * Environment types supported by Envapter
- *
- * The following keys are checked in order until the first with a non-empty value is found, or defaulting to development if none are set:
- * - `ENVIRONMENT`
- * - `ENV`
- * - `NODE_ENV`
- * - `MODE`
- *
- * @public
- */
-export enum Environment {
-    /** The default when no environment variable names a known environment. */
-    Development,
-    /** Selected when an environment variable reads `staging`. */
-    Staging,
-    /** Selected when an environment variable reads `production`. */
-    Production,
-    /** Selected when an environment variable reads `test`. */
-    Test
-}
-
-// Keys carrying the environment name, highest precedence first. Checked in order until the first with a non-empty value is found, or defaulting to development if none are set.
-const ENV_KEYS = ['ENVIRONMENT', 'ENV', 'NODE_ENV', 'MODE'] as const;
-
-function parseEnvironment(raw: string): Environment | undefined {
-    switch (raw.toLowerCase()) {
-        case 'production':
-            return Environment.Production;
-        case 'staging':
-            return Environment.Staging;
-        case 'test':
-            return Environment.Test;
-        case 'development':
-            return Environment.Development;
-        default:
-            return undefined;
-    }
-}
 
 /**
  * Mixin for environment detection and checking methods
  * @internal
  */
 export class EnvironmentMethods extends EnvapterBase {
-    protected static determineEnvironment(env?: string | Environment): void {
-        if (typeof env === 'number') {
-            state.environment = env;
-            state.environmentExplicitlySet = true;
-            return;
-        }
-        if (typeof env === 'string') {
-            state.environment = parseEnvironment(env) ?? Environment.Development;
-            state.environmentExplicitlySet = true;
-            return;
-        }
-
-        const raw = this.firstEnvKeyValue((key) => {
-            const value = this.config.get(key);
-            return typeof value === 'string' ? value : undefined;
-        });
-        if (raw === undefined) {
-            debugWarn(`no environment set (looked for ${ENV_KEYS.join(', ')}); defaulting to development`);
-            state.environment = Environment.Development;
-            return;
-        }
-        const parsed = parseEnvironment(raw);
-        if (parsed === undefined) {
-            debugWarn(`unrecognized environment "${raw}"; defaulting to development`);
-            state.environment = Environment.Development;
-            return;
-        }
-        state.environment = parsed;
-    }
-
-    private static firstEnvKeyValue(read: (key: string) => string | undefined): string | undefined {
-        for (const key of ENV_KEYS) {
-            const value = read(key);
-            if (value !== undefined && value.length > 0) return value;
-        }
-        return undefined;
-    }
-
     /**
      * Get the current application environment
      */
     static get environment(): Environment {
         if (state.environment === undefined) {
-            this.determineEnvironment();
+            determineEnvironment();
         }
         return state.environment as Environment;
     }
@@ -102,7 +22,7 @@ export class EnvironmentMethods extends EnvapterBase {
      * Set the application environment. Accepts either Environment enum or string value.
      */
     static set environment(env: string | Environment) {
-        this.determineEnvironment(env);
+        determineEnvironment(env);
     }
 
     /**
@@ -116,7 +36,7 @@ export class EnvironmentMethods extends EnvapterBase {
      * @see {@link EnvironmentMethods.environment}
      */
     set environment(env: string | Environment) {
-        EnvironmentMethods.determineEnvironment(env);
+        determineEnvironment(env);
     }
 
     /**
@@ -173,90 +93,5 @@ export class EnvironmentMethods extends EnvapterBase {
      */
     get isTest(): boolean {
         return EnvironmentMethods.environment === Environment.Test;
-    }
-
-    protected static override refreshCache(): void {
-        // If the env was inferred (not user-set), reset it so re-hydration re-determines
-        // from current state. If the user explicitly set Envapter.environment = X, preserve
-        // that value through the refresh. The immediate re-hydration inside super.refreshCache()
-        // will use it for cascade selection.
-        if (!state.environmentExplicitlySet) state.environment = undefined;
-        super.refreshCache();
-    }
-
-    /**
-     * Reads the source's raw vars (not `this.config`, which would recurse: cascade selection runs
-     * before the `.env` load). `Envapter.environment` may differ post-load if a file sets `ENVIRONMENT`.
-     * @internal
-     */
-    protected static getCascadeEnvironment(): Environment {
-        if (state.environment !== undefined) return state.environment;
-
-        const vars = state.source.readVars();
-        const raw = this.firstEnvKeyValue((key) => vars[key]);
-        return raw === undefined ? Environment.Development : (parseEnvironment(raw) ?? Environment.Development);
-    }
-
-    /**
-     * Build the dotenv-flow cascade for a given environment, in dotenv first-wins precedence
-     * order (highest precedence first). Missing files are silently filtered.
-     *
-     * Precedence is **most-specific-wins** (matches Vite / Astro / Vocs):
-     *   `.env.${env}.local` \> `.env.${env}` \> `.env.local` \> `.env`
-     *
-     * This differs from dotenv-flow / Next.js convention which puts `.env.local` above
-     * `.env.${env}`. We chose the most-specific-wins order so committed env-specific files
-     * (`.env.production`) are authoritative for that environment regardless of whether a
-     * stray `.env.local` is present.
-     * @internal
-     */
-    protected static buildCascadePaths(env: Environment): string[] {
-        const envName = Environment[env].toLowerCase();
-        return [`.env.${envName}.local`, `.env.${envName}`, '.env.local', '.env']
-            .map((name) => this.resolveAgainstBase(name))
-            .filter((p) => this.sourceFileExists(p));
-    }
-
-    private static normalizeProfilePaths(profile: EnvProfile | undefined): string[] {
-        if (!profile) return [];
-        return Array.isArray(profile.paths) ? profile.paths : [profile.paths];
-    }
-
-    /**
-     * Override the base implementation to layer the dotenv-flow cascade + any
-     * `Envapter.configureProfiles` overrides on top of `state.envPaths` when the user has NOT
-     * explicitly set `envPaths`.
-     *
-     * Precedence (passed to dotenv with first-wins semantics):
-     *   1. profile-configured paths for the current env (if any)
-     *   2. `.env.${env}.local`
-     *   3. `.env.${env}`
-     *   4. `.env.local`
-     *   5. `.env`
-     *
-     * If `useDefaults: false` is set on the profiles config, only (1) is loaded, no cascade.
-     * If `envPaths` was explicitly set, only `envPaths` is loaded (everything else ignored).
-     * @internal
-     */
-    protected static override resolveEffectivePaths(): string[] {
-        if (state.envPathsExplicitlySet) return state.envPaths.map((p) => this.resolveAgainstBase(p));
-
-        const env = this.getCascadeEnvironment();
-        const profileEntry = state.profiles?.[env];
-        const profilePaths = this.normalizeProfilePaths(profileEntry);
-
-        // Validate that explicitly configured profile paths exist for the active env.
-        if (profilePaths.length > 0) {
-            const missing = profilePaths.filter((p) => !this.sourceFileExists(this.resolveAgainstBase(p)));
-            if (missing.length > 0) {
-                throw new EnvaptError(
-                    EnvaptErrorCodes.EnvFilesNotFound,
-                    `Environment file not found at path: ${missing.join(', ')}`
-                );
-            }
-        }
-
-        const cascade = state.profiles?.useDefaults === false ? [] : this.buildCascadePaths(env);
-        return [...profilePaths.map((p) => this.resolveAgainstBase(p)), ...cascade];
     }
 }

--- a/packages/envapt/src/core/PrimitiveMethods.ts
+++ b/packages/envapt/src/core/PrimitiveMethods.ts
@@ -1,62 +1,12 @@
-import { BuiltInConverters, ValueConverter } from '../converters';
+import { Primitive, readPrimitive } from './engine';
 import { EnvironmentMethods } from './EnvironmentMethods';
-import { TemplateResolver } from '../engine/TemplateResolver';
-import { debugWarn } from '../infra/Debug';
 
 import type { ConditionalReturn, EnvKeyInput } from '../types';
-import type { EnvapterService } from '../types/Env';
 
 /**
  * @internal
  */
-enum Primitive {
-    String,
-    Number,
-    Boolean,
-    BigInt,
-    Symbol
-}
-
-/**
- * @internal
- */
-export class PrimitiveMethods extends EnvironmentMethods implements EnvapterService {
-    private static readonly service = new PrimitiveMethods();
-    protected static readonly templateResolver: TemplateResolver = new TemplateResolver(PrimitiveMethods.service);
-    protected static readonly valueConverter: ValueConverter = new ValueConverter(PrimitiveMethods.service);
-
-    protected static override resolveForMirror(key: string, value: string): string {
-        return this.templateResolver.resolveTemplate(key, value);
-    }
-
-    private static _get<EnvVarReturnType, DefaultType extends EnvVarReturnType | undefined = undefined>(
-        key: EnvKeyInput,
-        type: Primitive,
-        def?: DefaultType
-    ): ConditionalReturn<EnvVarReturnType, DefaultType> {
-        const { key: resolvedKey, value } = this.resolveKeyInput(key);
-        if (this.treatAsMissing(value)) {
-            if (def !== undefined) debugWarn(`${resolvedKey} is missing or empty, using fallback ${String(def)}`);
-            else debugWarn(`${resolvedKey} is missing or empty`);
-            return def as ConditionalReturn<EnvVarReturnType, DefaultType>;
-        }
-        const rawVal = value as string | number | boolean | undefined;
-
-        const parsed = this.templateResolver.resolveTemplate(resolvedKey, String(rawVal));
-
-        let result: EnvVarReturnType;
-        if (type === Primitive.Number) result = BuiltInConverters.number(parsed, def as number) as EnvVarReturnType;
-        else if (type === Primitive.Boolean)
-            result = BuiltInConverters.boolean(parsed, def as boolean) as EnvVarReturnType;
-        else if (type === Primitive.BigInt)
-            result = BuiltInConverters.bigint(parsed, def as bigint) as EnvVarReturnType;
-        else if (type === Primitive.Symbol)
-            result = BuiltInConverters.symbol(parsed, def as symbol) as EnvVarReturnType;
-        else result = BuiltInConverters.string(parsed, def as string) as EnvVarReturnType;
-
-        return result;
-    }
-
+export class PrimitiveMethods extends EnvironmentMethods {
     /**
      * Get a string environment variable with optional fallback.
      * Supports template variable resolution using `${VAR}` syntax.
@@ -66,7 +16,7 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<string, Default> {
-        return this._get(key, Primitive.String, def);
+        return readPrimitive(key, Primitive.String, def);
     }
 
     /**
@@ -76,7 +26,7 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<string, Default> {
-        return PrimitiveMethods._get(key, Primitive.String, def);
+        return readPrimitive(key, Primitive.String, def);
     }
 
     /**
@@ -88,7 +38,7 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<number, Default> {
-        return this._get(key, Primitive.Number, def);
+        return readPrimitive(key, Primitive.Number, def);
     }
 
     /**
@@ -98,7 +48,7 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<number, Default> {
-        return PrimitiveMethods._get(key, Primitive.Number, def);
+        return readPrimitive(key, Primitive.Number, def);
     }
 
     /**
@@ -110,7 +60,7 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<boolean, Default> {
-        return this._get(key, Primitive.Boolean, def);
+        return readPrimitive(key, Primitive.Boolean, def);
     }
 
     /**
@@ -120,7 +70,7 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<boolean, Default> {
-        return PrimitiveMethods._get(key, Primitive.Boolean, def);
+        return readPrimitive(key, Primitive.Boolean, def);
     }
 
     /**
@@ -132,7 +82,7 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<bigint, Default> {
-        return this._get(key, Primitive.BigInt, def);
+        return readPrimitive(key, Primitive.BigInt, def);
     }
 
     /**
@@ -142,7 +92,7 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<bigint, Default> {
-        return PrimitiveMethods._get(key, Primitive.BigInt, def);
+        return readPrimitive(key, Primitive.BigInt, def);
     }
 
     /**
@@ -154,7 +104,7 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<symbol, Default> {
-        return this._get(key, Primitive.Symbol, def);
+        return readPrimitive(key, Primitive.Symbol, def);
     }
 
     /**
@@ -164,6 +114,6 @@ export class PrimitiveMethods extends EnvironmentMethods implements EnvapterServ
         key: EnvKeyInput,
         def?: Default
     ): ConditionalReturn<symbol, Default> {
-        return PrimitiveMethods._get(key, Primitive.Symbol, def);
+        return readPrimitive(key, Primitive.Symbol, def);
     }
 }

--- a/packages/envapt/src/core/engine.ts
+++ b/packages/envapt/src/core/engine.ts
@@ -61,7 +61,9 @@ export function ensureLoaded(): Map<string, unknown> {
                     processEnv: isolatedEnv,
                     readFile: source.readFile.bind(source)
                 });
-            } catch {}
+            } catch (error) {
+                debugWarn(`failed to load .env: ${error instanceof Error ? error.message : String(error)}`);
+            }
         }
         state.dotenvAddedKeys = added;
         for (const [key, value] of Object.entries(isolatedEnv)) cache.set(key, value);
@@ -169,9 +171,8 @@ export function readPrimitive<EnvVarReturnType, DefaultType extends EnvVarReturn
         else debugWarn(`${resolvedKey} is missing or empty`);
         return def as ConditionalReturn<EnvVarReturnType, DefaultType>;
     }
-    const rawVal = value as string | number | boolean | undefined;
 
-    const parsed = templateResolver.resolveTemplate(resolvedKey, String(rawVal));
+    const parsed = templateResolver.resolveTemplate(resolvedKey, String(value));
 
     let result: EnvVarReturnType;
     if (type === Primitive.Number) result = BuiltInConverters.number(parsed, def as number) as EnvVarReturnType;

--- a/packages/envapt/src/core/engine.ts
+++ b/packages/envapt/src/core/engine.ts
@@ -1,0 +1,184 @@
+import { BuiltInConverters, ValueConverter } from '../converters';
+import { ENV_KEYS, Environment, firstEnvKeyValue, parseEnvironment } from './Environment';
+import { resolveEffectivePaths } from './paths';
+import { cache, state } from './state';
+import { TemplateResolver } from '../engine/TemplateResolver';
+import { debugVerbose, debugWarn } from '../infra/Debug';
+import { loadDotenv } from '../infra/Dotenv';
+import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
+
+import type { ConditionalReturn, EnvKeyInput } from '../types';
+import type { EnvapterService } from '../types/Env';
+
+export function resolveKeyInput(keyInput: EnvKeyInput): { key: string; value: string | undefined } {
+    const keys = Array.isArray(keyInput) ? keyInput : [keyInput];
+    const normalizedKeys = keys as readonly string[];
+
+    if (normalizedKeys.length === 0) {
+        throw new EnvaptError(EnvaptErrorCodes.InvalidKeyInput, 'At least one environment key must be provided.');
+    }
+
+    if (normalizedKeys.some((k) => typeof k !== 'string')) {
+        throw new EnvaptError(EnvaptErrorCodes.InvalidKeyInput, 'Environment keys must be strings.');
+    }
+
+    if (normalizedKeys.some((k) => k.trim() === '')) {
+        throw new EnvaptError(EnvaptErrorCodes.InvalidKeyInput, 'Environment keys cannot be empty strings.');
+    }
+
+    for (const candidate of normalizedKeys) {
+        const value = ensureLoaded().get(candidate) as string | undefined;
+        if (value !== undefined) return { key: candidate, value };
+    }
+
+    return { key: normalizedKeys[0] as string, value: undefined };
+}
+
+export function treatAsMissing(value: string | undefined): boolean {
+    if (value === undefined || value === '') return true;
+    if (state.strict && value.trim() === '') return true;
+    return false;
+}
+
+export function ensureLoaded(): Map<string, unknown> {
+    if (!state.cacheBuilt) {
+        const source = state.source;
+        // Clone so the loader and downstream reads never mutate the source's backing object.
+        const isolatedEnv: Record<string, string> = { ...source.readVars() };
+
+        let added = new Set<string>();
+        // Sources without a filesystem (injected objects on the browser or Workers) skip the .env
+        // cascade, profiles, and envPaths. Only the readVars() snapshot populates the cache.
+        if (source.supportsFiles) {
+            debugVerbose(`base dir: ${state.baseDir ?? 'working directory'}`);
+            // Outside the try below so a missing configured profile path surfaces its EnvaptError. Only dotenv parse errors stay caught.
+            const effectivePaths = resolveEffectivePaths();
+            debugVerbose(`effective .env paths: ${effectivePaths.length === 0 ? '(none)' : effectivePaths.join(', ')}`);
+            try {
+                added = loadDotenv({
+                    ...state.userDefinedEnvFileOptions,
+                    path: effectivePaths,
+                    processEnv: isolatedEnv,
+                    readFile: source.readFile.bind(source)
+                });
+            } catch {}
+        }
+        state.dotenvAddedKeys = added;
+        for (const [key, value] of Object.entries(isolatedEnv)) cache.set(key, value);
+        debugVerbose(`cache populated: ${cache.size} keys total`);
+        // set before mirroring, whose template expansion reads the cache and would re-enter this build otherwise
+        state.cacheBuilt = true;
+        if (state.syncProcessEnv) mirrorToProcessEnv();
+    }
+
+    return cache;
+}
+
+export function refreshCache(): void {
+    // Reset an inferred environment so re-hydration re-determines it from current state. An explicit
+    // Envapter.environment = X is preserved through the refresh and used for cascade selection.
+    if (!state.environmentExplicitlySet) state.environment = undefined;
+    cache.clear();
+    state.cacheBuilt = false;
+    state.dotenvAddedKeys = new Set<string>();
+    debugVerbose('cache cleared, reloading config');
+    ensureLoaded();
+}
+
+export function mirrorToProcessEnv(): void {
+    if (state.dotenvAddedKeys.size === 0) return;
+    const source = state.source;
+    /* v8 ignore next -- @preserve dotenv keys only accumulate under a file source, so the delta implies supportsFiles here */
+    if (!source.supportsFiles) return;
+    const mirrored: Record<string, string> = {};
+    for (const key of state.dotenvAddedKeys) {
+        const value = cache.get(key);
+        /* v8 ignore next -- @preserve loader only writes strings, defensive against future cache contents */
+        if (typeof value !== 'string') continue;
+        mirrored[key] = resolveForMirror(key, value);
+        debugVerbose(`mirrored ${key} to the ambient environment`);
+    }
+    source.writeVars(mirrored);
+    debugVerbose(`mirrored ${state.dotenvAddedKeys.size} keys to the ambient environment`);
+}
+
+function resolveForMirror(key: string, value: string): string {
+    return templateResolver.resolveTemplate(key, value);
+}
+
+export function determineEnvironment(env?: string | Environment): void {
+    if (typeof env === 'number') {
+        state.environment = env;
+        state.environmentExplicitlySet = true;
+        return;
+    }
+    if (typeof env === 'string') {
+        state.environment = parseEnvironment(env) ?? Environment.Development;
+        state.environmentExplicitlySet = true;
+        return;
+    }
+
+    const raw = firstEnvKeyValue((key) => {
+        const value = ensureLoaded().get(key);
+        return typeof value === 'string' ? value : undefined;
+    });
+    if (raw === undefined) {
+        debugWarn(`no environment set (looked for ${ENV_KEYS.join(', ')}); defaulting to development`);
+        state.environment = Environment.Development;
+        return;
+    }
+    const parsed = parseEnvironment(raw);
+    if (parsed === undefined) {
+        debugWarn(`unrecognized environment "${raw}"; defaulting to development`);
+        state.environment = Environment.Development;
+        return;
+    }
+    state.environment = parsed;
+}
+
+/**
+ * @internal
+ */
+export enum Primitive {
+    String,
+    Number,
+    Boolean,
+    BigInt,
+    Symbol
+}
+
+// getRaw is the raw string lookup, get is the template-resolved string read. Lazy arrows so the
+// resolver singletons below store envService without calling readPrimitive, which reads
+// templateResolver before it is assigned.
+const envService: EnvapterService = {
+    getRaw: (key) => resolveKeyInput(key).value,
+    get: (key, def) => readPrimitive<string, string | undefined>(key, Primitive.String, def)
+};
+
+export const templateResolver: TemplateResolver = new TemplateResolver(envService);
+export const valueConverter: ValueConverter = new ValueConverter(envService);
+
+export function readPrimitive<EnvVarReturnType, DefaultType extends EnvVarReturnType | undefined = undefined>(
+    key: EnvKeyInput,
+    type: Primitive,
+    def?: DefaultType
+): ConditionalReturn<EnvVarReturnType, DefaultType> {
+    const { key: resolvedKey, value } = resolveKeyInput(key);
+    if (treatAsMissing(value)) {
+        if (def !== undefined) debugWarn(`${resolvedKey} is missing or empty, using fallback ${String(def)}`);
+        else debugWarn(`${resolvedKey} is missing or empty`);
+        return def as ConditionalReturn<EnvVarReturnType, DefaultType>;
+    }
+    const rawVal = value as string | number | boolean | undefined;
+
+    const parsed = templateResolver.resolveTemplate(resolvedKey, String(rawVal));
+
+    let result: EnvVarReturnType;
+    if (type === Primitive.Number) result = BuiltInConverters.number(parsed, def as number) as EnvVarReturnType;
+    else if (type === Primitive.Boolean) result = BuiltInConverters.boolean(parsed, def as boolean) as EnvVarReturnType;
+    else if (type === Primitive.BigInt) result = BuiltInConverters.bigint(parsed, def as bigint) as EnvVarReturnType;
+    else if (type === Primitive.Symbol) result = BuiltInConverters.symbol(parsed, def as symbol) as EnvVarReturnType;
+    else result = BuiltInConverters.string(parsed, def as string) as EnvVarReturnType;
+
+    return result;
+}

--- a/packages/envapt/src/core/index.ts
+++ b/packages/envapt/src/core/index.ts
@@ -1,2 +1,2 @@
-export { Environment } from './EnvironmentMethods';
+export { Environment } from './Environment';
 export { AdvancedMethods } from './AdvancedMethods';

--- a/packages/envapt/src/core/paths.ts
+++ b/packages/envapt/src/core/paths.ts
@@ -1,0 +1,90 @@
+import { Environment, firstEnvKeyValue, parseEnvironment } from './Environment';
+import { state } from './state';
+import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
+
+import type { EnvProfile, FileCapableSource, Source } from '../types';
+
+// No baseDir: candidate returned unchanged so the source resolves it against its own default
+// (process.cwd() on Node). Resolution goes through the source to keep this node-free.
+export function resolveAgainstBase(candidate: string): string {
+    const baseDir = state.baseDir;
+    if (baseDir === undefined) return candidate;
+    const source = state.source;
+    /* v8 ignore next -- @preserve callers are all file-gated, so the source is never bare here */
+    if (!source.supportsFiles) return candidate;
+    return source.resolvePath(baseDir, candidate);
+}
+
+// File-based config (envPaths/baseDir/configureProfiles) is meaningless without a filesystem, and it
+// throws instead of silently ignoring it on the browser or Workers. Narrows the source so callers
+// can use the file capabilities (resolvePath/normalizeBaseDir) after the check.
+export function assertFileApiSupported(api: string, source: Source): asserts source is FileCapableSource {
+    if (!source.supportsFiles) {
+        throw new EnvaptError(
+            EnvaptErrorCodes.FileApiUnsupported,
+            `${api} requires a filesystem-backed source; the bound source does not support .env files.`
+        );
+    }
+}
+
+// Existence via the bound source instead of fs.existsSync/accessSync: a file "exists" when the source
+// can read it.
+export function sourceFileExists(path: string): boolean {
+    const source = state.source;
+    /* v8 ignore next -- @preserve every caller is file-gated, so this never sees a bare source */
+    if (!source.supportsFiles) return false;
+    return source.readFile(path, 'utf8') !== undefined;
+}
+
+// Precedence is most-specific-wins (matches Vite / Astro / Vocs): `.env.${env}.local` > `.env.${env}`
+// > `.env.local` > `.env`. This differs from dotenv-flow / Next.js, which put `.env.local` above
+// `.env.${env}`. Most-specific-wins keeps a committed `.env.production` authoritative regardless of a
+// stray `.env.local`. Missing files are filtered.
+function buildCascadePaths(env: Environment): string[] {
+    const envName = Environment[env].toLowerCase();
+    return [`.env.${envName}.local`, `.env.${envName}`, '.env.local', '.env']
+        .map((name) => resolveAgainstBase(name))
+        .filter((p) => sourceFileExists(p));
+}
+
+function normalizeProfilePaths(profile: EnvProfile | undefined): string[] {
+    if (!profile) return [];
+    return Array.isArray(profile.paths) ? profile.paths : [profile.paths];
+}
+
+// Reads the source's raw vars, not the cache, because cascade selection runs before the `.env` load.
+// `Envapter.environment` may differ post-load if a file sets `ENVIRONMENT`.
+function getCascadeEnvironment(): Environment {
+    if (state.environment !== undefined) return state.environment;
+
+    const vars = state.source.readVars();
+    const raw = firstEnvKeyValue((key) => vars[key]);
+    return raw === undefined ? Environment.Development : (parseEnvironment(raw) ?? Environment.Development);
+}
+
+/**
+ * Resolve the `.env` paths to load. When `envPaths` was explicitly set, only those load. Otherwise
+ * layer any `configureProfiles` paths for the active environment (higher precedence) over the
+ * dotenv-flow cascade, all in dotenv first-wins order. `useDefaults: false` drops the cascade.
+ */
+export function resolveEffectivePaths(): string[] {
+    if (state.envPathsExplicitlySet) return state.envPaths.map((p) => resolveAgainstBase(p));
+
+    const env = getCascadeEnvironment();
+    const profileEntry = state.profiles?.[env];
+    const profilePaths = normalizeProfilePaths(profileEntry);
+
+    // Validate that explicitly configured profile paths exist for the active env.
+    if (profilePaths.length > 0) {
+        const missing = profilePaths.filter((p) => !sourceFileExists(resolveAgainstBase(p)));
+        if (missing.length > 0) {
+            throw new EnvaptError(
+                EnvaptErrorCodes.EnvFilesNotFound,
+                `Environment file not found at path: ${missing.join(', ')}`
+            );
+        }
+    }
+
+    const cascade = state.profiles?.useDefaults === false ? [] : buildCascadePaths(env);
+    return [...profilePaths.map((p) => resolveAgainstBase(p)), ...cascade];
+}

--- a/packages/envapt/src/core/state.ts
+++ b/packages/envapt/src/core/state.ts
@@ -1,6 +1,6 @@
 import { UnboundSource } from '../sources/UnboundSource';
 
-import type { Environment } from './EnvironmentMethods';
+import type { Environment } from './Environment';
 import type { EnvFileOptions } from '../infra/Dotenv';
 import type { FileApiMode, ProfilesConfig, Source } from '../types';
 

--- a/packages/envapt/src/engine/Envapter.ts
+++ b/packages/envapt/src/engine/Envapter.ts
@@ -1,5 +1,6 @@
 import { AdvancedMethods } from '../core';
 import { resolveRequired } from '../core/AdvancedMethods';
+import { resolveKeyInput, templateResolver } from '../core/engine';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
 export { Environment } from '../core';
@@ -79,9 +80,7 @@ export class Envapter extends AdvancedMethods {
      * ```
      */
     static require(...keys: [string, ...string[]]): void {
-        const missing = keys.filter(
-            (k) => resolveRequired(Envapter.resolveKeyInput(k), Envapter.templateResolver).value === undefined
-        );
+        const missing = keys.filter((k) => resolveRequired(resolveKeyInput(k), templateResolver).value === undefined);
 
         if (missing.length > 0) {
             throw new EnvaptError(

--- a/packages/envapt/src/engine/NodeEnvapter.ts
+++ b/packages/envapt/src/engine/NodeEnvapter.ts
@@ -2,6 +2,8 @@ import process from 'node:process';
 
 import { Envapter } from './Envapter';
 import { Validator } from './Validators';
+import { refreshCache } from '../core/engine';
+import { assertFileApiSupported, resolveAgainstBase, sourceFileExists } from '../core/paths';
 import { state } from '../core/state';
 import { setRuntimeSink } from '../infra/runtime';
 import { FileSource } from '../sources/FileSource';
@@ -19,7 +21,7 @@ import type { ProfilesConfig } from '../types';
 export class NodeEnvapter extends Envapter {
     // A static block (not a top-level statement in a separate entry) keeps the bind intrinsic to this
     // class: tree-shaken out of `import { EnvaptError }`, run whenever `Envapter` is referenced, with no
-    // sideEffects entry. Depends on the es2022 native static-block emit; lowering the target defeats it.
+    // sideEffects entry. Depends on the es2022 native static-block emit.
     static {
         setRuntimeSink((line) => process.stderr.write(`${line}\n`));
         NodeEnvapter.useSource(new FileSource());
@@ -33,16 +35,16 @@ export class NodeEnvapter extends Envapter {
      * `Envapter.configureProfiles` configuration are ignored.
      */
     static set envPaths(paths: string[] | string) {
-        this.assertFileApiSupported('envPaths', state.source);
+        assertFileApiSupported('envPaths', state.source);
         const newPaths = Array.isArray(paths) ? paths : [paths];
         Validator.validateEnvFilesExist(
-            newPaths.map((p) => this.resolveAgainstBase(p)),
-            (p) => this.sourceFileExists(p)
+            newPaths.map((p) => resolveAgainstBase(p)),
+            (p) => sourceFileExists(p)
         );
 
         state.envPaths = newPaths;
         state.envPathsExplicitlySet = true;
-        this.refreshCache();
+        refreshCache();
     }
 
     /**
@@ -64,9 +66,9 @@ export class NodeEnvapter extends Envapter {
      */
     static set baseDir(value: string | URL | undefined) {
         const source = state.source;
-        this.assertFileApiSupported('baseDir', source);
+        assertFileApiSupported('baseDir', source);
         state.baseDir = value === undefined ? undefined : source.normalizeBaseDir(value);
-        this.refreshCache();
+        refreshCache();
     }
 
     /** The configured base directory, or `undefined` when relative paths resolve against the working directory. */
@@ -78,7 +80,7 @@ export class NodeEnvapter extends Envapter {
     static set envFileOptions(config: EnvFileOptions) {
         Validator.validateEnvFileOptions(config);
         state.userDefinedEnvFileOptions = config;
-        this.refreshCache();
+        refreshCache();
     }
 
     /**
@@ -106,9 +108,9 @@ export class NodeEnvapter extends Envapter {
      * ```
      */
     static configureProfiles(config: ProfilesConfig): void {
-        this.assertFileApiSupported('configureProfiles', state.source);
+        assertFileApiSupported('configureProfiles', state.source);
         state.profiles = config;
-        this.refreshCache();
+        refreshCache();
     }
 
     /**
@@ -122,6 +124,6 @@ export class NodeEnvapter extends Envapter {
         state.envPathsExplicitlySet = false;
         state.environmentExplicitlySet = false;
         state.environment = undefined;
-        this.refreshCache();
+        refreshCache();
     }
 }

--- a/packages/envapt/src/types/Options.ts
+++ b/packages/envapt/src/types/Options.ts
@@ -1,5 +1,5 @@
 import type { EnvaptConverter } from './Conversion';
-import type { Environment } from '../core/EnvironmentMethods';
+import type { Environment } from '../core/Environment';
 
 /**
  * Options for the \@Envapt decorator (modern API). `required: true` is mutually exclusive

--- a/packages/envapt/tests/013-defensive-tests.test.ts
+++ b/packages/envapt/tests/013-defensive-tests.test.ts
@@ -6,7 +6,7 @@ import { TemplateResolver } from '../src/engine/TemplateResolver';
 import { Validator } from '../src/engine/Validators';
 import { EnvaptError, EnvaptErrorCodes } from '../src/infra/Error';
 
-import type { BuiltInConverter, EnvKeyInput, PrimitiveConstructor } from '../src/types';
+import type { BuiltInConverter, PrimitiveConstructor } from '../src/types';
 import type { EnvapterService } from '../src/types/Env';
 
 class StubEnvService implements EnvapterService {
@@ -196,30 +196,24 @@ describe('Defensive tests', () => {
         });
     });
 
-    describe('EnvapterBase.resolveKeyInput validation', () => {
-        class ResolveHarness extends Envapter {
-            public static callResolve(key: EnvKeyInput): unknown {
-                return this.resolveKeyInput(key);
-            }
-        }
-
+    describe('key-input validation through the public read path', () => {
         it('throws when no keys are provided', () => {
             // @ts-expect-error Runtime guard ensures empty arrays are rejected
-            expect(() => ResolveHarness.callResolve([]))
+            expect(() => new Envapter().getRaw([]))
                 .to.throw(EnvaptError, 'At least one environment key must be provided.')
                 .and.to.have.property('code', EnvaptErrorCodes.InvalidKeyInput);
         });
 
         it('throws when keys include a non-string entry', () => {
             // @ts-expect-error Passing non-string key to trigger runtime guard
-            expect(() => ResolveHarness.callResolve(['VALID_KEY', 42])).to.throw(
+            expect(() => new Envapter().getRaw(['VALID_KEY', 42])).to.throw(
                 EnvaptError,
                 'Environment keys must be strings.'
             );
         });
 
         it('throws when keys include an empty string', () => {
-            expect(() => ResolveHarness.callResolve(['   '])).to.throw(
+            expect(() => new Envapter().getRaw(['   '])).to.throw(
                 EnvaptError,
                 'Environment keys cannot be empty strings.'
             );

--- a/packages/envapt/tests/039-module-private-state.test.ts
+++ b/packages/envapt/tests/039-module-private-state.test.ts
@@ -26,3 +26,9 @@ describe("engine's mutable state is module-private and should not be exposed as 
         expect(present).to.deep.equal([]);
     });
 });
+
+describe('the read cache is unreachable from a consumer subclass', () => {
+    it('exposes no `config` accessor that returns the cache Map', () => {
+        expect(Object.getOwnPropertyDescriptor(EnvapterBase, 'config')).to.equal(undefined);
+    });
+});


### PR DESCRIPTION
## What and why

- Move the engine read-path (cache build, key resolution, primitive + template reads, environment detection, `.env` path resolution) off the `EnvapterBase` → `AdvancedMethods` mixin chain into module functions under `core/` (`Environment.ts`, `paths.ts`, `engine.ts`). The chain classes are now thin public delegates.
- Closes the last protected-surface leak: the `config` getter returned the mutable read-cache `Map` by reference, so a consumer subclass could mutate every read. No class member exposes the cache or engine state now.
- No public API change.

## Checklist

- [x] New or regression tests cover the change
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment and path handling for more reliable configuration loading.
  * Strengthened key validation and missing-value checks when reading settings.
  * Prevented internal read state from being exposed through subclasses.

* **Refactor**
  * Consolidated core read, parsing, and cache behavior for better consistency.
  * Updated public exports to use the new environment utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->