### PR TITLE
feat: accept a reader function in useSource and merge

### DIFF
--- a/.changeset/merge-source-combinator.md
+++ b/.changeset/merge-source-combinator.md
@@ -3,3 +3,5 @@
 ---
 
 Add `merge`, a source combinator that layers several sources with last-wins precedence. It keeps the `.env` cascade and file APIs on one filesystem-backed member, and throws `InvalidMergedSource` with no members or more than one file-backed member.
+
+`useSource` and `merge` also accept a reader function `(key) => string | undefined` as a source, for a runtime that reads one key at a time and cannot list its keys. envapt calls the reader on a cache miss and caches the result.

--- a/.changeset/see-docs-links.md
+++ b/.changeset/see-docs-links.md
@@ -1,0 +1,7 @@
+---
+'envapt': patch
+---
+
+Add `@see` links to the docs site on the public API TSDoc, so hovering a reader, converter, source, decorator, or error in an editor links to its documentation page.
+
+Also drop the internal `isArrayOf` guard and the `EnvaptConverter` and `ConverterToken` types from the public exports.

--- a/apps/guide/content/docs/edge-runtimes.mdx
+++ b/apps/guide/content/docs/edge-runtimes.mdx
@@ -31,22 +31,17 @@ const origin = Envapter.getRequired('ORIGIN_URL', Converters.Url);
 
 ## Fastly Compute
 
-Fastly is the one runtime that hands you no environment object. You read values one key at a time with `env` from `fastly:env`, and `ConfigStore` is the same shape (a keyed `.get()`, no listing). So name the keys you read and build the object from them. Add the `fastly` condition to your bundler's resolve conditions so bare `envapt` resolves the portable build.
+Fastly is the one runtime that hands you no environment object. You read values one key at a time with `env` from `fastly:env`. Pass the reader straight to `useSource` and envapt reads each key from it on the first access, caching the result. Add the `fastly` condition to your bundler's resolve conditions so bare `envapt` resolves the portable build.
 
 ```ts
 import { env } from 'fastly:env';
-import { Envapter, PortableSource, Converters } from 'envapt';
+import { Envapter, Converters } from 'envapt';
 
-Envapter.useSource(
-    new PortableSource({
-        ORIGIN_URL: env('ORIGIN_URL'),
-        API_TOKEN: env('API_TOKEN')
-    })
-);
+Envapter.useSource(env);
 const origin = Envapter.getRequired('ORIGIN_URL', Converters.Url);
 ```
 
-Custom variables are inlined into the Wasm binary at build time through the `--env` flag, so changing one needs a redeploy. For values that change without a redeploy, read a `ConfigStore` by key the same way. See Fastly's [environment variables](https://www.fastly.com/documentation/reference/compute/ecp-env/) docs.
+Custom variables are inlined into the Wasm binary at build time through the `--env` flag, so changing one needs a redeploy. See Fastly's [environment variables](https://www.fastly.com/documentation/reference/compute/ecp-env/) docs.
 
 ## Expo and React Native
 

--- a/apps/guide/content/docs/sources.mdx
+++ b/apps/guide/content/docs/sources.mdx
@@ -52,6 +52,19 @@ An optional `supportsFiles` flag marks a source as backing the file-only config 
 
 For fetching that secrets object from 1Password, Vault, Doppler, AWS Secrets Manager, and others, see [Using secret stores](/docs/secret-stores).
 
+## A function can be a source
+
+Some sources read one key at a time and give you no way to list the keys. Pass a `(key) => string | undefined` reader to `useSource` and envapt calls it per key on the first read, caching the result. No object to assemble.
+
+```ts twoslash
+import { Envapter, Converters } from 'envapt';
+// ---cut---
+declare const store: { get(key: string): string | undefined }; // a keyed config store
+Envapter.useSource((key) => store.get(key));
+
+const region = Envapter.getRequired('REGION', Converters.String);
+```
+
 ## Combining sources
 
 `merge` composes several sources into one, read last-wins. A later member overrides an earlier member's key. Keep the `.env` cascade and layer fetched secrets on top in a single bind, with no write to `process.env`.
@@ -66,6 +79,17 @@ const dbUrl = Envapter.getUsing('DATABASE_URL', Converters.Url);
 ```
 
 At most one member is filesystem-backed, and the `.env` cascade and file APIs route to it. `merge` throws [`InvalidMergedSource`](/docs/errors) with no members or more than one file-backed member.
+
+A member can also be a `(key) => string | undefined` reader, so a keyed store fills any key the `.env` files do not define.
+
+```ts twoslash
+import { Envapter, FileSource, merge, Converters } from 'envapt';
+// ---cut---
+declare const store: { get(key: string): string | undefined };
+Envapter.useSource(merge(new FileSource(), (key) => store.get(key)));
+
+const dbUrl = Envapter.getUsing('DATABASE_URL', Converters.Url);
+```
 
 ## When nothing is bound
 

--- a/packages/envapt/src/common.ts
+++ b/packages/envapt/src/common.ts
@@ -1,8 +1,8 @@
 export { Environment } from './engine/Envapter';
-export { Converters, isArrayOf } from './converters';
+export { Converters } from './converters';
 export { PortableSource } from './sources/PortableSource';
 export { merge } from './sources/merge';
-export type { ConverterToken, CustomElementConverter } from './converters';
+export type { CustomElementConverter } from './converters';
 export type { DebugLevel } from './infra/Debug';
 export type { EnvFileOptions } from './infra/Dotenv';
 export type { StandardSchemaV1 } from './infra/StandardSchema';
@@ -10,7 +10,6 @@ export * from './infra/Error';
 
 export type {
     ConverterFunction,
-    EnvaptConverter,
     JsonValue,
     TimeFallback,
     EnvaptOptions,

--- a/packages/envapt/src/converters/Converters.ts
+++ b/packages/envapt/src/converters/Converters.ts
@@ -13,42 +13,33 @@ const SCALAR = {
     Time: 'time'
 } as const;
 
-/**
- * String tokens for every built-in scalar converter.
- * @public
- */
 export type ConverterToken = (typeof SCALAR)[keyof typeof SCALAR];
 
 /**
  * Custom element converter for use inside {@link Converters.array}. Receives the trimmed,
  * non-empty raw string for one array slot and returns the parsed value.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/converters#custom-converters}
  */
 export type CustomElementConverter<TReturn = unknown> = (raw: string) => TReturn;
 
-// array element converters, any scalar token except json/regexp (those don't compose) or a custom function
+// json/regexp are not allowed as array elements because they consume the whole string and cannot be split into slots
 export type ArrayElement = Exclude<ConverterToken, 'json' | 'regexp'> | CustomElementConverter;
 
-// phantom-branded token from Converters.array. TElement carries the element converter through variable
-// indirection so inference survives. __envaptKind is the runtime dispatch discriminant.
+// phantom type branded with __envaptKind for runtime dispatch. TElement preserves
+// element converter type through variable indirection for type inference
 export interface ArrayOf<TElement extends ArrayElement = ArrayElement> {
     readonly __envaptKind: 'array';
     readonly of: TElement;
     readonly delimiter: string;
 }
 
-/**
- * Runtime type guard for tokens produced by {@link Converters.array}.
- * @internal
- */
 export function isArrayOf(value: unknown): value is ArrayOf {
     return typeof value === 'object' && value !== null && '__envaptKind' in value && value.__envaptKind === 'array';
 }
 
 type ArrayScalarElement = Exclude<ConverterToken, 'json' | 'regexp'>;
 
-// Overloads. The function-element overload must come first so it wins inference when `of`
-// is a function, otherwise TS picks the scalar branch and `raw` defaults to `any`.
 function buildArrayConverter<TReturn>(opts: {
     of: CustomElementConverter<TReturn>;
     delimiter?: string;
@@ -80,6 +71,7 @@ function buildArrayConverter(opts?: { of?: ArrayElement; delimiter?: string }): 
  * ```
  *
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/converters#built-in-tokens}
  */
 export const Converters = {
     ...SCALAR,

--- a/packages/envapt/src/core/AdvancedMethods.ts
+++ b/packages/envapt/src/core/AdvancedMethods.ts
@@ -49,6 +49,8 @@ export class AdvancedMethods extends PrimitiveMethods {
      * Supports both scalar tokens (e.g. `Converters.Number`) and `ArrayOf<...>` tokens
      * produced by `Converters.array(...)`. The key can be a single name or an ordered list.
      * The first defined value wins.
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#converters}
+     * @see {@link https://envapt.materwelon.dev/docs/converters#custom-converters}
      */
     // Time-specific overload must precede the generic BuiltInConverter overload so it wins
     // overload resolution (TimeFallback accepts time-strings like `'10s'`).
@@ -109,6 +111,8 @@ export class AdvancedMethods extends PrimitiveMethods {
     /**
      * Get an environment variable using a custom converter function.
      * Accepts a single key or an ordered list for automatic fallback.
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#converters}
+     * @see {@link https://envapt.materwelon.dev/docs/converters#custom-converters}
      */
     static getWith<TReturnType, TFallback extends TReturnType | undefined = undefined>(
         key: EnvKeyInput,
@@ -142,6 +146,8 @@ export class AdvancedMethods extends PrimitiveMethods {
      * Read a required environment variable and convert it, throwing `MissingEnvValue` when the value
      * is missing or empty. Returns the non-undefined converter output. Accepts a built-in or `ArrayOf`
      * token, or a custom parser function. The key can be a single name or an ordered list.
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#fail-fast-on-missing-values}
+     * @see {@link https://envapt.materwelon.dev/docs/converters#require-a-converted-value}
      */
     static getRequired<TConverter extends BuiltInConverter | ArrayOf>(
         key: EnvKeyInput,
@@ -209,6 +215,8 @@ export class AdvancedMethods extends PrimitiveMethods {
      * `MissingEnvValue` listing them all. Pass a `casing` (`'camelCase'`, `'PascalCase'`, or
      * `'kebab-case'`) to rename the record keys, splitting on underscores, which assumes the
      * conventional SCREAMING_SNAKE env-var names. With no casing the keys stay as-is.
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#fail-fast-on-missing-values}
+     * @see {@link https://envapt.materwelon.dev/docs/converters#require-a-converted-value}
      */
     static getRequiredAll<Spec extends RequiredSpec, Casing extends KeyCasing | undefined = undefined>(
         spec: Spec,
@@ -269,6 +277,7 @@ export class AdvancedMethods extends PrimitiveMethods {
      * import { z } from 'zod';
      * const port = Envapter.parse('PORT', z.coerce.number().min(1024).max(65535), 3000);
      * ```
+     * @see {@link https://envapt.materwelon.dev/docs/standard-schema#any-conformant-validator-or-none}
      */
     static parse<Schema extends StandardSchemaV1>(
         key: EnvKeyInput,

--- a/packages/envapt/src/core/EnvapterBase.ts
+++ b/packages/envapt/src/core/EnvapterBase.ts
@@ -3,6 +3,7 @@ import { cache, state } from './state';
 import { Validator } from '../engine/Validators';
 import { getDebugLevel, setDebugLevel } from '../infra/Debug';
 import { bindRuntimeFromSource } from '../infra/runtime';
+import { normalizeSource } from '../sources/normalizeSource';
 
 import type { DebugLevel } from '../infra/Debug';
 import type { EnvKeyInput, FileApiMode, Source } from '../types';
@@ -85,11 +86,13 @@ export abstract class EnvapterBase {
     /**
      * Bind the environment {@link Source}. On Node the entry binds {@link FileSource} for you
      * (a `process.env` snapshot plus the `.env` cascade). On the browser or Workers, pass a
-     * `PortableSource` (or any `Source`) before reading. Clears and rebuilds the cache.
+     * `PortableSource` (or any `Source`) before reading. Pass a `(key) => string | undefined` reader for
+     * a source that reads one key at a time and cannot list its keys. Clears and rebuilds the cache.
      */
-    static useSource(source: Source): void {
-        state.source = source;
-        bindRuntimeFromSource(source);
+    static useSource(source: Source | ((key: string) => string | undefined)): void {
+        const resolved = normalizeSource(source);
+        state.source = resolved;
+        bindRuntimeFromSource(resolved);
         refreshCache();
     }
 

--- a/packages/envapt/src/core/EnvapterBase.ts
+++ b/packages/envapt/src/core/EnvapterBase.ts
@@ -13,6 +13,7 @@ export abstract class EnvapterBase {
     /**
      * Enable or disable strict mode. Default `false`. Setting refreshes the cache so
      * previously-cached converted values get re-evaluated under the new rule.
+     * @see {@link https://envapt.materwelon.dev/docs/strict-mode#what-strict-mode-changes}
      */
     static set strict(value: boolean) {
         state.strict = value;
@@ -27,6 +28,7 @@ export abstract class EnvapterBase {
      * Set the debug log level. Defaults to `silent`. When unset, reads `ENVAPT_DEBUG` from the
      * bound source on first access. The setter overrides any env-var value. Output goes to stderr
      * on Node (the console elsewhere), prefixed with `[envapt]`.
+     * @see {@link https://envapt.materwelon.dev/docs/configuration#debug-logging}
      */
     static set debug(level: DebugLevel) {
         setDebugLevel(level);
@@ -46,6 +48,7 @@ export abstract class EnvapterBase {
      * Flipping `false → true` mirrors the existing tracked delta immediately (no cache
      * refresh). Flipping `true → false` is one-way: previously mirrored keys remain in
      * `process.env` until the process exits.
+     * @see {@link https://envapt.materwelon.dev/docs/configuration#mirroring-to-processenv}
      */
     static set syncProcessEnv(value: boolean) {
         Validator.validateSyncProcessEnv(value);
@@ -63,6 +66,7 @@ export abstract class EnvapterBase {
      * `envFileOptions`, `configureProfiles`, `resetProfiles`). `'warn'` (the default) warns once and
      * no-ops, `'throw'` throws {@link EnvaptError} `FileApiUnsupported`. The node build runs these
      * APIs normally and this value has no effect there.
+     * @see {@link https://envapt.materwelon.dev/docs/compatibility#binding-by-runtime}
      */
     static set fileApiMode(mode: FileApiMode) {
         Validator.validateFileApiMode(mode);
@@ -78,6 +82,7 @@ export abstract class EnvapterBase {
      * Eagerly load the `.env` cascade now instead of lazily on the first read. Idempotent: a no-op
      * once the cache is built. Useful before mirroring to `process.env` (see {@link syncProcessEnv}),
      * which is what the `envapt/config` side-effect entry does.
+     * @see {@link https://envapt.materwelon.dev/docs/configuration#which-files-load}
      */
     static load(): void {
         ensureLoaded();
@@ -88,6 +93,7 @@ export abstract class EnvapterBase {
      * (a `process.env` snapshot plus the `.env` cascade). On the browser or Workers, pass a
      * `PortableSource` (or any `Source`) before reading. Pass a `(key) => string | undefined` reader for
      * a source that reads one key at a time and cannot list its keys. Clears and rebuilds the cache.
+     * @see {@link https://envapt.materwelon.dev/docs/sources#the-providers}
      */
     static useSource(source: Source | ((key: string) => string | undefined)): void {
         const resolved = normalizeSource(source);
@@ -98,6 +104,7 @@ export abstract class EnvapterBase {
 
     /**
      * Read an environment variable as its raw string, skipping parsing and conversion.
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#raw-values}
      */
     getRaw(key: EnvKeyInput): string | undefined {
         return resolveKeyInput(key).value;

--- a/packages/envapt/src/core/Environment.ts
+++ b/packages/envapt/src/core/Environment.ts
@@ -8,6 +8,7 @@
  * - `MODE`
  *
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/environment#detecting-the-environment}
  */
 export enum Environment {
     /** The default when no environment variable names a known environment. */

--- a/packages/envapt/src/core/EnvironmentMethods.ts
+++ b/packages/envapt/src/core/EnvironmentMethods.ts
@@ -10,6 +10,7 @@ import { state } from './state';
 export class EnvironmentMethods extends EnvapterBase {
     /**
      * Get the current application environment
+     * @see {@link https://envapt.materwelon.dev/docs/environment#detecting-the-environment}
      */
     static get environment(): Environment {
         if (state.environment === undefined) {
@@ -20,6 +21,7 @@ export class EnvironmentMethods extends EnvapterBase {
 
     /**
      * Set the application environment. Accepts either Environment enum or string value.
+     * @see {@link https://envapt.materwelon.dev/docs/environment#detecting-the-environment}
      */
     static set environment(env: string | Environment) {
         determineEnvironment(env);
@@ -41,6 +43,7 @@ export class EnvironmentMethods extends EnvapterBase {
 
     /**
      * Check if the current environment is production
+     * @see {@link https://envapt.materwelon.dev/docs/environment#branching-on-the-environment}
      */
     static get isProduction(): boolean {
         return this.environment === Environment.Production;
@@ -55,6 +58,7 @@ export class EnvironmentMethods extends EnvapterBase {
 
     /**
      * Check if the current environment is staging
+     * @see {@link https://envapt.materwelon.dev/docs/environment#branching-on-the-environment}
      */
     static get isStaging(): boolean {
         return this.environment === Environment.Staging;
@@ -69,6 +73,7 @@ export class EnvironmentMethods extends EnvapterBase {
 
     /**
      * Check if the current environment is development
+     * @see {@link https://envapt.materwelon.dev/docs/environment#branching-on-the-environment}
      */
     static get isDevelopment(): boolean {
         return this.environment === Environment.Development;
@@ -83,6 +88,7 @@ export class EnvironmentMethods extends EnvapterBase {
 
     /**
      * Check if the current environment is test
+     * @see {@link https://envapt.materwelon.dev/docs/environment#branching-on-the-environment}
      */
     static get isTest(): boolean {
         return this.environment === Environment.Test;

--- a/packages/envapt/src/core/PrimitiveMethods.ts
+++ b/packages/envapt/src/core/PrimitiveMethods.ts
@@ -11,6 +11,7 @@ export class PrimitiveMethods extends EnvironmentMethods {
      * Get a string environment variable with optional fallback.
      * Supports template variable resolution using `${VAR}` syntax.
      * Accepts a single key or an ordered array of keys (first match wins).
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#primitives}
      */
     static get<Default extends string | undefined = undefined>(
         key: EnvKeyInput,
@@ -33,6 +34,7 @@ export class PrimitiveMethods extends EnvironmentMethods {
      * Get a number environment variable with optional fallback.
      * Automatically converts string values to numbers.
      * Accepts a single key or an ordered array of keys (first match wins).
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#primitives}
      */
     static getNumber<Default extends number | undefined = undefined>(
         key: EnvKeyInput,
@@ -55,6 +57,7 @@ export class PrimitiveMethods extends EnvironmentMethods {
      * Get a boolean environment variable with optional fallback.
      * Recognizes: `1`, `yes`, `true`, `on` as **true**; `0`, `no`, `false`, `off` as **false** (case-insensitive).
      * Accepts a single key or an ordered array of keys (first match wins).
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#primitives}
      */
     static getBoolean<Default extends boolean | undefined = undefined>(
         key: EnvKeyInput,
@@ -77,6 +80,7 @@ export class PrimitiveMethods extends EnvironmentMethods {
      * Get a bigint environment variable with optional fallback.
      * Automatically converts string values to bigint.
      * Accepts a single key or an ordered array of keys (first match wins).
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#primitives}
      */
     static getBigInt<Default extends bigint | undefined = undefined>(
         key: EnvKeyInput,
@@ -99,6 +103,7 @@ export class PrimitiveMethods extends EnvironmentMethods {
      * Get a symbol environment variable with optional fallback.
      * Creates a symbol from the string value.
      * Accepts a single key or an ordered array of keys (first match wins).
+     * @see {@link https://envapt.materwelon.dev/docs/envapter#primitives}
      */
     static getSymbol<Default extends symbol | undefined = undefined>(
         key: EnvKeyInput,

--- a/packages/envapt/src/core/engine.ts
+++ b/packages/envapt/src/core/engine.ts
@@ -27,7 +27,7 @@ export function resolveKeyInput(keyInput: EnvKeyInput): { key: string; value: st
     }
 
     for (const candidate of normalizedKeys) {
-        const value = ensureLoaded().get(candidate) as string | undefined;
+        const value = readCached(candidate);
         if (value !== undefined) return { key: candidate, value };
     }
 
@@ -76,6 +76,17 @@ export function ensureLoaded(): Map<string, unknown> {
     return cache;
 }
 
+function readCached(key: string): string | undefined {
+    const c = ensureLoaded();
+    if (c.has(key)) return c.get(key) as string | undefined;
+    const source = state.source;
+    if (typeof source.readVar !== 'function') return undefined;
+    const value = source.readVar(key);
+    // cache a miss too, so a later read of an absent key skips the reader
+    c.set(key, value);
+    return value;
+}
+
 export function refreshCache(): void {
     // Reset an inferred environment so re-hydration re-determines it from current state. An explicit
     // Envapter.environment = X is preserved through the refresh and used for cascade selection.
@@ -120,10 +131,7 @@ export function determineEnvironment(env?: string | Environment): void {
         return;
     }
 
-    const raw = firstEnvKeyValue((key) => {
-        const value = ensureLoaded().get(key);
-        return typeof value === 'string' ? value : undefined;
-    });
+    const raw = firstEnvKeyValue((key) => readCached(key));
     if (raw === undefined) {
         debugWarn(`no environment set (looked for ${ENV_KEYS.join(', ')}); defaulting to development`);
         state.environment = Environment.Development;

--- a/packages/envapt/src/core/engine.ts
+++ b/packages/envapt/src/core/engine.ts
@@ -78,7 +78,11 @@ export function ensureLoaded(): Map<string, unknown> {
 
 function readCached(key: string): string | undefined {
     const c = ensureLoaded();
-    if (c.has(key)) return c.get(key) as string | undefined;
+    // decorator memoization also stores non-string values in this shared cache
+    if (c.has(key)) {
+        const cached = c.get(key);
+        return typeof cached === 'string' ? cached : undefined;
+    }
     const source = state.source;
     if (typeof source.readVar !== 'function') return undefined;
     const value = source.readVar(key);

--- a/packages/envapt/src/core/paths.ts
+++ b/packages/envapt/src/core/paths.ts
@@ -52,13 +52,13 @@ function normalizeProfilePaths(profile: EnvProfile | undefined): string[] {
     return Array.isArray(profile.paths) ? profile.paths : [profile.paths];
 }
 
-// Reads the source's raw vars, not the cache, because cascade selection runs before the `.env` load.
-// `Envapter.environment` may differ post-load if a file sets `ENVIRONMENT`.
+// the cache is not built yet here, so read the reader directly (readCached would re-enter this build)
 function getCascadeEnvironment(): Environment {
     if (state.environment !== undefined) return state.environment;
 
-    const vars = state.source.readVars();
-    const raw = firstEnvKeyValue((key) => vars[key]);
+    const source = state.source;
+    const vars = source.readVars();
+    const raw = firstEnvKeyValue((key) => vars[key] ?? source.readVar?.(key));
     return raw === undefined ? Environment.Development : (parseEnvironment(raw) ?? Environment.Development);
 }
 

--- a/packages/envapt/src/decorators/legacy/Envapt.ts
+++ b/packages/envapt/src/decorators/legacy/Envapt.ts
@@ -219,6 +219,7 @@ export function Envapt<Schema extends StandardSchemaV1>(
 
 /**
  * Instance or static property decorator that loads and converts an environment variable.
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#declaring-decorated-fields}
  */
 export function Envapt<TFallback = unknown>(key: EnvKeyInput, options?: unknown): EnvaptFieldDecorator<unknown> {
     return createPropertyDecorator(key, parseEnvaptOptions<TFallback>(options)) as EnvaptFieldDecorator<unknown>;

--- a/packages/envapt/src/decorators/legacy/SugarDecorators.ts
+++ b/packages/envapt/src/decorators/legacy/SugarDecorators.ts
@@ -23,6 +23,7 @@ function sugar<TFallback>(
 /**
  * Shorthand for `@Envapt(key, { converter: Converters.Boolean, fallback })`.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvBool(key: EnvKeyInput, fallback: boolean): EnvaptFieldDecorator<boolean>;
 export function EnvBool(key: EnvKeyInput): EnvaptFieldDecorator<boolean | null>;
@@ -33,6 +34,7 @@ export function EnvBool(key: EnvKeyInput, fallback?: boolean): EnvaptFieldDecora
 /**
  * Shorthand for `@Envapt(key, { converter: Converters.Number, fallback })`.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvNum(key: EnvKeyInput, fallback: number): EnvaptFieldDecorator<number>;
 export function EnvNum(key: EnvKeyInput): EnvaptFieldDecorator<number | null>;
@@ -43,6 +45,7 @@ export function EnvNum(key: EnvKeyInput, fallback?: number): EnvaptFieldDecorato
 /**
  * Shorthand for `@Envapt(key, { converter: Converters.String, fallback })`.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvStr(key: EnvKeyInput, fallback: string): EnvaptFieldDecorator<string>;
 export function EnvStr(key: EnvKeyInput): EnvaptFieldDecorator<string | null>;
@@ -54,6 +57,7 @@ export function EnvStr(key: EnvKeyInput, fallback?: string): EnvaptFieldDecorato
  * Shorthand for `@Envapt(key, { converter: Converters.Time, fallback })`. The fallback is a
  * millisecond number or a time string (`'15m'`), and the resolved value is always milliseconds.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvTime(key: EnvKeyInput, fallback: TimeFallback): EnvaptFieldDecorator<number>;
 export function EnvTime(key: EnvKeyInput): EnvaptFieldDecorator<number | null>;
@@ -65,6 +69,7 @@ export function EnvTime(key: EnvKeyInput, fallback?: TimeFallback): EnvaptFieldD
  * Shorthand for `@Envapt(key, { converter: Converters.Url, fallback })`. The fallback is a `URL`
  * instance, not a URL string.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvUrl(key: EnvKeyInput, fallback: URL): EnvaptFieldDecorator<URL>;
 export function EnvUrl(key: EnvKeyInput): EnvaptFieldDecorator<URL | null>;

--- a/packages/envapt/src/decorators/modern/Envapt.ts
+++ b/packages/envapt/src/decorators/modern/Envapt.ts
@@ -237,6 +237,7 @@ export function Envapt<Schema extends StandardSchemaV1>(
  *   accessor databaseUrl!: URL;
  * }
  * ```
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#declaring-decorated-fields}
  */
 /* v8 ignore start -- @preserve oxc (vitest's transform) breaks modern accessor decorators (context.name unset), so the tsc stage3-emit harness covers these, not vitest */
 export function Envapt<TFallback = unknown>(key: EnvKeyInput, options?: unknown): EnvaptAccessorDecorator<unknown> {

--- a/packages/envapt/src/decorators/modern/SugarDecorators.ts
+++ b/packages/envapt/src/decorators/modern/SugarDecorators.ts
@@ -24,6 +24,7 @@ function sugar<TFallback>(
 /**
  * Shorthand for `@Envapt(key, { converter: Converters.Boolean, fallback })`.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvBool(key: EnvKeyInput, fallback: boolean): EnvaptAccessorDecorator<boolean>;
 export function EnvBool(key: EnvKeyInput): EnvaptAccessorDecorator<boolean | null>;
@@ -34,6 +35,7 @@ export function EnvBool(key: EnvKeyInput, fallback?: boolean): EnvaptAccessorDec
 /**
  * Shorthand for `@Envapt(key, { converter: Converters.Number, fallback })`.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvNum(key: EnvKeyInput, fallback: number): EnvaptAccessorDecorator<number>;
 export function EnvNum(key: EnvKeyInput): EnvaptAccessorDecorator<number | null>;
@@ -44,6 +46,7 @@ export function EnvNum(key: EnvKeyInput, fallback?: number): EnvaptAccessorDecor
 /**
  * Shorthand for `@Envapt(key, { converter: Converters.String, fallback })`.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvStr(key: EnvKeyInput, fallback: string): EnvaptAccessorDecorator<string>;
 export function EnvStr(key: EnvKeyInput): EnvaptAccessorDecorator<string | null>;
@@ -55,6 +58,7 @@ export function EnvStr(key: EnvKeyInput, fallback?: string): EnvaptAccessorDecor
  * Shorthand for `@Envapt(key, { converter: Converters.Time, fallback })`. The fallback is a
  * millisecond number or a time string (`'15m'`), and the resolved value is always milliseconds.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvTime(key: EnvKeyInput, fallback: TimeFallback): EnvaptAccessorDecorator<number>;
 export function EnvTime(key: EnvKeyInput): EnvaptAccessorDecorator<number | null>;
@@ -66,6 +70,7 @@ export function EnvTime(key: EnvKeyInput, fallback?: TimeFallback): EnvaptAccess
  * Shorthand for `@Envapt(key, { converter: Converters.Url, fallback })`. The fallback is a `URL`
  * instance, not a URL string.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvUrl(key: EnvKeyInput, fallback: URL): EnvaptAccessorDecorator<URL>;
 export function EnvUrl(key: EnvKeyInput): EnvaptAccessorDecorator<URL | null>;

--- a/packages/envapt/src/engine/Envapter.ts
+++ b/packages/envapt/src/engine/Envapter.ts
@@ -43,6 +43,7 @@ export class Envapter extends AdvancedMethods {
      * const message = Envapter.resolve`Service endpoint: ${'API_URL'}`;
      * // Returns: "Service endpoint: https://api.example.com:8080"
      * ```
+     * @see {@link https://envapt.materwelon.dev/docs/templates#the-resolve-tagged-template}
      */
     static resolve(strings: TemplateStringsArray, ...keys: string[]): string {
         const strict = Envapter.strict;

--- a/packages/envapt/src/engine/NodeEnvapter.ts
+++ b/packages/envapt/src/engine/NodeEnvapter.ts
@@ -33,6 +33,7 @@ export class NodeEnvapter extends Envapter {
      *
      * When set, this takes absolute precedence. The dotenv-flow auto-cascade and any
      * `Envapter.configureProfiles` configuration are ignored.
+     * @see {@link https://envapt.materwelon.dev/docs/configuration#which-files-load}
      */
     static set envPaths(paths: string[] | string) {
         assertFileApiSupported('envPaths', state.source);
@@ -49,6 +50,7 @@ export class NodeEnvapter extends Envapter {
 
     /**
      * Get currently configured .env file paths
+     * @see {@link https://envapt.materwelon.dev/docs/configuration#which-files-load}
      */
     static get envPaths(): string[] {
         return state.envPaths;
@@ -63,6 +65,7 @@ export class NodeEnvapter extends Envapter {
      *
      * Set this before `envPaths` so relative `envPaths` validate against the right directory.
      * Unset (`undefined`) restores `process.cwd()` resolution.
+     * @see {@link https://envapt.materwelon.dev/docs/configuration#reading-from-a-fixed-directory}
      */
     static set baseDir(value: string | URL | undefined) {
         const source = state.source;
@@ -71,12 +74,18 @@ export class NodeEnvapter extends Envapter {
         refreshCache();
     }
 
-    /** The configured base directory, or `undefined` when relative paths resolve against the working directory. */
+    /**
+     * The configured base directory, or `undefined` when relative paths resolve against the working directory.
+     * @see {@link https://envapt.materwelon.dev/docs/configuration#reading-from-a-fixed-directory}
+     */
     static get baseDir(): string | undefined {
         return state.baseDir;
     }
 
-    /** Set the env file loader options (`encoding`, `override`). Refreshes the cache. */
+    /**
+     * Set the env file loader options (`encoding`, `override`). Refreshes the cache.
+     * @see {@link https://envapt.materwelon.dev/docs/configuration#which-files-load}
+     */
     static set envFileOptions(config: EnvFileOptions) {
         Validator.validateEnvFileOptions(config);
         state.userDefinedEnvFileOptions = config;
@@ -85,6 +94,7 @@ export class NodeEnvapter extends Envapter {
 
     /**
      * Get current env file loader options
+     * @see {@link https://envapt.materwelon.dev/docs/configuration#which-files-load}
      */
     static get envFileOptions(): EnvFileOptions {
         return state.userDefinedEnvFileOptions;
@@ -106,6 +116,7 @@ export class NodeEnvapter extends Envapter {
      *   [Environment.Production]: { paths: ['config/prod.env', 'secrets/prod.env'] }
      * });
      * ```
+     * @see {@link https://envapt.materwelon.dev/docs/environment#custom-profiles}
      */
     static configureProfiles(config: ProfilesConfig): void {
         assertFileApiSupported('configureProfiles', state.source);
@@ -117,6 +128,7 @@ export class NodeEnvapter extends Envapter {
      * Reset all path-resolution configuration to defaults: clears any prior
      * `Envapter.configureProfiles` call AND any explicit `Envapter.envPaths` assignment.
      * Returns the resolver to the pure dotenv-flow cascade.
+     * @see {@link https://envapt.materwelon.dev/docs/environment#custom-profiles}
      */
     static resetProfiles(): void {
         state.profiles = undefined;

--- a/packages/envapt/src/infra/Debug.ts
+++ b/packages/envapt/src/infra/Debug.ts
@@ -8,6 +8,7 @@ import { readRuntimeEnv, writeRuntimeLine } from './runtime';
  * (whether it returns a fallback or `undefined`). `verbose` adds every loaded file,
  * per-file key count, per-key load lines, and effective-paths / cache-rebuild notices.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/configuration#debug-logging}
  */
 export type DebugLevel = 'silent' | 'warn' | 'verbose';
 

--- a/packages/envapt/src/infra/Debug.ts
+++ b/packages/envapt/src/infra/Debug.ts
@@ -1,5 +1,5 @@
 import { EnvaptError, EnvaptErrorCodes } from './Error';
-import { readRuntimeEnv, writeRuntimeLine } from './runtime';
+import { readRuntimeVar, writeRuntimeLine } from './runtime';
 
 /**
  * Debug log levels for {@link Envapter.debug}. `silent` (default) emits nothing.
@@ -24,7 +24,7 @@ function isDebugLevel(value: string | undefined): value is DebugLevel {
 // Reads `ENVAPT_DEBUG` lazily on first access. Setter wins after that.
 function resolveLevel(): DebugLevel {
     if (!initialized) {
-        const fromEnv = readRuntimeEnv().ENVAPT_DEBUG;
+        const fromEnv = readRuntimeVar('ENVAPT_DEBUG');
         currentLevel = isDebugLevel(fromEnv) ? fromEnv : 'silent';
         initialized = true;
     }

--- a/packages/envapt/src/infra/Dotenv.ts
+++ b/packages/envapt/src/infra/Dotenv.ts
@@ -6,6 +6,7 @@ import { debugVerbose, debugWarn } from './Debug';
  * For debug output, use `Envapter.debug` (or the `ENVAPT_DEBUG` env var).
  *
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/configuration#which-files-load}
  */
 export interface EnvFileOptions {
     /** Encoding for reading .env files. Defaults to 'utf8'. */

--- a/packages/envapt/src/infra/Error.ts
+++ b/packages/envapt/src/infra/Error.ts
@@ -4,6 +4,7 @@ import type { StandardSchemaV1 } from './StandardSchema';
 /**
  * Numeric codes carried by {@link EnvaptError.code}, grouped by fallback (1xx), converter (2xx),
  * and configuration (3xx) failures.
+ * @see {@link https://envapt.materwelon.dev/docs/errors#codes}
  */
 export enum EnvaptErrorCodes {
     // Fallback related errors
@@ -70,6 +71,7 @@ interface EnvaptErrorOptions {
  * ```ts
  * throw new EnvaptError(EnvaptErrorCodes.InvalidFallback, "Invalid fallback value provided for environment variable.");
  * ```
+ * @see {@link https://envapt.materwelon.dev/docs/errors#the-error-shape}
  */
 export class EnvaptError extends Error {
     /** The {@link EnvaptErrorCodes} value identifying what failed. */

--- a/packages/envapt/src/infra/StandardSchema.ts
+++ b/packages/envapt/src/infra/StandardSchema.ts
@@ -8,6 +8,7 @@
  * `SchemaMustBeSync` brand in `Types.ts`) and at runtime by the Parser dispatch.
  *
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/standard-schema#any-conformant-validator-or-none}
  */
 export interface StandardSchemaV1<Input = unknown, Output = Input> {
     /** The Standard Schema entry point holding the validator and the inferred input/output types. */

--- a/packages/envapt/src/infra/runtime.ts
+++ b/packages/envapt/src/infra/runtime.ts
@@ -1,12 +1,13 @@
 import type { Source } from '../types';
 
 // importing Debug back into EnvapterBase would cycle, so the source and sink are injected via the setters below.
-/* v8 ignore start -- @preserve replaced at load on Node, so the Node suite never runs these defaults */
+/* v8 ignore start -- @preserve replaced at load on Node so the Node suite never runs these defaults */
 let sink: (line: string) => void = (line) => {
     // eslint-disable-next-line no-console -- the off-Node fallback log sink
     console.error(line);
 };
 let envReader: () => Record<string, string> = () => ({});
+let varReader: ((key: string) => string | undefined) | undefined;
 /* v8 ignore stop */
 
 export function setRuntimeSink(fn: (line: string) => void): void {
@@ -17,10 +18,13 @@ export function writeRuntimeLine(line: string): void {
     sink(line);
 }
 
-export function readRuntimeEnv(): Record<string, string> {
-    return envReader();
+// check snapshot first, then the source's per-key reader, so a reader source (empty snapshot) still resolves a key
+export function readRuntimeVar(key: string): string | undefined {
+    return envReader()[key] ?? varReader?.(key);
 }
 
 export function bindRuntimeFromSource(source: Source): void {
     envReader = (): Record<string, string> => source.readVars();
+    const readVar = source.readVar;
+    varReader = typeof readVar === 'function' ? readVar.bind(source) : undefined;
 }

--- a/packages/envapt/src/infra/runtime.ts
+++ b/packages/envapt/src/infra/runtime.ts
@@ -20,7 +20,14 @@ export function writeRuntimeLine(line: string): void {
 
 // check snapshot first, then the source's per-key reader, so a reader source (empty snapshot) still resolves a key
 export function readRuntimeVar(key: string): string | undefined {
-    return envReader()[key] ?? varReader?.(key);
+    const fromSnapshot = envReader()[key];
+    if (fromSnapshot !== undefined) return fromSnapshot;
+    // ENVAPT_DEBUG resolves through here, so a throwing reader must not abort the config load that triggered it
+    try {
+        return varReader?.(key);
+    } catch {
+        return undefined;
+    }
 }
 
 export function bindRuntimeFromSource(source: Source): void {

--- a/packages/envapt/src/sources/FileSource.ts
+++ b/packages/envapt/src/sources/FileSource.ts
@@ -10,6 +10,7 @@ import type { FileCapableSource } from '../types';
  * `supportsFiles` is `true`, so the engine also layers the `.env` cascade on top, resolves
  * `baseDir`, and can mirror loaded keys back to `process.env`.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/sources#the-providers}
  */
 export class FileSource implements FileCapableSource {
     /** Always `true`. The engine layers the `.env` cascade and `baseDir` on top of `process.env`. */

--- a/packages/envapt/src/sources/PortableSource.ts
+++ b/packages/envapt/src/sources/PortableSource.ts
@@ -10,6 +10,7 @@ import type { BareSource } from '../types';
  * still apply, which means they must be JSON-serializable. Without a filesystem the `.env` cascade and
  * file APIs do not apply.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/sources#the-providers}
  */
 export class PortableSource implements BareSource {
     /** Always `false`. With no filesystem, the `.env` cascade and file APIs do not apply. */

--- a/packages/envapt/src/sources/merge.ts
+++ b/packages/envapt/src/sources/merge.ts
@@ -1,19 +1,24 @@
+import { normalizeSource } from './normalizeSource';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
-import type { FileCapableSource, Source } from '../types';
+import type { BareSource, FileCapableSource, Source } from '../types';
 
 /**
- * Compose several sources into one, read last-wins. A later member's value overrides an earlier
- * member's value for the same key. Bind the result with `Envapter.useSource`. Throws
- * {@link EnvaptErrorCodes.InvalidMergedSource} with no members or with more than one file-backed member.
+ * Compose several sources into one, read last-wins. A later member's `readVars()` value overrides an
+ * earlier member's for the same key. A member may be a `(key) => string | undefined` reader for a
+ * source that reads one key at a time, and it fills a key missing from every snapshot. Bind the result
+ * with `Envapter.useSource`. Throws {@link EnvaptErrorCodes.InvalidMergedSource} with no members or with
+ * more than one file-backed member.
  * @public
  */
-export function merge(...members: Source[]): Source {
+export function merge(...members: (Source | ((key: string) => string | undefined))[]): Source {
     if (members.length === 0) {
         throw new EnvaptError(EnvaptErrorCodes.InvalidMergedSource, 'merge requires at least one source.');
     }
 
-    const fileMembers = members.filter((m): m is FileCapableSource => m.supportsFiles === true);
+    const sources = members.map(normalizeSource);
+
+    const fileMembers = sources.filter((m): m is FileCapableSource => m.supportsFiles === true);
     if (fileMembers.length > 1) {
         throw new EnvaptError(
             EnvaptErrorCodes.InvalidMergedSource,
@@ -23,12 +28,31 @@ export function merge(...members: Source[]): Source {
 
     const readVars = (): Record<string, string> => {
         const merged: Record<string, string> = {};
-        for (const m of members) Object.assign(merged, m.readVars());
+        for (const m of sources) Object.assign(merged, m.readVars());
         return merged;
     };
 
+    const readers = sources.filter(
+        (m): m is Source & { readVar: (key: string) => string | undefined } => typeof m.readVar === 'function'
+    );
+    const readVar =
+        readers.length === 0
+            ? undefined
+            : (key: string): string | undefined => {
+                  let value: string | undefined;
+                  for (const m of readers) {
+                      const found = m.readVar(key);
+                      if (found !== undefined) value = found;
+                  }
+                  return value;
+              };
+
     const fileMember = fileMembers[0];
-    if (!fileMember) return { readVars };
+    if (!fileMember) {
+        const bare: BareSource = { readVars };
+        if (readVar) bare.readVar = readVar;
+        return bare;
+    }
 
     const fileCapable: FileCapableSource = {
         readVars,
@@ -38,5 +62,6 @@ export function merge(...members: Source[]): Source {
         normalizeBaseDir: (value) => fileMember.normalizeBaseDir(value),
         writeVars: (vars) => fileMember.writeVars(vars)
     };
+    if (readVar) fileCapable.readVar = readVar;
     return fileCapable;
 }

--- a/packages/envapt/src/sources/merge.ts
+++ b/packages/envapt/src/sources/merge.ts
@@ -40,12 +40,12 @@ export function merge(...members: (Source | ((key: string) => string | undefined
         readers.length === 0
             ? undefined
             : (key: string): string | undefined => {
-                  let value: string | undefined;
-                  for (const m of readers) {
-                      const found = m.readVar(key);
-                      if (found !== undefined) value = found;
+                  // last reader that answers wins, so scan from the end and return the first defined value
+                  for (let i = readers.length - 1; i >= 0; i--) {
+                      const found = readers[i]?.readVar(key);
+                      if (found !== undefined) return found;
                   }
-                  return value;
+                  return undefined;
               };
 
     const fileMember = fileMembers[0];

--- a/packages/envapt/src/sources/merge.ts
+++ b/packages/envapt/src/sources/merge.ts
@@ -10,6 +10,7 @@ import type { BareSource, FileCapableSource, Source } from '../types';
  * with `Envapter.useSource`. Throws {@link EnvaptErrorCodes.InvalidMergedSource} with no members or with
  * more than one file-backed member.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/sources#combining-sources}
  */
 export function merge(...members: (Source | ((key: string) => string | undefined))[]): Source {
     if (members.length === 0) {

--- a/packages/envapt/src/sources/normalizeSource.ts
+++ b/packages/envapt/src/sources/normalizeSource.ts
@@ -1,0 +1,5 @@
+import type { Source } from '../types';
+
+export function normalizeSource(source: Source | ((key: string) => string | undefined)): Source {
+    return typeof source === 'function' ? { supportsFiles: false, readVars: () => ({}), readVar: source } : source;
+}

--- a/packages/envapt/src/types/Conversion.ts
+++ b/packages/envapt/src/types/Conversion.ts
@@ -14,17 +14,13 @@ type BaseInput = string | undefined;
  * @param fallback - Fallback value when parsing is skipped
  * @returns Parsed value of type `TFallback`
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/converters#custom-converters}
  */
 type ConverterFunction<TFallback = unknown, TRaw extends BaseInput = BaseInput> = (
     raw: TRaw,
     fallback?: TFallback
 ) => TFallback;
 
-/**
- * Environment variable converter: a primitive constructor, a built-in scalar token, an `ArrayOf<...>`
- * produced by {@link Converters.array}, or a custom parser function.
- * @public
- */
 type EnvaptConverter<TFallback> = PrimitiveConstructor | BuiltInConverter | ArrayOf | ConverterFunction<TFallback>;
 
 type JsonPrimitive = string | number | boolean | null;
@@ -36,6 +32,7 @@ interface JsonObject {
 /**
  * JSON value types for custom converters
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/converters#json}
  */
 type JsonValue = JsonPrimitive | JsonArray | JsonObject;
 
@@ -73,6 +70,7 @@ type TimeUnit = 'ms' | 's' | 'm' | 'h' | 'd' | 'w';
 /**
  * Fallback type for time duration conversions
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/converters#time-and-durations}
  */
 type TimeFallback = number | `${number}${TimeUnit}`;
 

--- a/packages/envapt/src/types/Options.ts
+++ b/packages/envapt/src/types/Options.ts
@@ -5,6 +5,7 @@ import type { Environment } from '../core/Environment';
  * Options for the \@Envapt decorator (modern API). `required: true` is mutually exclusive
  * with `fallback`; see the per-converter overloads in `Envapt.ts` for the type-level mutex.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/decorators#declaring-decorated-fields}
  */
 interface EnvaptOptions<TFallback = string> {
     /** Value returned when the variable is missing or empty. Mutually exclusive with `required: true`. */
@@ -18,6 +19,7 @@ interface EnvaptOptions<TFallback = string> {
 /**
  * Per-environment profile entry passed to `Envapter.configureProfiles`.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/environment#custom-profiles}
  */
 interface EnvProfile {
     /** One or more `.env` paths to load for this environment. Order matters: earlier paths take precedence. */
@@ -29,6 +31,7 @@ interface EnvProfile {
  * profile override. Unspecified environments fall through to the default cascade behavior
  * (`.env.${env}.local`, `.env.local`, `.env.${env}`, `.env`).
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/environment#custom-profiles}
  */
 type ProfilesConfig = Partial<Record<Environment, EnvProfile>> & {
     /**
@@ -44,6 +47,7 @@ type ProfilesConfig = Partial<Record<Environment, EnvProfile>> & {
  * warns once and no-ops, `'throw'` throws `FileApiUnsupported`. The node build runs these APIs
  * normally and is unaffected by this value.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/compatibility#binding-by-runtime}
  */
 type FileApiMode = 'warn' | 'throw';
 

--- a/packages/envapt/src/types/Source.ts
+++ b/packages/envapt/src/types/Source.ts
@@ -2,6 +2,7 @@
 interface BareSource {
     readVars(): Record<string, string>;
     readonly supportsFiles?: false;
+    readVar?(key: string): string | undefined;
 }
 
 // a filesystem-backed source. supportsFiles true unlocks the .env cascade and baseDir. FileSource implements it.
@@ -12,6 +13,7 @@ interface FileCapableSource {
     resolvePath(baseDir: string, candidate: string): string;
     normalizeBaseDir(value: string | URL): string;
     writeVars(vars: Record<string, string>): void;
+    readVar?(key: string): string | undefined;
 }
 
 /**

--- a/packages/envapt/src/types/Source.ts
+++ b/packages/envapt/src/types/Source.ts
@@ -22,6 +22,7 @@ interface FileCapableSource {
  * environment (an injected object on the browser, the Cloudflare `env` binding on Workers). Bind one
  * with `Envapter.useSource`.
  * @public
+ * @see {@link https://envapt.materwelon.dev/docs/sources#any-object-can-be-a-source}
  */
 type Source = BareSource | FileCapableSource;
 

--- a/packages/envapt/tests/.env.042-prod
+++ b/packages/envapt/tests/.env.042-prod
@@ -1,0 +1,1 @@
+READER_CASCADE_FOO=prod

--- a/packages/envapt/tests/042-reader-source.test.ts
+++ b/packages/envapt/tests/042-reader-source.test.ts
@@ -97,4 +97,18 @@ describe('a reader source reads one key at a time', () => {
 
         expect(Envapter.debug).to.equal('verbose');
     });
+
+    it('swallows a throwing reader during the debug probe instead of aborting the load', () => {
+        resetDebugForTesting();
+
+        expect(() =>
+            Envapter.useSource((key) => {
+                if (key === 'ENVAPT_DEBUG') throw new Error('reader unavailable');
+                return key === 'PORT' ? '8080' : undefined;
+            })
+        ).to.not.throw();
+
+        expect(Envapter.getNumber('PORT')).to.equal(8080);
+        expect(Envapter.debug).to.equal('silent');
+    });
 });

--- a/packages/envapt/tests/042-reader-source.test.ts
+++ b/packages/envapt/tests/042-reader-source.test.ts
@@ -72,6 +72,17 @@ describe('a reader source reads one key at a time', () => {
         expect(Envapter.get('ONLY_B')).to.equal('b');
     });
 
+    it('returns a miss from a merge when no reader answers the key', () => {
+        Envapter.useSource(
+            merge(
+                (key) => (key === 'ONLY_A' ? 'a' : undefined),
+                (key) => (key === 'ONLY_B' ? 'b' : undefined)
+            )
+        );
+
+        expect(Envapter.get('UNANSWERED', 'fallback')).to.equal('fallback');
+    });
+
     it('selects the cascade environment from a reader member of a file merge', () => {
         Envapter.useSource(merge(new FileSource(), (key) => (key === 'ENVIRONMENT' ? 'production' : undefined)));
         Envapter.baseDir = import.meta.dirname;

--- a/packages/envapt/tests/042-reader-source.test.ts
+++ b/packages/envapt/tests/042-reader-source.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { Converters, Environment, Envapter, FileSource, merge, PortableSource } from '../src';
+
+describe('a reader source reads one key at a time', () => {
+    afterEach(() => {
+        Envapter.useSource(new FileSource());
+        Envapter.baseDir = undefined;
+        Envapter.resetProfiles();
+    });
+
+    it('binds a reader function and reads a key through it', () => {
+        Envapter.useSource((key) => (key === 'PORT' ? '8080' : undefined));
+
+        expect(Envapter.getNumber('PORT')).to.equal(8080);
+    });
+
+    it('reads each key once and negative-caches a miss', () => {
+        const calls: string[] = [];
+        Envapter.useSource((key) => {
+            calls.push(key);
+            return key === 'HIT' ? 'yes' : undefined;
+        });
+
+        expect(Envapter.get('HIT')).to.equal('yes');
+        expect(Envapter.get('HIT')).to.equal('yes');
+        expect(Envapter.get('MISS', 'fallback')).to.equal('fallback');
+        expect(Envapter.get('MISS', 'fallback')).to.equal('fallback');
+
+        expect(calls).to.deep.equal(['HIT', 'MISS']);
+    });
+
+    it('reads a required value through a reader', () => {
+        Envapter.useSource((key) => (key === 'ORIGIN_URL' ? 'https://origin.test' : undefined));
+
+        expect(Envapter.getRequired('ORIGIN_URL', Converters.Url).href).to.equal('https://origin.test/');
+    });
+
+    it('detects the environment from a reader', () => {
+        Envapter.useSource((key) => (key === 'NODE_ENV' ? 'production' : undefined));
+
+        expect(Envapter.environment).to.equal(Environment.Production);
+    });
+
+    it('fills a gap from a reader member of a merge, and the snapshot beats the reader for a shared key', () => {
+        Envapter.useSource(
+            merge(new PortableSource({ SHARED: 'snapshot' }), (key) =>
+                key === 'SHARED' ? 'reader' : key === 'READER_ONLY' ? 'from-reader' : undefined
+            )
+        );
+
+        expect(Envapter.get('SHARED')).to.equal('snapshot');
+        expect(Envapter.get('READER_ONLY')).to.equal('from-reader');
+    });
+
+    it('picks the last reader that answers among several reader members', () => {
+        Envapter.useSource(
+            merge(
+                (key) => (key === 'SHARED' ? 'first' : key === 'ONLY_A' ? 'a' : undefined),
+                (key) => (key === 'SHARED' ? 'second' : key === 'ONLY_B' ? 'b' : undefined)
+            )
+        );
+
+        expect(Envapter.get('SHARED')).to.equal('second');
+        expect(Envapter.get('ONLY_A')).to.equal('a');
+        expect(Envapter.get('ONLY_B')).to.equal('b');
+    });
+
+    it('selects the cascade environment from a reader member of a file merge', () => {
+        Envapter.useSource(merge(new FileSource(), (key) => (key === 'ENVIRONMENT' ? 'production' : undefined)));
+        Envapter.baseDir = import.meta.dirname;
+        Envapter.configureProfiles({ [Environment.Production]: { paths: '.env.042-prod' } });
+
+        expect(Envapter.get('READER_CASCADE_FOO')).to.equal('prod');
+    });
+});

--- a/packages/envapt/tests/042-reader-source.test.ts
+++ b/packages/envapt/tests/042-reader-source.test.ts
@@ -1,12 +1,18 @@
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { Converters, Environment, Envapter, FileSource, merge, PortableSource } from '../src';
+import { resetDebugForTesting } from '../src/infra/Debug';
 
 describe('a reader source reads one key at a time', () => {
     afterEach(() => {
         Envapter.useSource(new FileSource());
         Envapter.baseDir = undefined;
         Envapter.resetProfiles();
+    });
+
+    // resolve the debug level once up front so its one-time ENVAPT_DEBUG probe never ends up on a tracked reader
+    beforeEach(() => {
+        void Envapter.debug;
     });
 
     it('binds a reader function and reads a key through it', () => {
@@ -72,5 +78,12 @@ describe('a reader source reads one key at a time', () => {
         Envapter.configureProfiles({ [Environment.Production]: { paths: '.env.042-prod' } });
 
         expect(Envapter.get('READER_CASCADE_FOO')).to.equal('prod');
+    });
+
+    it('reads ENVAPT_DEBUG through a reader source', () => {
+        resetDebugForTesting();
+        Envapter.useSource((key) => (key === 'ENVAPT_DEBUG' ? 'verbose' : undefined));
+
+        expect(Envapter.debug).to.equal('verbose');
     });
 });

--- a/skills/envapt/SKILL.md
+++ b/skills/envapt/SKILL.md
@@ -121,6 +121,10 @@ envapt reads through a pluggable `Source`, and the build you import binds the ri
 
 `PortableSource` snapshots the object and JSON-stringifies non-string values, so you pass the runtime's object straight through. Any object with a `readVars(): Record<string, string>` method is a valid `Source`.
 
+For a source that reads one key at a time and cannot list its keys, pass a `(key) => string | undefined` reader to `useSource`, and envapt calls it per key on the first read, caching the result.
+
+`merge(...members)` composes several sources, last-wins across their `readVars()` snapshots. A member may be a `(key) => string | undefined` reader, which fills a key missing from every snapshot. At most one member is filesystem-backed, and the `.env` cascade and file APIs route to it. `merge` throws `EnvaptError` `InvalidMergedSource` with no members or more than one file-backed member.
+
 On the portable build (Workers, the browser, edge runtimes) there is no filesystem: the file-only config APIs (`envPaths`, `baseDir`, `envFileOptions`, `configureProfiles`, `resetProfiles`) warn once and no-op by default. Set `Envapter.fileApiMode = 'throw'` to make them throw `EnvaptError` `FileApiUnsupported` instead. A read before `useSource` throws `NoSourceBound` regardless of `fileApiMode`.
 
 ## Loading .env files


### PR DESCRIPTION
## What and why

- `Envapter.useSource` and `merge` accept a `(key) => string | undefined` reader as a source, for a runtime that reads one variable at a time and cannot list its keys. envapt reads each key from the reader on a cache miss and caches the result, including a miss. `readVar` is an optional method on `Source`, so the reader adds no new export. A reader member of a `merge` fills a key missing from every snapshot.
- Add a `@see` docs-site link to every public API TSDoc, so an editor hover points to the page for that reader, converter, source, decorator, or error.
- Drop three internal-only exports from the public surface: the `isArrayOf` guard and the `EnvaptConverter` and `ConverterToken` types. None appeared in a public signature.
- Docs: a function-source section on Sources, a merge-with-reader example, updates to the edge-runtimes page, and SKILL.md.

## Checklist

- [x] New or regression tests cover the change
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `useSource` and `merge` now support per-key reader functions `(key) => string | undefined`, lazily read on first access and cached.
  * `merge` combines members with **last-wins** precedence, including mixed source/reader members, and throws `InvalidMergedSource` for invalid configurations.

* **Bug Fixes**
  * Improved candidate/environment resolution when values come from per-key readers (including merged sources).
  * Cache miss results are memoized to avoid repeated per-key lookups.

* **Documentation**
  * Added `@see` links across the public docs and updated guidance (including Fastly Compute) for reader-driven loading and merging.

* **Chores / Breaking Changes**
  * Reduced public converter exports (e.g., removed `ConverterToken`, `EnvaptConverter`, and `isArrayOf`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->