### PR TITLE
fix(core)!: return undefined for a missing read and normalize the undefined fallback

### DIFF
--- a/.changeset/missing-read-undefined.md
+++ b/.changeset/missing-read-undefined.md
@@ -1,0 +1,5 @@
+---
+'envapt': major
+---
+
+Return `undefined` for a missing read with no fallback across every reader, including the decorators and converter dispatch that returned `null` before. No-fallback decorator field types drop `| null` and retype such fields to `| undefined`. `getWith` now runs its custom converter on a missing key with `raw` as `undefined`. An explicit `undefined` fallback counts as no fallback everywhere, so `Envapter.parse(key, schema, undefined)` throws `MissingEnvValue`.

--- a/.changeset/missing-read-undefined.md
+++ b/.changeset/missing-read-undefined.md
@@ -2,4 +2,4 @@
 'envapt': major
 ---
 
-Return `undefined` for a missing read with no fallback across every reader, including the decorators and converter dispatch that returned `null` before. No-fallback decorator field types drop `| null` and retype such fields to `| undefined`. `getWith` now runs its custom converter on a missing key with `raw` as `undefined`. An explicit `undefined` fallback counts as no fallback everywhere, so `Envapter.parse(key, schema, undefined)` throws `MissingEnvValue`.
+Return `undefined` for a missing read with no fallback across every reader, including the decorators and converter dispatch that returned `null` before. No-fallback decorator field types drop `| null`, so retype such fields to `| undefined`. `getWith` now runs its custom converter on a missing key with `raw` as `undefined`. An explicit `undefined` fallback counts as no fallback everywhere, so `Envapter.parse(key, schema, undefined)` throws `MissingEnvValue`.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -122,15 +122,3 @@ Pull requests that do not pass CI will not be reviewed in detail.
 - `pnpm --filter envapt test:all`, builds once then runs every suite in parallel, skipping the browser suite when Chromium is absent
 
 Build the package before running the workerd or browser suite on its own, or use `test:all`, which builds first. CI runs all of them as parallel jobs.
-
-## Questions?
-
-If you have questions or need help:
-
-- Open an issue on GitHub
-- Check existing issues for similar questions
-- Look at the README for examples
-
----
-
-Thank you for helping improve envapt!

--- a/apps/guide/content/blog/whats-new-v6-to-v8.mdx
+++ b/apps/guide/content/blog/whats-new-v6-to-v8.mdx
@@ -79,7 +79,7 @@ Warning by default still catches the real mistake. An unconfigured read throws `
 
 Oh, and I finally added `Converters.Email`. It was about time envapt had that...
 
-The [v7-to-v8 migration guide](/docs/migration-v7-to-v8) covers all eight breaking changes.
+The [v7-to-v8 migration guide](/docs/migration-v7-to-v8) covers all eleven breaking changes.
 
 ## That is the throughline
 

--- a/apps/guide/content/docs/converters.mdx
+++ b/apps/guide/content/docs/converters.mdx
@@ -11,7 +11,7 @@ import { Envapter, Converters } from 'envapt';
 const timeout = Envapter.getUsing('TIMEOUT', Converters.Time, '30s');
 //    ^?
 
-const retries = Envapter.getWith('RETRIES', (raw) => Number(raw ?? 0), 3);
+const retries = Envapter.getWith('RETRIES', (raw, fallback) => (raw ? Number(raw) : fallback), 3);
 //    ^?
 ```
 

--- a/apps/guide/content/docs/decorators.mdx
+++ b/apps/guide/content/docs/decorators.mdx
@@ -92,7 +92,7 @@ class Config {
 }
 ```
 
-With no `converter` and no `fallback`, the property resolves to the raw string or `null`.
+With no `converter` and no `fallback`, the property resolves to the raw string or `undefined`.
 
 ## The field type is checked
 
@@ -106,13 +106,13 @@ class Config {
     @EnvNum('PORT', 3000)
     static accessor port: number;
 
-    // without a fallback the value can be missing, so the output is number | null
+    // without a fallback the value can be missing, so the output is number | undefined
     @EnvNum('TIMEOUT')
-    static accessor timeout: number | null;
+    static accessor timeout: number | undefined;
 }
 ```
 
-A no-fallback read adds `| null` to the output, `fallback: undefined` adds `| undefined`, and `required: true` adds neither. A field that cannot hold the output fails to compile with `[envapt] field type must hold the converter output`. The same check applies to the legacy decorators.
+A no-fallback read makes the output `T | undefined`, and `fallback: undefined` counts the same. `required: true` makes it `T`. A field that cannot hold the output fails to compile with `[envapt] field type must hold the converter output`. The same check applies to the legacy decorators.
 
 ## Shorthand decorators
 
@@ -139,7 +139,7 @@ class Config {
 }
 ```
 
-The second argument is the fallback, typed to the converter, `@EnvUrl` takes a `URL`, `@EnvTime` takes a millisecond number or a time string, the rest take their primitive. Omit it and the property resolves to the converted value or `null`. The key can also be an [ordered list](#ordered-keys).
+The second argument is the fallback, typed to the converter, `@EnvUrl` takes a `URL`, `@EnvTime` takes a millisecond number or a time string, the rest take their primitive. Omit it and the property resolves to the converted value or `undefined`. The key can also be an [ordered list](#ordered-keys).
 
 These are accessor decorators like `@Envapt`, so the same [declaration rule](#declaring-decorated-fields) applies. They take a fallback only. For `required`, a `schema`, an array, or a custom function, use `@Envapt` with the options object.
 
@@ -189,7 +189,7 @@ import { Envapt, Converters } from 'envapt';
 class Config {
     // CANARY_URL if set, otherwise APP_URL
     @Envapt(['CANARY_URL', 'APP_URL'], { converter: Converters.Url })
-    static accessor url: URL | null;
+    static accessor url: URL | undefined;
 }
 ```
 

--- a/apps/guide/content/docs/envapter.mdx
+++ b/apps/guide/content/docs/envapter.mdx
@@ -89,7 +89,7 @@ import { Envapter, Converters } from 'envapt';
 const origins = Envapter.getUsing('CORS', Converters.array({ of: Converters.String }));
 //    ^?
 
-const retries = Envapter.getWith('RETRIES', (raw) => Number(raw), 3);
+const retries = Envapter.getWith('RETRIES', (raw, fallback) => (raw ? Number(raw) : fallback), 3);
 //    ^?
 ```
 

--- a/apps/guide/content/docs/envapter.mdx
+++ b/apps/guide/content/docs/envapter.mdx
@@ -76,11 +76,6 @@ const raw = new Envapter().getRaw('DATABASE_URL');
 //    ^?
 ```
 
-<Callout type="info">
-    There is no `Envapter.getRaw` static. Every other reader has a static form, but the raw string is reachable only
-    through an instance.
-</Callout>
-
 ## Converters
 
 For shapes beyond primitives, two readers take a converter:

--- a/apps/guide/content/docs/migration-v7-to-v8.mdx
+++ b/apps/guide/content/docs/migration-v7-to-v8.mdx
@@ -3,9 +3,9 @@ title: Migration (v7 to v8)
 description: Moving from envapt v7 to v8. The source classes get shorter names, one universal envapt import replaces the workerd and browser subpaths, and the portable file APIs warn instead of throwing by default.
 ---
 
-v8 is a major release with **eight** breaking changes. The source classes are renamed, the `envapt/workerd` and `envapt/browser` subpaths are removed, the portable build's filesystem-only config APIs warn once and no-op by default instead of throwing, the public type surface is trimmed, the functional required-read bag moves to `getRequired`, the `Integer` and `Float` converters reject malformed values, the missing-value rule is unified so ordered reads skip an empty key and whitespace-only values follow `strict`, and built-in converter fallbacks are validated by value.
+v8 is a major release with **eleven** breaking changes. The source classes are renamed, the `envapt/workerd` and `envapt/browser` subpaths are removed, the portable build's filesystem-only config APIs warn once and no-op by default, the public type surface is trimmed, the functional required-read bag moves to `getRequired`, the `Integer` and `Float` converters reject malformed values, the missing-value rule is unified so ordered reads skip an empty key and whitespace-only values follow `strict`, built-in converter fallbacks are validated by value, a missing read with no fallback resolves to `undefined` across every reader, `getWith` passes the raw value to its custom converter, and an explicit `undefined` fallback counts as no fallback.
 
-Most upgrades touch only two of these, the source renames and the single `envapt` import. The rest apply only if you imported an internal type by name or leaned on loose parsing, and each section says when it affects you.
+Most upgrades touch only two of these, the source renames and the single `envapt` import. The rest apply only if you imported an internal type by name, typed a decorator field as `| null`, or leaned on loose parsing, and each section says when it affects you.
 
 ## Source and type renames
 
@@ -160,3 +160,51 @@ Envapter.getUsing('SAMPLE_RATE', Converters.Float, NaN);
 ```
 
 You only need a change here if you passed a sentinel or placeholder fallback that is not a real value. Pass a valid fallback, or omit it to get `T | undefined`.
+
+## A missing read with no fallback resolves to `undefined`
+
+A read of a missing key with no fallback resolves to `undefined` everywhere. The functional readers (`get`, `getNumber`, `getUsing`, `getWith`, `getRaw`) already returned `undefined`. The decorators returned `null` on this path. v8 returns `undefined` from the decorators and the converter dispatch too, so one value marks an absent read across the whole API.
+
+The no-fallback decorator field types drop `| null`. A field typed `T | null` stops type-checking. Retype it to `T | undefined`.
+
+```ts
+// v7
+class Config {
+    @Envapt('OPTIONAL_TOKEN') static accessor token: string | null;
+}
+// Config.token is null when OPTIONAL_TOKEN is unset
+
+// v8
+class Config {
+    @Envapt('OPTIONAL_TOKEN') static accessor token: string | undefined;
+}
+// Config.token is undefined when OPTIONAL_TOKEN is unset
+```
+
+You only need a change here if you typed a no-fallback decorator field as `| null`, or branched on a decorator read with `=== null`. Nullish handling (`?? fallback`, `== null`) keeps working.
+
+## `getWith` passes the raw value to your converter
+
+`getWith` calls your custom converter with the raw value on every read, including a missing key, where the converter receives `raw === undefined`. v7 short-circuited a missing key and returned the fallback without running the converter. The converter already received the fallback as the second argument, so you can still return it when `raw` is missing. Just that now it's your converter's choice, not envapt's.
+
+```ts
+const name = Envapter.getWith('NAME', (raw, fallback) => raw?.toUpperCase(), 'ANON');
+// with NAME unset
+// v7: 'ANON' (the converter never ran)
+// v8: undefined (the converter ran with raw === undefined)
+```
+
+A converter that reads `raw` without a guard now runs on a missing key. Guard it with `raw ?? ''` or an early `if (!raw) return fallback`. The `ConverterFunction` type has always typed `raw` as `string | undefined` and passed the fallback as the second argument. The `@Envapt` custom-converter decorator already ran the converter on a missing key, and v8 brings `getWith` in line with it.
+
+## An explicit `undefined` fallback counts as no fallback
+
+Passing `undefined` as the fallback argument counts as no fallback, across every reader and the `@Envapt` options. `Envapter.parse` previously read an explicit `undefined` as a provided fallback and returned it for a missing key. It now throws `MissingEnvValue`.
+
+```ts
+// with API_URL unset
+Envapter.parse('API_URL', schema, undefined); // why would you even do this
+// v7: undefined
+// v8: throws MissingEnvValue
+```
+
+You only need a change here if you passed `undefined` to `parse` to make a key optional. Pass a real fallback, or guard the read with `getRaw` before parsing.

--- a/apps/guide/content/docs/standard-schema.mdx
+++ b/apps/guide/content/docs/standard-schema.mdx
@@ -68,9 +68,8 @@ const port = Envapter.parse('PORT', positiveInt, 3000);
 </Callout>
 
 <Callout type="warn">
-    Passing a third argument at all counts as a fallback, even when that argument is `undefined`. So
-    `Envapter.parse('PORT', schema, undefined)` returns `undefined` on a missing value instead of throwing. Omit the
-    argument entirely when you want the missing-value throw.
+    An explicit `undefined` third argument counts as no fallback. `Envapter.parse('PORT', schema, undefined)` throws
+    `MissingEnvValue` on a missing value, the same as omitting the argument.
 </Callout>
 
 ## What throws

--- a/packages/envapt/src/converters/ValueConverter.ts
+++ b/packages/envapt/src/converters/ValueConverter.ts
@@ -26,7 +26,7 @@ export class ValueConverter {
         fallback: TFallback | undefined,
         converter: EnvaptConverter<TFallback> | undefined,
         hasFallback: boolean
-    ): TFallback | null | undefined {
+    ): TFallback | undefined {
         const resolvedConverter = this.resolveConverter(converter, fallback);
         const processedFallback = this.processFallbackForConverter(resolvedConverter, fallback);
 
@@ -74,19 +74,18 @@ export class ValueConverter {
         resolvedConverter: BuiltInConverter,
         hasFallback: boolean,
         wasOriginallyConstructor: boolean
-    ): TFallback | null | undefined {
+    ): TFallback | undefined {
         Validator.builtInConverter(resolvedConverter);
 
-        if (hasFallback && fallback !== undefined && !wasOriginallyConstructor) {
+        if (hasFallback && !wasOriginallyConstructor) {
             Validator.validateBuiltInConverterFallback(resolvedConverter, fallback);
         }
 
         const parsed = this.envService.get(key, undefined);
 
         if (parsed === undefined) {
-            if (!hasFallback) return null;
-            // Route the fallback through the time converter to coerce it to the return type,
-            // since fallback may be a string while the return type is number.
+            if (!hasFallback) return undefined;
+            // coerce a string fallback to the number return type through the time converter
             if (resolvedConverter === 'time' && typeof fallback === 'string') {
                 const timeFn = BuiltInConverters.getConverter(resolvedConverter);
                 return timeFn('', fallback) as TFallback;
@@ -98,12 +97,12 @@ export class ValueConverter {
         const converted = converterFn(parsed, undefined);
 
         if (converted === undefined) {
-            // key and type only, no value: env values can be secrets and verbose logs reach stderr
+            // key and type only, no value, since env values can be secrets and verbose logs reach stderr
             debugVerbose(
                 `could not convert ${formatKeyForError(key)} as ${resolvedConverter}${hasFallback ? ', using the fallback' : ''}`
             );
             // re-run with the real fallback so time's string-form fallback still coerces to a number
-            return hasFallback ? (converterFn(parsed, fallback) as TFallback) : null;
+            return hasFallback ? (converterFn(parsed, fallback) as TFallback) : undefined;
         }
 
         return converted as TFallback;
@@ -114,10 +113,10 @@ export class ValueConverter {
         fallback: TFallback | undefined,
         resolvedConverter: ArrayOf,
         hasFallback: boolean
-    ): TFallback | null | undefined {
+    ): TFallback | undefined {
         Validator.arrayConverter(resolvedConverter);
 
-        if (hasFallback && fallback !== undefined && !Array.isArray(fallback)) {
+        if (hasFallback && !Array.isArray(fallback)) {
             throw new EnvaptError(
                 EnvaptErrorCodes.InvalidFallback,
                 `ArrayOf<...> requires that the fallback be an array, got ${typeof fallback}`
@@ -132,10 +131,9 @@ export class ValueConverter {
         const parsed = this.envService.get(key, undefined);
 
         if (parsed === undefined) {
-            if (!hasFallback) return null;
-            // When the array element is `time` and the fallback is a list of time-strings,
-            // coerce each entry through the time converter so the returned array is
-            // `number[]` matching the declared return type.
+            if (!hasFallback) return undefined;
+            // coerce each time-string entry through the time converter so the array is number[]
+            // matching the declared return type
             if (
                 resolvedConverter.of === 'time' &&
                 Array.isArray(fallback) &&
@@ -155,8 +153,8 @@ export class ValueConverter {
         key: EnvKeyInput,
         fallback: TFallback | undefined,
         resolvedConverter: EnvaptConverter<TFallback>,
-        _hasFallback: boolean // hasFallback is not needed because customConverter is called even if the raw value is undefined
-    ): TFallback | null | undefined {
+        _hasFallback: boolean // unused. the custom converter runs even when raw is undefined
+    ): TFallback | undefined {
         Validator.customConvertor(resolvedConverter);
 
         const raw = this.envService.get(key, undefined);

--- a/packages/envapt/src/core/AdvancedMethods.ts
+++ b/packages/envapt/src/core/AdvancedMethods.ts
@@ -1,5 +1,5 @@
 import { resolveKeyInput, templateResolver, valueConverter } from './engine';
-import { isMissing } from './missing';
+import { hasFallback, isMissing } from './missing';
 import { PrimitiveMethods } from './PrimitiveMethods';
 import { debugWarn } from '../infra/Debug';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
@@ -28,9 +28,8 @@ function formatKeyForError(key: EnvKeyInput): string {
     return Array.isArray(key) ? `[${key.join(', ')}]` : String(key);
 }
 
-// template-resolve a present value, then apply the shared missing check so a resolved blank falls
-// through (empty always, whitespace-only under strict).
-// a module function so getRequired/getRequiredAll and Envapter.require share it without exposing it on any subclass.
+// missing check runs after template resolution so a value that resolves to blank falls through
+// (empty always, whitespace-only under strict)
 export function resolveRequired(
     resolved: { key: string; value: string | undefined },
     templateResolver: TemplateResolver
@@ -74,16 +73,14 @@ export class AdvancedMethods extends PrimitiveMethods {
     ): AdvancedConverterReturn<TConverter, TFallback> {
         const { key: resolvedKey, value } = resolveKeyInput(key);
 
-        // missing with no fallback returns undefined, matching the primitive methods. with a fallback,
-        // route through the parser so asymmetric types (TimeFallback, TimeFallback[] for `of: time`)
-        // coerce to the return type.
-        if (isMissing(value) && fallback === undefined) {
+        // a missing value with a fallback falls through to the parser so asymmetric types
+        // (TimeFallback, TimeFallback[] for `of: time`) coerce to the return type
+        if (isMissing(value) && !hasFallback(fallback)) {
             debugWarn(`${resolvedKey} is missing or empty`);
             return undefined as AdvancedConverterReturn<TConverter, TFallback>;
         }
 
-        const hasFallback = fallback !== undefined;
-        const result = valueConverter.convertValue(resolvedKey, fallback, converter, hasFallback);
+        const result = valueConverter.convertValue(resolvedKey, fallback, converter, hasFallback(fallback));
 
         return result as AdvancedConverterReturn<TConverter, TFallback>;
     }
@@ -121,14 +118,8 @@ export class AdvancedMethods extends PrimitiveMethods {
         converter: ConverterFunction<TReturnType>,
         fallback?: TFallback
     ): ConditionalReturn<TReturnType, TFallback> {
-        const { key: resolvedKey, value } = resolveKeyInput(key);
-        if (isMissing(value)) {
-            debugWarn(`${resolvedKey} is missing or empty`);
-            return fallback as ConditionalReturn<TReturnType, TFallback>;
-        }
-
-        const hasFallback = fallback !== undefined;
-        const result = valueConverter.convertValue<TReturnType>(resolvedKey, fallback, converter, hasFallback);
+        // run the custom converter even on a missing value, with raw as undefined
+        const result = valueConverter.convertValue<TReturnType>(key, fallback, converter, hasFallback(fallback));
 
         return result as ConditionalReturn<TReturnType, TFallback>;
     }
@@ -185,7 +176,7 @@ export class AdvancedMethods extends PrimitiveMethods {
             converter as EnvaptConverter<TReturnType>,
             false
         );
-        // convertValue returns null for a present value it can't convert, which would break the non-undefined return.
+        // a built-in yields undefined for a present value it cannot convert, a custom converter can return null, both break the non-undefined return
         if (result === undefined || result === null) {
             throw new EnvaptError(
                 EnvaptErrorCodes.MissingEnvValue,
@@ -286,14 +277,13 @@ export class AdvancedMethods extends PrimitiveMethods {
         schema: SchemaConstraint<Schema>,
         fallback?: InferSchemaOutput<Schema>
     ): InferSchemaOutput<Schema> {
-        const hasFallback = arguments.length > 2;
         // SchemaConstraint resolves to the unsatisfiable SchemaMustBeSync brand for async
         // schemas, so reaching this body means the input is structurally a sync Schema.
         const result = valueConverter.convertWithSchema(
             key,
             schema as unknown as StandardSchemaV1,
             fallback,
-            hasFallback
+            hasFallback(fallback)
         );
         return result;
     }
@@ -306,12 +296,11 @@ export class AdvancedMethods extends PrimitiveMethods {
         schema: SchemaConstraint<Schema>,
         fallback?: InferSchemaOutput<Schema>
     ): InferSchemaOutput<Schema> {
-        const hasFallback = arguments.length > 2;
         const result = valueConverter.convertWithSchema(
             key,
             schema as unknown as StandardSchemaV1,
             fallback,
-            hasFallback
+            hasFallback(fallback)
         );
         return result;
     }

--- a/packages/envapt/src/core/missing.ts
+++ b/packages/envapt/src/core/missing.ts
@@ -1,8 +1,13 @@
 import { state } from './state';
 
-// this should be used to determine if a value is missing EVERYWHERE so the behavior is consistent
+// the one missing-check, use it everywhere so behavior stays consistent
 export function isMissing(value: string | undefined): boolean {
     if (value === undefined || value === '') return true;
     if (state.strict && value.trim() === '') return true;
     return false;
+}
+
+// an explicit undefined fallback counts as no fallback, use it everywhere so behavior stays consistent
+export function hasFallback(fallback: unknown): boolean {
+    return fallback !== undefined;
 }

--- a/packages/envapt/src/decorators/legacy/Envapt.ts
+++ b/packages/envapt/src/decorators/legacy/Envapt.ts
@@ -43,7 +43,7 @@ import type {
  */
 export function Envapt(
     key: EnvKeyInput,
-    options: { fallback: undefined; converter?: undefined }
+    options?: { fallback?: undefined; converter?: undefined }
 ): EnvaptFieldDecorator<string | undefined>;
 export function Envapt<TFallback>(
     key: EnvKeyInput,
@@ -105,7 +105,7 @@ export function Envapt<TReturnType>(
  *
  *   // prefers CANARY_URL when present, otherwise APP_URL
  *   \@Envapt(['CANARY_URL', 'APP_URL'], { converter: Converters.Url })
- *   static readonly canaryUrl: URL | null;
+ *   static readonly canaryUrl: URL | undefined;
  *
  *   // Time takes a number (milliseconds) or a time-string fallback (`<number><unit>`)
  *   \@Envapt('REQUEST_TIMEOUT', { converter: Converters.Time, fallback: '10s' })
@@ -130,12 +130,8 @@ export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
 ): EnvaptFieldDecorator<InferConverterReturnType<TConverter>>;
 export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
     key: EnvKeyInput,
-    options: { converter: TConverter; fallback: undefined; required?: false }
+    options: { converter: TConverter; fallback?: undefined; required?: false }
 ): EnvaptFieldDecorator<InferConverterReturnType<TConverter> | undefined>;
-export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
-    key: EnvKeyInput,
-    options: { converter: TConverter; required?: false }
-): EnvaptFieldDecorator<InferConverterReturnType<TConverter> | null>;
 
 /**
  * A primitive constructor (`Number`, `Boolean`) with an optional fallback.
@@ -162,12 +158,8 @@ export function Envapt<TConstructor extends PrimitiveConstructor>(
 ): EnvaptFieldDecorator<InferPrimitiveReturnType<TConstructor>>;
 export function Envapt<TConstructor extends PrimitiveConstructor>(
     key: EnvKeyInput,
-    options: { converter: TConstructor; fallback: undefined; required?: false }
+    options: { converter: TConstructor; fallback?: undefined; required?: false }
 ): EnvaptFieldDecorator<InferPrimitiveReturnType<TConstructor> | undefined>;
-export function Envapt<TConstructor extends PrimitiveConstructor>(
-    key: EnvKeyInput,
-    options: { converter: TConstructor; required?: false }
-): EnvaptFieldDecorator<InferPrimitiveReturnType<TConstructor> | null>;
 
 /**
  * Required, no converter (raw string). Throws `MissingEnvValue` on first access when the env
@@ -187,21 +179,6 @@ export function Envapt<TConstructor extends PrimitiveConstructor>(
  * ```
  */
 export function Envapt(key: EnvKeyInput, options: { required: true }): EnvaptFieldDecorator<string>;
-
-/**
- * No-fallback form. The property resolves from env or `null`.
- *
- * @param key - Environment variable name(s) to load
- * @public
- * @example
- * ```ts
- * class Config extends Envapter {
- *   \@Envapt('SIMPLE_VALUE')
- *   static readonly simple?: string | null;
- * }
- * ```
- */
-export function Envapt(key: EnvKeyInput): EnvaptFieldDecorator<string | null>;
 
 /**
  * A Standard Schema v1 adapter (zod, valibot, arktype, hand-rolled). Synchronous schemas only,

--- a/packages/envapt/src/decorators/legacy/Envapt.ts
+++ b/packages/envapt/src/decorators/legacy/Envapt.ts
@@ -43,7 +43,7 @@ import type {
  */
 export function Envapt(
     key: EnvKeyInput,
-    options?: { fallback?: undefined; converter?: undefined }
+    options?: { fallback: undefined; converter?: undefined }
 ): EnvaptFieldDecorator<string | undefined>;
 export function Envapt<TFallback>(
     key: EnvKeyInput,

--- a/packages/envapt/src/decorators/legacy/SugarDecorators.ts
+++ b/packages/envapt/src/decorators/legacy/SugarDecorators.ts
@@ -26,8 +26,8 @@ function sugar<TFallback>(
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvBool(key: EnvKeyInput, fallback: boolean): EnvaptFieldDecorator<boolean>;
-export function EnvBool(key: EnvKeyInput): EnvaptFieldDecorator<boolean | null>;
-export function EnvBool(key: EnvKeyInput, fallback?: boolean): EnvaptFieldDecorator<boolean | null> {
+export function EnvBool(key: EnvKeyInput): EnvaptFieldDecorator<boolean | undefined>;
+export function EnvBool(key: EnvKeyInput, fallback?: boolean): EnvaptFieldDecorator<boolean | undefined> {
     return sugar(Converters.Boolean, key, fallback);
 }
 
@@ -37,8 +37,8 @@ export function EnvBool(key: EnvKeyInput, fallback?: boolean): EnvaptFieldDecora
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvNum(key: EnvKeyInput, fallback: number): EnvaptFieldDecorator<number>;
-export function EnvNum(key: EnvKeyInput): EnvaptFieldDecorator<number | null>;
-export function EnvNum(key: EnvKeyInput, fallback?: number): EnvaptFieldDecorator<number | null> {
+export function EnvNum(key: EnvKeyInput): EnvaptFieldDecorator<number | undefined>;
+export function EnvNum(key: EnvKeyInput, fallback?: number): EnvaptFieldDecorator<number | undefined> {
     return sugar(Converters.Number, key, fallback);
 }
 
@@ -48,8 +48,8 @@ export function EnvNum(key: EnvKeyInput, fallback?: number): EnvaptFieldDecorato
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvStr(key: EnvKeyInput, fallback: string): EnvaptFieldDecorator<string>;
-export function EnvStr(key: EnvKeyInput): EnvaptFieldDecorator<string | null>;
-export function EnvStr(key: EnvKeyInput, fallback?: string): EnvaptFieldDecorator<string | null> {
+export function EnvStr(key: EnvKeyInput): EnvaptFieldDecorator<string | undefined>;
+export function EnvStr(key: EnvKeyInput, fallback?: string): EnvaptFieldDecorator<string | undefined> {
     return sugar(Converters.String, key, fallback);
 }
 
@@ -60,8 +60,8 @@ export function EnvStr(key: EnvKeyInput, fallback?: string): EnvaptFieldDecorato
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvTime(key: EnvKeyInput, fallback: TimeFallback): EnvaptFieldDecorator<number>;
-export function EnvTime(key: EnvKeyInput): EnvaptFieldDecorator<number | null>;
-export function EnvTime(key: EnvKeyInput, fallback?: TimeFallback): EnvaptFieldDecorator<number | null> {
+export function EnvTime(key: EnvKeyInput): EnvaptFieldDecorator<number | undefined>;
+export function EnvTime(key: EnvKeyInput, fallback?: TimeFallback): EnvaptFieldDecorator<number | undefined> {
     return sugar(Converters.Time, key, fallback);
 }
 
@@ -72,7 +72,7 @@ export function EnvTime(key: EnvKeyInput, fallback?: TimeFallback): EnvaptFieldD
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvUrl(key: EnvKeyInput, fallback: URL): EnvaptFieldDecorator<URL>;
-export function EnvUrl(key: EnvKeyInput): EnvaptFieldDecorator<URL | null>;
-export function EnvUrl(key: EnvKeyInput, fallback?: URL): EnvaptFieldDecorator<URL | null> {
+export function EnvUrl(key: EnvKeyInput): EnvaptFieldDecorator<URL | undefined>;
+export function EnvUrl(key: EnvKeyInput, fallback?: URL): EnvaptFieldDecorator<URL | undefined> {
     return sugar(Converters.Url, key, fallback);
 }

--- a/packages/envapt/src/decorators/modern/Envapt.ts
+++ b/packages/envapt/src/decorators/modern/Envapt.ts
@@ -43,7 +43,7 @@ import type {
  */
 export function Envapt(
     key: EnvKeyInput,
-    options: { fallback: undefined; converter?: undefined }
+    options?: { fallback?: undefined; converter?: undefined }
 ): EnvaptAccessorDecorator<string | undefined>;
 export function Envapt<TFallback>(
     key: EnvKeyInput,
@@ -105,7 +105,7 @@ export function Envapt<TReturnType>(
  *
  *   // prefers CANARY_URL when present, otherwise APP_URL
  *   \@Envapt(['CANARY_URL', 'APP_URL'], { converter: Converters.Url })
- *   static accessor canaryUrl: URL | null;
+ *   static accessor canaryUrl: URL | undefined;
  *
  *   // Time takes a number (milliseconds) or a time-string fallback (`<number><unit>`)
  *   \@Envapt('REQUEST_TIMEOUT', { converter: Converters.Time, fallback: '10s' })
@@ -130,12 +130,8 @@ export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
 ): EnvaptAccessorDecorator<InferConverterReturnType<TConverter>>;
 export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
     key: EnvKeyInput,
-    options: { converter: TConverter; fallback: undefined; required?: false }
+    options: { converter: TConverter; fallback?: undefined; required?: false }
 ): EnvaptAccessorDecorator<InferConverterReturnType<TConverter> | undefined>;
-export function Envapt<TConverter extends BuiltInConverter | ArrayOf>(
-    key: EnvKeyInput,
-    options: { converter: TConverter; required?: false }
-): EnvaptAccessorDecorator<InferConverterReturnType<TConverter> | null>;
 
 /**
  * A primitive constructor (`Number`, `Boolean`) with an optional fallback.
@@ -162,12 +158,8 @@ export function Envapt<TConstructor extends PrimitiveConstructor>(
 ): EnvaptAccessorDecorator<InferPrimitiveReturnType<TConstructor>>;
 export function Envapt<TConstructor extends PrimitiveConstructor>(
     key: EnvKeyInput,
-    options: { converter: TConstructor; fallback: undefined; required?: false }
+    options: { converter: TConstructor; fallback?: undefined; required?: false }
 ): EnvaptAccessorDecorator<InferPrimitiveReturnType<TConstructor> | undefined>;
-export function Envapt<TConstructor extends PrimitiveConstructor>(
-    key: EnvKeyInput,
-    options: { converter: TConstructor; required?: false }
-): EnvaptAccessorDecorator<InferPrimitiveReturnType<TConstructor> | null>;
 
 /**
  * Required, no converter (raw string). Throws `MissingEnvValue` on first access when the env
@@ -187,21 +179,6 @@ export function Envapt<TConstructor extends PrimitiveConstructor>(
  * ```
  */
 export function Envapt(key: EnvKeyInput, options: { required: true }): EnvaptAccessorDecorator<string>;
-
-/**
- * No-fallback form. The property resolves from env or `null`.
- *
- * @param key - Environment variable name(s) to load
- * @public
- * @example
- * ```ts
- * class Config {
- *   \@Envapt('SIMPLE_VALUE')
- *   static accessor simple: string | null;
- * }
- * ```
- */
-export function Envapt(key: EnvKeyInput): EnvaptAccessorDecorator<string | null>;
 
 /**
  * A Standard Schema v1 adapter (zod, valibot, arktype, hand-rolled). Synchronous schemas only,

--- a/packages/envapt/src/decorators/modern/Envapt.ts
+++ b/packages/envapt/src/decorators/modern/Envapt.ts
@@ -43,7 +43,7 @@ import type {
  */
 export function Envapt(
     key: EnvKeyInput,
-    options?: { fallback?: undefined; converter?: undefined }
+    options?: { fallback: undefined; converter?: undefined }
 ): EnvaptAccessorDecorator<string | undefined>;
 export function Envapt<TFallback>(
     key: EnvKeyInput,

--- a/packages/envapt/src/decorators/modern/SugarDecorators.ts
+++ b/packages/envapt/src/decorators/modern/SugarDecorators.ts
@@ -27,8 +27,8 @@ function sugar<TFallback>(
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvBool(key: EnvKeyInput, fallback: boolean): EnvaptAccessorDecorator<boolean>;
-export function EnvBool(key: EnvKeyInput): EnvaptAccessorDecorator<boolean | null>;
-export function EnvBool(key: EnvKeyInput, fallback?: boolean): EnvaptAccessorDecorator<boolean | null> {
+export function EnvBool(key: EnvKeyInput): EnvaptAccessorDecorator<boolean | undefined>;
+export function EnvBool(key: EnvKeyInput, fallback?: boolean): EnvaptAccessorDecorator<boolean | undefined> {
     return sugar(Converters.Boolean, key, fallback);
 }
 
@@ -38,8 +38,8 @@ export function EnvBool(key: EnvKeyInput, fallback?: boolean): EnvaptAccessorDec
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvNum(key: EnvKeyInput, fallback: number): EnvaptAccessorDecorator<number>;
-export function EnvNum(key: EnvKeyInput): EnvaptAccessorDecorator<number | null>;
-export function EnvNum(key: EnvKeyInput, fallback?: number): EnvaptAccessorDecorator<number | null> {
+export function EnvNum(key: EnvKeyInput): EnvaptAccessorDecorator<number | undefined>;
+export function EnvNum(key: EnvKeyInput, fallback?: number): EnvaptAccessorDecorator<number | undefined> {
     return sugar(Converters.Number, key, fallback);
 }
 
@@ -49,8 +49,8 @@ export function EnvNum(key: EnvKeyInput, fallback?: number): EnvaptAccessorDecor
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvStr(key: EnvKeyInput, fallback: string): EnvaptAccessorDecorator<string>;
-export function EnvStr(key: EnvKeyInput): EnvaptAccessorDecorator<string | null>;
-export function EnvStr(key: EnvKeyInput, fallback?: string): EnvaptAccessorDecorator<string | null> {
+export function EnvStr(key: EnvKeyInput): EnvaptAccessorDecorator<string | undefined>;
+export function EnvStr(key: EnvKeyInput, fallback?: string): EnvaptAccessorDecorator<string | undefined> {
     return sugar(Converters.String, key, fallback);
 }
 
@@ -61,8 +61,8 @@ export function EnvStr(key: EnvKeyInput, fallback?: string): EnvaptAccessorDecor
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvTime(key: EnvKeyInput, fallback: TimeFallback): EnvaptAccessorDecorator<number>;
-export function EnvTime(key: EnvKeyInput): EnvaptAccessorDecorator<number | null>;
-export function EnvTime(key: EnvKeyInput, fallback?: TimeFallback): EnvaptAccessorDecorator<number | null> {
+export function EnvTime(key: EnvKeyInput): EnvaptAccessorDecorator<number | undefined>;
+export function EnvTime(key: EnvKeyInput, fallback?: TimeFallback): EnvaptAccessorDecorator<number | undefined> {
     return sugar(Converters.Time, key, fallback);
 }
 
@@ -73,8 +73,8 @@ export function EnvTime(key: EnvKeyInput, fallback?: TimeFallback): EnvaptAccess
  * @see {@link https://envapt.materwelon.dev/docs/decorators#shorthand-decorators}
  */
 export function EnvUrl(key: EnvKeyInput, fallback: URL): EnvaptAccessorDecorator<URL>;
-export function EnvUrl(key: EnvKeyInput): EnvaptAccessorDecorator<URL | null>;
-export function EnvUrl(key: EnvKeyInput, fallback?: URL): EnvaptAccessorDecorator<URL | null> {
+export function EnvUrl(key: EnvKeyInput): EnvaptAccessorDecorator<URL | undefined>;
+export function EnvUrl(key: EnvKeyInput, fallback?: URL): EnvaptAccessorDecorator<URL | undefined> {
     return sugar(Converters.Url, key, fallback);
 }
 /* v8 ignore stop */

--- a/packages/envapt/src/decorators/parseEnvaptOptions.ts
+++ b/packages/envapt/src/decorators/parseEnvaptOptions.ts
@@ -1,3 +1,4 @@
+import { hasFallback } from '../core/missing';
 import { Validator } from '../engine/Validators';
 import { EnvaptError, EnvaptErrorCodes } from '../infra/Error';
 
@@ -9,7 +10,6 @@ export function parseEnvaptOptions<TFallback>(options: unknown): DecoratorConfig
     let fallback: TFallback | undefined;
     let converter: EnvaptConverter<TFallback> | undefined;
     let schema: StandardSchemaV1 | undefined;
-    let hasFallback = false;
     let required = false;
 
     if (options !== undefined) {
@@ -32,10 +32,9 @@ export function parseEnvaptOptions<TFallback>(options: unknown): DecoratorConfig
         };
         fallback = opts.fallback;
         converter = opts.converter;
-        hasFallback = 'fallback' in opts;
         required = opts.required === true;
 
-        if (required && hasFallback && fallback !== undefined) {
+        if (required && hasFallback(fallback)) {
             throw new EnvaptError(
                 EnvaptErrorCodes.InvalidUserDefinedConfig,
                 '`required: true` and `fallback` are mutually exclusive on @Envapt options. Drop the fallback or call `Envapter.require()` separately.'
@@ -59,5 +58,5 @@ export function parseEnvaptOptions<TFallback>(options: unknown): DecoratorConfig
         }
     }
 
-    return { fallback, converter, hasFallback, required, schema };
+    return { fallback, converter, hasFallback: hasFallback(fallback), required, schema };
 }

--- a/packages/envapt/src/decorators/resolveDecoratorValue.ts
+++ b/packages/envapt/src/decorators/resolveDecoratorValue.ts
@@ -22,7 +22,7 @@ function formatKeyForError(key: EnvKeyInput): string {
 const classIds = new WeakMap<object, number>();
 let nextClassId = 0;
 
-// keyed on the constructor object, not its name, so two same-named classes (and a same-named
+// keyed on the constructor object's identity so two same-named classes (and a same-named
 // static/instance pair) stay in separate cache slots
 export function decoratorCacheKey(owner: object, isStatic: boolean, prop: string): string {
     let id = classIds.get(owner);
@@ -37,12 +37,12 @@ export function resolveDecoratorValue<TFallback>(
     key: EnvKeyInput,
     config: DecoratorConfig<TFallback>,
     cacheKey: string
-): TFallback | null | undefined {
+): TFallback | undefined {
     const { fallback, converter, hasFallback, required, schema } = config;
 
-    // .has(), not a get()-truthiness check, so a cached undefined (fallback: undefined, or a converter
-    // that returns undefined) resolves once instead of re-running on every access
-    if (cache.has(cacheKey)) return cache.get(cacheKey) as TFallback | null | undefined;
+    // cache.has guards the read so a cached undefined counts as resolved (a converter returning
+    // undefined, or a missing no-fallback read) and later accesses skip re-resolving
+    if (cache.has(cacheKey)) return cache.get(cacheKey) as TFallback | undefined;
 
     const envapter = new Envapter();
 

--- a/packages/envapt/tests/.env.044
+++ b/packages/envapt/tests/.env.044
@@ -1,0 +1,2 @@
+PRESENT_044=hello
+BAD_NUM_044=notanumber

--- a/packages/envapt/tests/001-missing-env-file.test.ts
+++ b/packages/envapt/tests/001-missing-env-file.test.ts
@@ -15,7 +15,7 @@ describe('Missing .env file handling', () => {
             public static readonly anotherNonexistentVar: number;
 
             @Envapt('PROCESS_ENV_VAR')
-            public static readonly processEnvVar: string | null;
+            public static readonly processEnvVar: string | undefined;
         }
 
         it('should use fallback values when no .env file exists', () => {
@@ -23,8 +23,8 @@ describe('Missing .env file handling', () => {
             expect(TestEnvWithoutFile.anotherNonexistentVar).to.equal(42);
         });
 
-        it('should return null for variables without fallback when no .env file exists', () => {
-            expect(TestEnvWithoutFile.processEnvVar).to.be.null;
+        it('should return undefined for variables without fallback when no .env file exists', () => {
+            expect(TestEnvWithoutFile.processEnvVar).to.be.undefined;
         });
 
         it('should still work with functional API when no .env file exists', () => {

--- a/packages/envapt/tests/002-envapt.test.ts
+++ b/packages/envapt/tests/002-envapt.test.ts
@@ -15,10 +15,10 @@ describe('Envapt', () => {
             public static readonly testUndefinedVar: string | undefined;
 
             @Envapt('NONEXISTENT_VAR_WITHOUT_FALLBACK', { converter: String })
-            public static readonly nonexistentVarWithoutFallback: string | null;
+            public static readonly nonexistentVarWithoutFallback: string | undefined;
 
             @Envapt('NONEXISTENT_VAR_NO_OPTIONS')
-            public static readonly nonexistentVarNoOptions: string | null;
+            public static readonly nonexistentVarNoOptions: string | undefined;
 
             @Envapt('PORT', { fallback: 6956 })
             public static readonly port: number;
@@ -40,12 +40,12 @@ describe('Envapt', () => {
             expect(TestTypeDetection.testUndefinedVar).to.be.undefined;
         });
 
-        it('should return null for non-existent variable without fallback but with converter', () => {
-            expect(TestTypeDetection.nonexistentVarWithoutFallback).to.be.null;
+        it('should return undefined for non-existent variable without fallback but with converter', () => {
+            expect(TestTypeDetection.nonexistentVarWithoutFallback).to.be.undefined;
         });
 
-        it('should return null for non-existent variable without fallback or converter', () => {
-            expect(TestTypeDetection.nonexistentVarNoOptions).to.be.null;
+        it('should return undefined for non-existent variable without fallback or converter', () => {
+            expect(TestTypeDetection.nonexistentVarNoOptions).to.be.undefined;
         });
 
         it('should detect number type from fallback', () => {
@@ -238,22 +238,22 @@ describe('Envapt', () => {
     describe('built-in converters showcase', () => {
         class BuiltInConverterShowcase {
             @Envapt('DATABASE_CONFIG', { converter: Converters.Json })
-            static readonly databaseConfig: JsonValue;
+            static readonly databaseConfig: JsonValue | undefined;
 
             @Envapt('API_ENDPOINTS', { converter: Converters.array({ delimiter: ';' }) })
-            static readonly apiEndpoints: string[] | null;
+            static readonly apiEndpoints: string[] | undefined;
 
             @Envapt('CORS_ORIGINS', { converter: Converters.array({ of: Converters.Url, delimiter: '|' }) })
-            static readonly corsOrigins: URL[] | null;
+            static readonly corsOrigins: URL[] | undefined;
 
             @Envapt('SERVICE_TAGS', { converter: Converters.array({ delimiter: ' ' }) })
-            static readonly serviceTags: string[] | null;
+            static readonly serviceTags: string[] | undefined;
 
             @Envapt('ENABLED_FEATURES', { converter: Converters.Boolean })
-            static readonly enabledFeatures: boolean | null;
+            static readonly enabledFeatures: boolean | undefined;
 
             @Envapt('API_TIMEOUT', { converter: Converters.Integer })
-            static readonly apiTimeout: number | null;
+            static readonly apiTimeout: number | undefined;
         }
 
         it('should parse JSON configuration', () => {
@@ -297,16 +297,16 @@ describe('Envapt', () => {
     describe('multi-line variables', () => {
         class MultiLineEnv {
             @Envapt('MULTI_LINE_VAR')
-            public static readonly multiLineVar: string | null;
+            public static readonly multiLineVar: string | undefined;
 
             @Envapt('MULTI_LINE_VAR_ESCAPED')
-            public static readonly multiLineVarEscaped: string | null;
+            public static readonly multiLineVarEscaped: string | undefined;
 
             @Envapt('MULTI_LINE_WITH_BACKSLASHN')
-            public static readonly multiLineWithBackslashN: string | null;
+            public static readonly multiLineWithBackslashN: string | undefined;
 
             @Envapt('MULTI_LINE_NUMBER', { converter: Converters.Number })
-            public static readonly multiLineNumber: number | null;
+            public static readonly multiLineNumber: number | undefined;
         }
 
         it('should handle multi-line variables correctly', () => {
@@ -324,20 +324,20 @@ describe('Envapt', () => {
         });
 
         it('should only allow strings in multiline', () => {
-            expect(MultiLineEnv.multiLineNumber).to.be.null;
+            expect(MultiLineEnv.multiLineNumber).to.be.undefined;
         });
     });
 
     describe('multi-key lookups', () => {
         class MultiKeyEnv extends Envapter {
             @Envapt(['PRIMARY_DB_URL', 'REPLICA_DB_URL'])
-            public static readonly databaseUrl: string | null;
+            public static readonly databaseUrl: string | undefined;
 
             @Envapt(['PRIMARY_SERVICE_PORT', 'LEGACY_SERVICE_PORT'], { converter: Converters.Number })
-            public static readonly preferredPort: number | null;
+            public static readonly preferredPort: number | undefined;
 
             @Envapt(['MISSING_SERVICE_PORT', 'LEGACY_SERVICE_PORT'], { converter: Converters.Number })
-            public static readonly legacyFallbackPort: number | null;
+            public static readonly legacyFallbackPort: number | undefined;
 
             @Envapt(['NOT_DEFINED_ONE', 'NOT_DEFINED_TWO'], { fallback: 'decorator-fallback' })
             public static readonly fallbackValue: string;

--- a/packages/envapt/tests/004-builtin-converters.test.ts
+++ b/packages/envapt/tests/004-builtin-converters.test.ts
@@ -181,7 +181,7 @@ describe('Built-in Converters', () => {
     describe('url converter', () => {
         class UrlTest {
             @Envapt('TEST_URL_VALID', { converter: Converters.Url })
-            static readonly validUrl: URL | null;
+            static readonly validUrl: URL | undefined;
 
             @Envapt('TEST_URL_INVALID', { converter: Converters.Url, fallback: new URL('http://fallback.com') })
             static readonly invalidUrl: URL;
@@ -209,19 +209,19 @@ describe('Built-in Converters', () => {
     describe('regexp converter', () => {
         class RegexpTest {
             @Envapt('TEST_REGEXP_SIMPLE', { converter: Converters.Regexp })
-            static readonly simpleRegexp: RegExp | null;
+            static readonly simpleRegexp: RegExp | undefined;
 
             @Envapt('TEST_REGEXP_WITH_FLAGS', { converter: Converters.Regexp })
-            static readonly regexpWithFlags: RegExp | null;
+            static readonly regexpWithFlags: RegExp | undefined;
 
             @Envapt('TEST_REGEXP_EMAIL', { converter: Converters.Regexp })
-            static readonly emailRegexp: RegExp | null;
+            static readonly emailRegexp: RegExp | undefined;
 
             @Envapt('TEST_REGEXP_URL_PATTERN', { converter: Converters.Regexp })
-            static readonly urlRegexp: RegExp | null;
+            static readonly urlRegexp: RegExp | undefined;
 
             @Envapt('TEST_REGEXP_PHONE', { converter: Converters.Regexp })
-            static readonly phoneRegexp: RegExp | null;
+            static readonly phoneRegexp: RegExp | undefined;
 
             @Envapt('TEST_REGEXP_INVALID', { converter: Converters.Regexp, fallback: /fallback/i })
             static readonly invalidRegexp: RegExp;
@@ -326,10 +326,10 @@ describe('Built-in Converters', () => {
     describe('date converter', () => {
         class DateTest {
             @Envapt('TEST_DATE_ISO', { converter: Converters.Date })
-            static readonly isoDate: Date | null;
+            static readonly isoDate: Date | undefined;
 
             @Envapt('TEST_DATE_TIMESTAMP', { converter: Converters.Date })
-            static readonly timestampDate: Date | null;
+            static readonly timestampDate: Date | undefined;
 
             @Envapt('TEST_DATE_INVALID', { converter: Converters.Date, fallback: new Date('2023-01-01') })
             static readonly invalidDate: Date;

--- a/packages/envapt/tests/005-runtime-validation.test.ts
+++ b/packages/envapt/tests/005-runtime-validation.test.ts
@@ -112,7 +112,7 @@ describe('Runtime Validation', () => {
             @Envapt('NONEXISTENT_ARRAY_VAR', {
                 converter: Converters.array()
             })
-            static readonly noFallbackArray: string[] | null;
+            static readonly noFallbackArray: string[] | undefined;
         }
 
         it('should throw error when ArrayOf is used with non-array fallback for missing env var', () => {
@@ -121,8 +121,8 @@ describe('Runtime Validation', () => {
                 .with.property('code', EnvaptErrorCodes.InvalidFallback);
         });
 
-        it('should return null when ArrayOf is used without fallback for missing env var', () => {
-            expect(FallbackTests.noFallbackArray).to.be.null;
+        it('should return undefined when ArrayOf is used without fallback for missing env var', () => {
+            expect(FallbackTests.noFallbackArray).to.be.undefined;
         });
     });
 

--- a/packages/envapt/tests/006-edge-cases.test.ts
+++ b/packages/envapt/tests/006-edge-cases.test.ts
@@ -77,22 +77,22 @@ describe('Edge Cases', () => {
     describe('Template resolution edge cases', () => {
         class TemplateEdgeCases {
             @Envapt('NONEXISTENT_TEMPLATE')
-            static readonly nonexistentTemplate: string | null;
+            static readonly nonexistentTemplate: string | undefined;
 
             @Envapt('EMPTY_TEMPLATE')
-            static readonly emptyTemplate: string | null;
+            static readonly emptyTemplate: string | undefined;
 
             @Envapt('CIRCULAR_TEMPLATE')
-            static readonly circularTemplate: string | null;
+            static readonly circularTemplate: string | undefined;
 
             @Envapt('CIRCULAR_A')
-            static readonly circularA: string | null;
+            static readonly circularA: string | undefined;
 
             @Envapt('CIRCULAR_B')
-            static readonly circularB: string | null;
+            static readonly circularB: string | undefined;
 
             @Envapt('MULTI_TYPE_TEMPLATE')
-            static readonly multiTypeTemplate: string | null;
+            static readonly multiTypeTemplate: string | undefined;
         }
 
         it('should handle nonexistent template variables', () => {

--- a/packages/envapt/tests/008-instance-props.test.ts
+++ b/packages/envapt/tests/008-instance-props.test.ts
@@ -12,9 +12,9 @@ describe('Instance Properties with @Envapt', () => {
 
     describe('basic instance properties', () => {
         class BasicInstanceProperties extends Envapter {
-            @Envapt('INSTANCE_PROP_1') declare instanceProp1: string | null;
+            @Envapt('INSTANCE_PROP_1') declare instanceProp1: string | undefined;
 
-            @Envapt('INSTANCE_PROP_2') declare instanceProp2: string | null;
+            @Envapt('INSTANCE_PROP_2') declare instanceProp2: string | undefined;
 
             @Envapt('INSTANCE_PROP_3_TEMPLATED', { fallback: 'default3' })
             declare instanceProp3: string;

--- a/packages/envapt/tests/014-time-string-fallback.test.ts
+++ b/packages/envapt/tests/014-time-string-fallback.test.ts
@@ -49,13 +49,13 @@ describe('Converters.Time — time-string fallbacks', () => {
     describe('absent fallback', () => {
         class NoFallback extends Envapter {
             // Env value is malformed (`TEST_TIME_INVALID=5x` in the fixture) and no fallback
-            // is provided — converter returns undefined, decorator surfaces it as null.
+            // is provided, the converter returns undefined and the decorator surfaces that.
             @Envapt('TEST_TIME_INVALID', { converter: Converters.Time })
-            static readonly noFallback: number | null;
+            static readonly noFallback: number | undefined;
         }
 
-        it('returns null when raw is malformed and no fallback is provided', () => {
-            expect(NoFallback.noFallback).to.be.null;
+        it('returns undefined when raw is malformed and no fallback is provided', () => {
+            expect(NoFallback.noFallback).to.be.undefined;
         });
     });
 

--- a/packages/envapt/tests/021-type-error-messages.test.ts
+++ b/packages/envapt/tests/021-type-error-messages.test.ts
@@ -116,6 +116,16 @@ describe('TS error message verification (compiler API)', () => {
         });
     });
 
+    describe('an empty @Envapt options object produces a no-overload compile error', () => {
+        it('rejects the legacy @Envapt(key, {}) form', { timeout: FIXTURE_TIMEOUT_MS }, () => {
+            const diagnostics = compileFixture('empty-options.ts');
+            expect(
+                diagnostics.some((d) => d.code === 2769),
+                joinedMessages(diagnostics)
+            ).to.be.true;
+        });
+    });
+
     describe('legacy decorator constrains the declared field type to the converter output', () => {
         it('rejects a field whose type cannot hold the converter output', { timeout: FIXTURE_TIMEOUT_MS }, () => {
             const diagnostics = compileFixture('field-type-mismatch.ts');
@@ -124,7 +134,7 @@ describe('TS error message verification (compiler API)', () => {
         });
 
         it(
-            'rejects a non-null field for a no-fallback decorator (the value can be null)',
+            'rejects a field that cannot hold undefined for a no-fallback decorator',
             { timeout: FIXTURE_TIMEOUT_MS },
             () => {
                 const diagnostics = compileFixture('field-type-no-fallback.ts');
@@ -160,7 +170,7 @@ describe('TS error message verification (compiler API)', () => {
         });
 
         it(
-            'rejects a non-null accessor for a no-fallback decorator (the value can be null)',
+            'rejects an accessor that cannot hold undefined for a no-fallback decorator',
             { timeout: FIXTURE_TIMEOUT_MS },
             () => {
                 const diagnostics = compileFixture('modern/accessor-field-type-no-fallback.ts', MODERN_CONFIG);
@@ -187,5 +197,13 @@ describe('TS error message verification (compiler API)', () => {
                 expect(diagnostics, joinedMessages(diagnostics)).to.have.lengthOf(0);
             }
         );
+
+        it('rejects an empty @Envapt options object', { timeout: FIXTURE_TIMEOUT_MS }, () => {
+            const diagnostics = compileFixture('modern/empty-options.ts', MODERN_CONFIG);
+            expect(
+                diagnostics.some((d) => d.code === 2769),
+                joinedMessages(diagnostics)
+            ).to.be.true;
+        });
     });
 });

--- a/packages/envapt/tests/028-sugar-decorators.test.ts
+++ b/packages/envapt/tests/028-sugar-decorators.test.ts
@@ -57,7 +57,7 @@ describe('Sugar decorators', () => {
             static readonly ttl: number;
 
             @EnvNum('SUGAR_MISSING_NO_FALLBACK')
-            static readonly none: number | null;
+            static readonly none: number | undefined;
         }
 
         it('EnvNum uses the numeric fallback', () => expect(SugarDefaults.port).to.equal(3000));
@@ -69,16 +69,16 @@ describe('Sugar decorators', () => {
         });
         it('EnvTime coerces the time-string fallback to milliseconds (10s -> 10000)', () =>
             expect(SugarDefaults.ttl).to.equal(10000));
-        it('no fallback resolves to null, like @Envapt(key)', () => expect(SugarDefaults.none).to.be.null);
+        it('no fallback resolves to undefined, like @Envapt(key)', () => expect(SugarDefaults.none).to.be.undefined);
     });
 
     describe('multi-key ordered fallback (inherited)', () => {
         class SugarMultiKey {
             @EnvUrl(['SUGAR_CANARY_URL', 'SUGAR_APP_URL'])
-            static readonly url: URL | null;
+            static readonly url: URL | undefined;
 
             @EnvNum(['SUGAR_MISSING_PORT', 'SUGAR_LEGACY_PORT'])
-            static readonly port: number | null;
+            static readonly port: number | undefined;
         }
 
         it('picks the first defined key', () => expect(SugarMultiKey.url?.href).to.equal('https://app.example.com/'));

--- a/packages/envapt/tests/044-missing-value-unification.test.ts
+++ b/packages/envapt/tests/044-missing-value-unification.test.ts
@@ -1,0 +1,48 @@
+import { resolve } from 'node:path';
+
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { Converters, Envapter } from '../src';
+import { EnvaptError } from '../src/infra/Error';
+
+import type { StandardSchemaV1 } from '../src/infra/StandardSchema';
+
+const echoSchema: StandardSchemaV1<string> = {
+    '~standard': {
+        version: 1,
+        vendor: 'test',
+        validate: (value) => ({ value: value as string })
+    }
+};
+
+describe('missing-value return unification (v8)', () => {
+    beforeAll(() => (Envapter.envPaths = resolve(import.meta.dirname, '.env.044')));
+
+    describe('a read with no fallback resolves to undefined', () => {
+        it('getUsing returns undefined for a present but unconvertible value', () => {
+            expect(Envapter.getUsing('BAD_NUM_044', Converters.Number)).to.be.undefined;
+        });
+
+        it('getUsing returns undefined for a missing value', () => {
+            expect(Envapter.getUsing('MISSING_044', Converters.Number)).to.be.undefined;
+        });
+    });
+
+    describe('getWith passes the raw value to the custom converter', () => {
+        it('calls the converter with undefined for a missing key', () => {
+            const seen: (string | undefined)[] = [];
+            const converter = (raw: string | undefined): string => {
+                seen.push(raw);
+                return raw === undefined ? 'MISSING' : raw.toUpperCase();
+            };
+            expect(Envapter.getWith('MISSING_044', converter)).to.equal('MISSING');
+            expect(seen).to.deep.equal([undefined]);
+        });
+    });
+
+    describe('an explicit undefined fallback is no fallback', () => {
+        it('parse throws when the key is missing and the fallback is an explicit undefined', () => {
+            expect(() => Envapter.parse('MISSING_044', echoSchema, undefined)).to.throw(EnvaptError);
+        });
+    });
+});

--- a/packages/envapt/tests/integration/modern-decorator-check.ts
+++ b/packages/envapt/tests/integration/modern-decorator-check.ts
@@ -16,7 +16,7 @@ class Config {
     static accessor tags: string[];
 
     @EnvBool('MD_NO_FALLBACK_ABSENT')
-    static accessor missing: boolean | null;
+    static accessor missing: boolean | undefined;
 }
 
 const runtime = typeof Deno !== 'undefined' ? 'deno' : typeof Bun !== 'undefined' ? 'bun' : 'node';

--- a/packages/envapt/tests/integration/modern-decorator-check.ts
+++ b/packages/envapt/tests/integration/modern-decorator-check.ts
@@ -24,7 +24,7 @@ const runtime = typeof Deno !== 'undefined' ? 'deno' : typeof Bun !== 'undefined
 assert.equal(Config.port, 3000, `${runtime}: number fallback via static accessor`);
 assert.equal(Config.region, 'us-east-1', `${runtime}: string fallback via static accessor`);
 assert.deepEqual(Config.tags, ['a', 'b'], `${runtime}: array fallback via static accessor`);
-assert.equal(Config.missing, null, `${runtime}: no-fallback resolves to null`);
+assert.equal(Config.missing, undefined, `${runtime}: no-fallback resolves to undefined`);
 
 let readOnlyThrew = false;
 try {

--- a/packages/envapt/tests/stage3-emit/fixture.mts
+++ b/packages/envapt/tests/stage3-emit/fixture.mts
@@ -44,22 +44,22 @@ class Config {
     static accessor fallbackValue: number;
 
     @EnvNum(['S3_ABSENT', 'S3_PORT'])
-    static accessor multiKey: number | null;
+    static accessor multiKey: number | undefined;
 
     @EnvStr('S3_GREETING')
-    static accessor greeting: string | null;
+    static accessor greeting: string | undefined;
 
     @Envapt('S3_PORT', { schema: numberSchema })
     static accessor schemaPort: number;
 
     @EnvNum('S3_ABSENT')
-    static accessor noFallback: number | null;
+    static accessor noFallback: number | undefined;
 }
 
 // a subclass reads the inherited instance accessor
 class Base {
     @EnvStr('S3_REGION')
-    accessor region!: string | null;
+    accessor region!: string | undefined;
 }
 class Sub extends Base {}
 const inheritedRegion = new Sub().region;

--- a/packages/envapt/tests/stage3-emit/run.mjs
+++ b/packages/envapt/tests/stage3-emit/run.mjs
@@ -45,7 +45,7 @@ function assertReads(reads, runtime) {
     assert.equal(reads.multiKey, 8080, `${runtime}: multi-key falls through to the second key`);
     assert.equal(reads.greeting, 'Hello eu-west-1', `${runtime}: template variable resolution`);
     assert.equal(reads.schemaPort, 8080, `${runtime}: standard schema validates and returns the output`);
-    assert.equal(reads.noFallback, null, `${runtime}: no-fallback sugar resolves to null`);
+    assert.equal(reads.noFallback, undefined, `${runtime}: no-fallback sugar resolves to undefined`);
     assert.equal(reads.inheritedRegion, 'eu-west-1', `${runtime}: subclass reads the inherited instance accessor`);
     assert.equal(reads.collisionA, 8080, `${runtime}: first of two same-named classes`);
     assert.equal(reads.collisionB, 4321, `${runtime}: second same-named class resolves independently`);

--- a/packages/envapt/tests/type-error-fixtures/empty-options.ts
+++ b/packages/envapt/tests/type-error-fixtures/empty-options.ts
@@ -1,0 +1,8 @@
+import { Envapt } from '../../src/legacy';
+
+// @Envapt(key, {}) carries no supported options key, and parseEnvaptOptions throws on it at runtime.
+// the overload rejects it at compile time (TS2769) to keep the type surface aligned with that check.
+export class EmptyOptions {
+    @Envapt('EMPTY', {})
+    static readonly value: string | undefined;
+}

--- a/packages/envapt/tests/type-error-fixtures/envapt-overloads-clean.ts
+++ b/packages/envapt/tests/type-error-fixtures/envapt-overloads-clean.ts
@@ -1,14 +1,14 @@
 import { Converters } from '../../src';
 import { Envapt } from '../../src/legacy';
 
-// Correct declarations across the overloads, including no-fallback `| null` and a deliberately wider
+// Correct declarations across the overloads, including no-fallback `| undefined` and a deliberately wider
 // field, must all compile cleanly.
 export class OverloadClean {
     @Envapt('A', { converter: Converters.Number, fallback: 3000 })
     static readonly a: number;
 
     @Envapt('B', { converter: Converters.Url })
-    static readonly b: URL | null;
+    static readonly b: URL | undefined;
 
     @Envapt('C', { converter: Number, fallback: 100 })
     static readonly c: number;
@@ -17,13 +17,13 @@ export class OverloadClean {
     static readonly d: string;
 
     @Envapt('E')
-    static readonly e: string | null;
+    static readonly e: string | undefined;
 
     @Envapt('F', { fallback: 3000 })
     static readonly f: number;
 
     @Envapt('G', { converter: Converters.Number, fallback: 1 })
-    static readonly g: number | null;
+    static readonly g: number | undefined;
 
     @Envapt('H', { converter: Converters.Number, fallback: undefined })
     static readonly h: number | undefined;

--- a/packages/envapt/tests/type-error-fixtures/envapt-overloads-clean.ts
+++ b/packages/envapt/tests/type-error-fixtures/envapt-overloads-clean.ts
@@ -27,4 +27,7 @@ export class OverloadClean {
 
     @Envapt('H', { converter: Converters.Number, fallback: undefined })
     static readonly h: number | undefined;
+
+    @Envapt('I', { fallback: undefined })
+    static readonly i: string | undefined;
 }

--- a/packages/envapt/tests/type-error-fixtures/field-type-no-fallback.ts
+++ b/packages/envapt/tests/type-error-fixtures/field-type-no-fallback.ts
@@ -1,6 +1,6 @@
 import { EnvNum } from '../../src/legacy';
 
-// With no fallback the value can be null, so a non-null field cannot hold it and must fail to compile.
+// With no fallback the value can be undefined, so a field that omits undefined cannot hold it and must fail to compile.
 export class FieldTypeNoFallback {
     @EnvNum('PORT')
     static readonly port: number;

--- a/packages/envapt/tests/type-error-fixtures/modern/accessor-field-type-no-fallback.ts
+++ b/packages/envapt/tests/type-error-fixtures/modern/accessor-field-type-no-fallback.ts
@@ -1,6 +1,6 @@
 import { EnvNum } from '../../../src/decorators/modern';
 
-// With no fallback the value can be null, so a non-null accessor cannot hold it and must fail to compile.
+// With no fallback the value can be undefined, so an accessor that omits undefined cannot hold it and must fail to compile.
 export class FieldTypeNoFallback {
     @EnvNum('PORT')
     static accessor port: number;

--- a/packages/envapt/tests/type-error-fixtures/modern/accessor-overloads-clean.ts
+++ b/packages/envapt/tests/type-error-fixtures/modern/accessor-overloads-clean.ts
@@ -1,14 +1,14 @@
 import { Converters } from '../../../src';
 import { Envapt } from '../../../src/decorators/modern';
 
-// Correct declarations across the overloads, including no-fallback `| null`, `fallback: undefined`
+// Correct declarations across the overloads, including no-fallback `| undefined`, `fallback: undefined`
 // `| undefined`, and a deliberately wider field, must all compile cleanly.
 export class OverloadClean {
     @Envapt('A', { converter: Converters.Number, fallback: 3000 })
     static accessor a: number;
 
     @Envapt('B', { converter: Converters.Url })
-    static accessor b: URL | null;
+    static accessor b: URL | undefined;
 
     @Envapt('C', { converter: Number, fallback: 100 })
     static accessor c: number;
@@ -17,13 +17,13 @@ export class OverloadClean {
     static accessor d: string;
 
     @Envapt('E')
-    static accessor e: string | null;
+    static accessor e: string | undefined;
 
     @Envapt('F', { fallback: 3000 })
     static accessor f: number;
 
     @Envapt('G', { converter: Converters.Number, fallback: 1 })
-    static accessor g: number | null;
+    static accessor g: number | undefined;
 
     @Envapt('H', { converter: Converters.Number, fallback: undefined })
     static accessor h: number | undefined;

--- a/packages/envapt/tests/type-error-fixtures/modern/accessor-overloads-clean.ts
+++ b/packages/envapt/tests/type-error-fixtures/modern/accessor-overloads-clean.ts
@@ -27,4 +27,7 @@ export class OverloadClean {
 
     @Envapt('H', { converter: Converters.Number, fallback: undefined })
     static accessor h: number | undefined;
+
+    @Envapt('I', { fallback: undefined })
+    static accessor i: string | undefined;
 }

--- a/packages/envapt/tests/type-error-fixtures/modern/empty-options.ts
+++ b/packages/envapt/tests/type-error-fixtures/modern/empty-options.ts
@@ -1,0 +1,8 @@
+import { Envapt } from '../../../src/decorators/modern';
+
+// @Envapt(key, {}) carries no supported options key, and parseEnvaptOptions throws on it at runtime.
+// the overload rejects it at compile time to keep the type surface aligned with that runtime check.
+export class EmptyOptions {
+    @Envapt('EMPTY', {})
+    static accessor value: string | undefined;
+}


### PR DESCRIPTION
## What and why

- A missing read with no fallback now resolves to `undefined` across every reader. The functional readers already did this, the decorators and converter dispatch returned `null`. No-fallback decorator field types drop `| null`, so retype such fields to `| undefined`.
- `getWith` now correctly runs its custom converter on a missing key with `raw` as `undefined`, matching the `@Envapt` custom-converter path and the `ConverterFunction` contract (which always typed `raw` as `string | undefined`).
- An explicit `undefined` fallback counts as no fallback everywhere, through a shared `hasFallback` helper beside `isMissing`. `Envapter.parse(key, schema, undefined)` throws `MissingEnvValue`, and the redundant `fallback: undefined` decorator overloads collapse into `fallback?: undefined`.

## Checklist

- [x] New or regression tests cover the change
- [x] Changeset added (`pnpm cs`) for `packages/envapt/**` changes if needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Missing environment reads with no fallback now resolve to `undefined` instead of `null` across the full read pipeline (including decorators and converter dispatch).
  * An explicit `fallback: undefined` is treated as “no fallback,” so parsing can throw `MissingEnvValue`.
  * Public decorator/accessor TypeScript typings were updated from `| null` to `| undefined` in no-fallback scenarios.
* **Bug Fixes**
  * Custom converters now receive `raw === undefined` for missing keys, enabling correct fallback handling.
* **Documentation**
  * Updated migration and examples to reflect the new missing-value and fallback semantics.
* **Tests**
  * Updated runtime and type fixtures to expect `undefined` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->